### PR TITLE
chore: install jsbarcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "hammerjs": "^2.0.8",
     "jimp": "^0.10.3",
     "jquery": "^1.11.0",
+    "jsbarcode": "^3.11.6",
     "jsencrypt": "3.0.0-rc.1",
     "jszip": "^3.10.1",
     "mini-css-extract-plugin": "^1.6.0",

--- a/src/implementations/localFontHelper.ts
+++ b/src/implementations/localFontHelper.ts
@@ -1,4 +1,4 @@
-import fontkit from 'fontkit';
+import fontkit, { FontCollection } from 'fontkit';
 
 import communicator from 'implementations/communicator';
 import { FontDescriptor, LocalFontHelper } from 'interfaces/IFont';
@@ -60,8 +60,20 @@ export default {
   },
   getLocalFont: (font: FontDescriptor) => {
     try {
+      const getFontDirectly = fontkit.openSync(font.path, font.postscriptName)
+
+      if (getFontDirectly) {
+        return getFontDirectly;
+      }
+
+      const getFontFromPath = fontkit.openSync(font.path);
+
+      if (["TTF" , "WOFF" , "WOFF2"].includes(getFontFromPath.type)) {
+        return getFontFromPath;
+      }
+
       // Font Collection
-      return fontkit.openSync(font.path, font.postscriptName);
+      return (getFontFromPath as FontCollection).fonts[0];
     } catch {
       // Single Font
       return fontkit.openSync(font.path);

--- a/src/node/menu-manager.ts
+++ b/src/node/menu-manager.ts
@@ -501,7 +501,7 @@ function buildMenuItems(
     label: r.tools.title,
     submenu: [
       { id: 'MATERIAL_TEST_GENERATOR', label: r.tools.material_test_generator, click: callback },
-      { id: 'QR_CODE_GENERATOR', label: r.tools.qr_code_generator, click: callback },
+      { id: 'CODE_GENERATOR', label: r.tools.code_generator, click: callback },
       { id: 'BOX_GEN', label: r.tools.box_generator, click: callback },
     ],
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9340,6 +9340,11 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbarcode@^3.11.6:
+  version "3.11.6"
+  resolved "https://registry.yarnpkg.com/jsbarcode/-/jsbarcode-3.11.6.tgz#96e8fbc3395476e162982a6064b98a09b5ea02c0"
+  integrity sha512-G5TKGyKY1zJo0ZQKFM1IIMfy0nF2rs92BLlCz+cU4/TazIc4ZH+X1GYeDRt7TKjrYqmPfTjwTBkU/QnQlsYiuA==
+
 jsbn@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"


### PR DESCRIPTION
## Overview

1. [chore: install jsbarcode](https://github.com/flux3dp/beam-studio/commit/212e75da1c0fac73d71d936d20e906ce94b36e56)
2. [fix(implementations): get-local-font now can handle font collection properly](https://github.com/flux3dp/beam-studio/commit/34173ced47f33d6d3b0f74b56e07ebd892e87675)