### PR TITLE
Remove ubuntu18 from build script

### DIFF
--- a/.github/workflows/buildBS-linux.yml
+++ b/.github/workflows/buildBS-linux.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         node-version: [16.17]
         python-version: [3.7]
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
github does not provide ubuntu 18 runner anymore.