### PR TITLE
feat(menu): add z-axis adjustment for promark series

### DIFF
--- a/src/node/menu-manager.ts
+++ b/src/node/menu-manager.ts
@@ -577,6 +577,11 @@ function buildDeviceMenu(
       label: i18n.lang.promark_settings?.title,
       click: handleClick,
     },
+    isPromark && {
+      id: 'Z_AXIS_ADJUSTMENT',
+      label: i18n.lang.promark_settings?.z_axis_adjustment.title,
+      click: handleClick,
+    },
     { type: 'separator' },
     {
       id: 'CALIBRATION',


### PR DESCRIPTION
## Overview

1. [feat(menu): add z-axis adjustment for promark series](https://github.com/flux3dp/beam-studio/commit/27bbc181fdb42ed9f53330cf677a328dc75c3535)