### PR TITLE
feat(examples): add mopa color examples

### DIFF
--- a/public/examples/promark_mopa_100w_color_example.bvg
+++ b/public/examples/promark_mopa_100w_color_example.bvg
@@ -1,0 +1,781 @@
+<svg id="svgcontent" width="2200" height="2200" viewBox="0 0 2200 2200" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" data-top="-182" data-left="-482" data-zoom="0.324" data-workarea="fpm1" data-en_af="false" data-en_diode="false" data-rotary_mode="0" data-engrave_dpi="medium">
+
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.02" data-color="#E91E63" class="layer" data-module="15">
+  <title>FI0.02-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F400" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1477" stroke="#E91E63" height="30" width="30" y="688.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.02" data-color="#673AB7" class="layer" data-module="15">
+  <title>FI0.02-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F367" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1478" stroke="#673AB7" height="30" width="30" y="688.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.02" data-color="#03A9F4" class="layer" data-module="15">
+  <title>FI0.02-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F334" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1479" stroke="#03A9F4" height="30" width="30" y="688.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.02" data-color="#9C27B0" class="layer" data-module="15">
+  <title>FI0.02-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F300" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1480" stroke="#9C27B0" height="30" width="30" y="688.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.02" data-color="#607D8B" class="layer" data-module="15">
+  <title>FI0.02-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F267" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1481" stroke="#607D8B" height="30" width="30" y="688.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.02" data-color="#9E9E9E" class="layer" data-module="15">
+  <title>FI0.02-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F234" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1482" stroke="#9E9E9E" height="30" width="30" y="688.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.02" data-color="#333333" class="layer" data-module="15">
+  <title>FI0.02-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F200" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1483" stroke="#333333" height="30" width="30" y="688.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.02" data-color="#3F51B5" class="layer" data-module="15">
+  <title>FI0.02-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F167" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1484" stroke="#3F51B5" height="30" width="30" y="688.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.02" data-color="#F44336" class="layer" data-module="15">
+  <title>FI0.02-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F134" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1485" stroke="#F44336" height="30" width="30" y="688.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.02" data-color="#FFC107" class="layer" data-module="15">
+  <title>FI0.02-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F100" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1486" stroke="#FFC107" height="30" width="30" y="688.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0179" data-color="#8BC34A" class="layer" data-module="15">
+  <title>FI0.0179-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F400" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1487" stroke="#8BC34A" height="30" width="30" y="648.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0179" data-color="#2196F3" class="layer" data-module="15">
+  <title>FI0.0179-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F367" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1488" stroke="#2196F3" height="30" width="30" y="648.02361" x="713.09999"/>
+ </g>
+ <g display="inline" data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0179" data-color="#009688" class="layer" data-module="15">
+  <title>FI0.0179-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F334" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1489" stroke="#009688" height="30" width="30" y="648.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0179" data-color="#FF9800" class="layer" data-module="15">
+  <title>FI0.0179-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F300" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1490" stroke="#FF9800" height="30" width="30" y="648.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0179" data-color="#CDDC39" class="layer" data-module="15">
+  <title>FI0.0179-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F267" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1491" stroke="#CDDC39" height="30" width="30" y="648.02361" x="593.09999"/>
+ </g>
+ <g display="inline" data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0179" data-color="#00BCD4" class="layer" data-module="15">
+  <title>FI0.0179-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F234" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1492" stroke="#00BCD4" height="30" width="30" y="648.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0179" data-color="#FFEB3B" class="layer" data-module="15">
+  <title>FI0.0179-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F200" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1493" stroke="#FFEB3B" height="30" width="30" y="648.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0179" data-color="#E91E63" class="layer" data-module="15">
+  <title>FI0.0179-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F167" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1494" stroke="#E91E63" height="30" width="30" y="648.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0179" data-color="#673AB7" class="layer" data-module="15">
+  <title>FI0.0179-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F134" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1495" stroke="#673AB7" height="30" width="30" y="648.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0179" data-color="#03A9F4" class="layer" data-module="15">
+  <title>FI0.0179-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F100" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1496" stroke="#03A9F4" height="30" width="30" y="648.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0158" data-color="#9C27B0" class="layer" data-module="15">
+  <title>FI0.0158-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F400" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1497" stroke="#9C27B0" height="30" width="30" y="608.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0158" data-color="#607D8B" class="layer" data-module="15">
+  <title>FI0.0158-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F367" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1498" stroke="#607D8B" height="30" width="30" y="608.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0158" data-color="#9E9E9E" class="layer" data-module="15">
+  <title>FI0.0158-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F334" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1499" stroke="#9E9E9E" height="30" width="30" y="608.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0158" data-color="#333333" class="layer" data-module="15">
+  <title>FI0.0158-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F300" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1500" stroke="#333333" height="30" width="30" y="608.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0158" data-color="#3F51B5" class="layer" data-module="15">
+  <title>FI0.0158-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F267" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1501" stroke="#3F51B5" height="30" width="30" y="608.02361" x="593.09999"/>
+ </g>
+ <g display="inline" data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0158" data-color="#F44336" class="layer" data-module="15">
+  <title>FI0.0158-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F234" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1502" stroke="#F44336" height="30" width="30" y="608.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0158" data-color="#FFC107" class="layer" data-module="15">
+  <title>FI0.0158-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F200" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1503" stroke="#FFC107" height="30" width="30" y="608.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0158" data-color="#8BC34A" class="layer" data-module="15">
+  <title>FI0.0158-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F167" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1504" stroke="#8BC34A" height="30" width="30" y="608.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0158" data-color="#2196F3" class="layer" data-module="15">
+  <title>FI0.0158-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F134" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1505" stroke="#2196F3" height="30" width="30" y="608.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0158" data-color="#009688" class="layer" data-module="15">
+  <title>FI0.0158-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F100" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1506" stroke="#009688" height="30" width="30" y="608.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0137" data-color="#FF9800" class="layer" data-module="15">
+  <title>FI0.0137-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F400" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1507" stroke="#FF9800" height="30" width="30" y="568.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0137" data-color="#CDDC39" class="layer" data-module="15">
+  <title>FI0.0137-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F367" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1508" stroke="#CDDC39" height="30" width="30" y="568.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0137" data-color="#00BCD4" class="layer" data-module="15">
+  <title>FI0.0137-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F334" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1509" stroke="#00BCD4" height="30" width="30" y="568.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0137" data-color="#FFEB3B" class="layer" data-module="15">
+  <title>FI0.0137-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F300" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1510" stroke="#FFEB3B" height="30" width="30" y="568.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0137" data-color="#E91E63" class="layer" data-module="15">
+  <title>FI0.0137-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F267" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1511" stroke="#E91E63" height="30" width="30" y="568.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0137" data-color="#673AB7" class="layer" data-module="15">
+  <title>FI0.0137-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F234" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1512" stroke="#673AB7" height="30" width="30" y="568.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0137" data-color="#03A9F4" class="layer" data-module="15">
+  <title>FI0.0137-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F200" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1513" stroke="#03A9F4" height="30" width="30" y="568.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0137" data-color="#9C27B0" class="layer" data-module="15">
+  <title>FI0.0137-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F167" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1514" stroke="#9C27B0" height="30" width="30" y="568.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0137" data-color="#607D8B" class="layer" data-module="15">
+  <title>FI0.0137-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F134" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1515" stroke="#607D8B" height="30" width="30" y="568.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0137" data-color="#9E9E9E" class="layer" data-module="15">
+  <title>FI0.0137-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F100" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1516" stroke="#9E9E9E" height="30" width="30" y="568.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0116" data-color="#333333" class="layer" data-module="15">
+  <title>FI0.0116-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F400" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1517" stroke="#333333" height="30" width="30" y="528.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0116" data-color="#3F51B5" class="layer" data-module="15">
+  <title>FI0.0116-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F367" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1518" stroke="#3F51B5" height="30" width="30" y="528.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0116" data-color="#F44336" class="layer" data-module="15">
+  <title>FI0.0116-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F334" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1519" stroke="#F44336" height="30" width="30" y="528.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0116" data-color="#FFC107" class="layer" data-module="15">
+  <title>FI0.0116-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F300" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1520" stroke="#FFC107" height="30" width="30" y="528.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0116" data-color="#8BC34A" class="layer" data-module="15">
+  <title>FI0.0116-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F267" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1521" stroke="#8BC34A" height="30" width="30" y="528.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0116" data-color="#2196F3" class="layer" data-module="15">
+  <title>FI0.0116-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F234" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1522" stroke="#2196F3" height="30" width="30" y="528.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0116" data-color="#009688" class="layer" data-module="15">
+  <title>FI0.0116-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F200" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1523" stroke="#009688" height="30" width="30" y="528.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0116" data-color="#FF9800" class="layer" data-module="15">
+  <title>FI0.0116-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F167" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1524" stroke="#FF9800" height="30" width="30" y="528.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0116" data-color="#CDDC39" class="layer" data-module="15">
+  <title>FI0.0116-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F134" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1525" stroke="#CDDC39" height="30" width="30" y="528.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0116" data-color="#00BCD4" class="layer" data-module="15">
+  <title>FI0.0116-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F100" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1526" stroke="#00BCD4" height="30" width="30" y="528.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0094" data-color="#FFEB3B" class="layer" data-module="15">
+  <title>FI0.0094-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F400" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1527" stroke="#FFEB3B" height="30" width="30" y="488.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0094" data-color="#E91E63" class="layer" data-module="15">
+  <title>FI0.0094-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F367" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1528" stroke="#E91E63" height="30" width="30" y="488.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0094" data-color="#673AB7" class="layer" data-module="15">
+  <title>FI0.0094-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F334" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1529" stroke="#673AB7" height="30" width="30" y="488.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0094" data-color="#03A9F4" class="layer" data-module="15">
+  <title>FI0.0094-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F300" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1530" stroke="#03A9F4" height="30" width="30" y="488.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0094" data-color="#9C27B0" class="layer" data-module="15">
+  <title>FI0.0094-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F267" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1531" stroke="#9C27B0" height="30" width="30" y="488.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0094" data-color="#607D8B" class="layer" data-module="15">
+  <title>FI0.0094-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F234" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1532" stroke="#607D8B" height="30" width="30" y="488.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0094" data-color="#9E9E9E" class="layer" data-module="15">
+  <title>FI0.0094-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F200" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1533" stroke="#9E9E9E" height="30" width="30" y="488.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0094" data-color="#333333" class="layer" data-module="15">
+  <title>FI0.0094-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F167" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1534" stroke="#333333" height="30" width="30" y="488.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0094" data-color="#3F51B5" class="layer" data-module="15">
+  <title>FI0.0094-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F134" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1535" stroke="#3F51B5" height="30" width="30" y="488.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0094" data-color="#F44336" class="layer" data-module="15">
+  <title>FI0.0094-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F100" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1536" stroke="#F44336" height="30" width="30" y="488.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0073" data-color="#FFC107" class="layer" data-module="15">
+  <title>FI0.0073-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F400" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1537" stroke="#FFC107" height="30" width="30" y="448.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0073" data-color="#8BC34A" class="layer" data-module="15">
+  <title>FI0.0073-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F367" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1538" stroke="#8BC34A" height="30" width="30" y="448.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0073" data-color="#2196F3" class="layer" data-module="15">
+  <title>FI0.0073-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F334" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1539" stroke="#2196F3" height="30" width="30" y="448.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0073" data-color="#009688" class="layer" data-module="15">
+  <title>FI0.0073-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F300" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1540" stroke="#009688" height="30" width="30" y="448.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0073" data-color="#FF9800" class="layer" data-module="15">
+  <title>FI0.0073-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F267" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1541" stroke="#FF9800" height="30" width="30" y="448.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0073" data-color="#CDDC39" class="layer" data-module="15">
+  <title>FI0.0073-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F234" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1542" stroke="#CDDC39" height="30" width="30" y="448.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0073" data-color="#00BCD4" class="layer" data-module="15">
+  <title>FI0.0073-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F200" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1543" stroke="#00BCD4" height="30" width="30" y="448.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0073" data-color="#FFEB3B" class="layer" data-module="15">
+  <title>FI0.0073-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F167" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1544" stroke="#FFEB3B" height="30" width="30" y="448.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0073" data-color="#E91E63" class="layer" data-module="15">
+  <title>FI0.0073-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F134" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1545" stroke="#E91E63" height="30" width="30" y="448.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0073" data-color="#673AB7" class="layer" data-module="15">
+  <title>FI0.0073-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F100" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1546" stroke="#673AB7" height="30" width="30" y="448.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0052" data-color="#03A9F4" class="layer" data-module="15">
+  <title>FI0.0052-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F400" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1547" stroke="#03A9F4" height="30" width="30" y="408.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0052" data-color="#9C27B0" class="layer" data-module="15">
+  <title>FI0.0052-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F367" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1548" stroke="#9C27B0" height="30" width="30" y="408.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0052" data-color="#607D8B" class="layer" data-module="15">
+  <title>FI0.0052-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F334" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1549" stroke="#607D8B" height="30" width="30" y="408.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0052" data-color="#9E9E9E" class="layer" data-module="15">
+  <title>FI0.0052-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F300" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1550" stroke="#9E9E9E" height="30" width="30" y="408.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0052" data-color="#333333" class="layer" data-module="15">
+  <title>FI0.0052-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F267" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1551" stroke="#333333" height="30" width="30" y="408.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0052" data-color="#3F51B5" class="layer" data-module="15">
+  <title>FI0.0052-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F234" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1552" stroke="#3F51B5" height="30" width="30" y="408.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0052" data-color="#F44336" class="layer" data-module="15">
+  <title>FI0.0052-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F200" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1553" stroke="#F44336" height="30" width="30" y="408.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0052" data-color="#FFC107" class="layer" data-module="15">
+  <title>FI0.0052-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F167" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1554" stroke="#FFC107" height="30" width="30" y="408.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0052" data-color="#8BC34A" class="layer" data-module="15">
+  <title>FI0.0052-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F134" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1555" stroke="#8BC34A" height="30" width="30" y="408.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0052" data-color="#2196F3" class="layer" data-module="15">
+  <title>FI0.0052-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F100" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1556" stroke="#2196F3" height="30" width="30" y="408.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.0031" data-color="#009688" class="layer" data-module="15">
+  <title>FI0.0031-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F400" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1557" stroke="#009688" height="30" width="30" y="368.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.0031" data-color="#FF9800" class="layer" data-module="15">
+  <title>FI0.0031-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F367" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1558" stroke="#FF9800" height="30" width="30" y="368.02361" x="713.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.0031" data-color="#CDDC39" class="layer" data-module="15">
+  <title>FI0.0031-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F334" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1559" stroke="#CDDC39" height="30" width="30" y="368.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.0031" data-color="#00BCD4" class="layer" data-module="15">
+  <title>FI0.0031-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F300" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1560" stroke="#00BCD4" height="30" width="30" y="368.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.0031" data-color="#FFEB3B" class="layer" data-module="15">
+  <title>FI0.0031-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F267" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1561" stroke="#FFEB3B" height="30" width="30" y="368.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.0031" data-color="#E91E63" class="layer" data-module="15">
+  <title>FI0.0031-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F234" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1562" stroke="#E91E63" height="30" width="30" y="368.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.0031" data-color="#673AB7" class="layer" data-module="15">
+  <title>FI0.0031-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F200" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1563" stroke="#673AB7" height="30" width="30" y="368.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.0031" data-color="#03A9F4" class="layer" data-module="15">
+  <title>FI0.0031-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F167" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1564" stroke="#03A9F4" height="30" width="30" y="368.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.0031" data-color="#9C27B0" class="layer" data-module="15">
+  <title>FI0.0031-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F134" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1565" stroke="#9C27B0" height="30" width="30" y="368.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.0031" data-color="#607D8B" class="layer" data-module="15">
+  <title>FI0.0031-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F100" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1566" stroke="#607D8B" height="30" width="30" y="368.02361" x="393.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="400" data-fillInterval="0.001" data-color="#9E9E9E" class="layer" data-module="15">
+  <title>FI0.001-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F400" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1567" stroke="#9E9E9E" height="30" width="30" y="328.02361" x="753.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="367" data-fillInterval="0.001" data-color="#333333" class="layer" data-module="15">
+  <title>FI0.001-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F367" fill="#333333" id="svg_1568" stroke="#333333" height="30" width="30" y="328.02361" x="713.09999" vector-effect="non-scaling-stroke"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="334" data-fillInterval="0.001" data-color="#3F51B5" class="layer" data-module="15">
+  <title>FI0.001-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F334" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1569" stroke="#3F51B5" height="30" width="30" y="328.02361" x="673.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="300" data-fillInterval="0.001" data-color="#F44336" class="layer" data-module="15">
+  <title>FI0.001-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F300" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1570" stroke="#F44336" height="30" width="30" y="328.02361" x="633.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="267" data-fillInterval="0.001" data-color="#FFC107" class="layer" data-module="15">
+  <title>FI0.001-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F267" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1571" stroke="#FFC107" height="30" width="30" y="328.02361" x="593.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="234" data-fillInterval="0.001" data-color="#8BC34A" class="layer" data-module="15">
+  <title>FI0.001-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F234" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1572" stroke="#8BC34A" height="30" width="30" y="328.02361" x="553.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="200" data-fillInterval="0.001" data-color="#2196F3" class="layer" data-module="15">
+  <title>FI0.001-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F200" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1573" stroke="#2196F3" height="30" width="30" y="328.02361" x="513.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="167" data-fillInterval="0.001" data-color="#009688" class="layer" data-module="15">
+  <title>FI0.001-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F167" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1574" stroke="#009688" height="30" width="30" y="328.02361" x="473.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="134" data-fillInterval="0.001" data-color="#FF9800" class="layer" data-module="15">
+  <title>FI0.001-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F134" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1575" stroke="#FF9800" height="30" width="30" y="328.02361" x="433.09999"/>
+ </g>
+ <g data-strength="100" data-configName="0" data-pulseWidth="10" data-frequency="100" data-fillInterval="0.001" data-color="#CDDC39" class="layer" data-module="15">
+  <title>FI0.001-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F100" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1576" stroke="#CDDC39" height="30" width="30" y="328.02361" x="393.09999"/>
+ </g>
+ <g data-color="#000" class="layer" data-module="15">
+  <title>Material Test - Frame</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#000">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+ </g>
+ <g data-speed="500" data-strength="30" data-color="#000" class="layer" data-module="15">
+  <title>Material Test - Info</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#000">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" stroke="#000" transform="matrix(0.39615311408174136,0,0,0.40208618205920743,-38.989045012168376,11.311773934141236) " font-weight="400" font-style="normal" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="130" id="svg_1578" y="458.21677" x="1082.88707" fill="#000">
+   <tspan y="458.21677" x="1082.88707" vector-effect="non-scaling-stroke" id="svg_1">Frequency (kHz)</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" stroke="#000" font-weight="400" font-style="normal" transform="rotate(-90 175.4853668212892,512.8138427734376) matrix(0.396449935397989,0,0,0.3953106434175737,-420.62189536153284,221.0324494896294) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="130" id="svg_1579" y="784.83515" x="999.17239" fill="#000">
+   <tspan y="784.83515" x="999.17239" vector-effect="non-scaling-stroke" id="svg_2">Fill Interval (mm)</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 404.5882873535156,260.0256958007813) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.277160310342623,-0.10660530757832021) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1580" y="277.43434" x="364.61695" stroke="#000" fill="#000">
+   <tspan y="277.43434" x="364.61695" vector-effect="non-scaling-stroke" id="svg_3">100</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 444.6287841796875,260.02572631835943) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.3707507970934216,-0.10661085047718188) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1581" y="277.43437" x="404.61686" stroke="#000" fill="#000">
+   <tspan y="277.43437" x="404.61686" vector-effect="non-scaling-stroke" id="svg_4">134</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 484.66937255859375,260.0256652832032) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.4644043250489176,-0.10661677037205664) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1582" y="277.43434" x="444.6169" stroke="#000" fill="#000">
+   <tspan y="277.43434" x="444.6169" vector-effect="non-scaling-stroke" id="svg_5">167</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 524.7098388671876,260.02584838867193) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.5580240953137832,-0.10659562280113732) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1583" y="277.43447" x="484.61684" stroke="#000" fill="#000">
+   <tspan y="277.43447" x="484.61684" vector-effect="non-scaling-stroke" id="svg_6">200</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 564.7503662109376,260.0258178710938) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.6516772488524794,-0.1066020071712046) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1584" y="277.4345" x="524.61681" stroke="#000" fill="#000">
+   <tspan y="277.4345" x="524.61681" vector-effect="non-scaling-stroke" id="svg_7">234</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 604.7908935546876,260.02572631835943) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.7453912271887475,-0.10666882997895755) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1585" y="277.43443" x="564.61687" stroke="#000" fill="#000">
+   <tspan y="277.43443" x="564.61687" vector-effect="non-scaling-stroke" id="svg_8">267</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 644.8314208984376,260.0257873535157) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.8389789449971659,-0.10661446606047775) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1586" y="277.43449" x="604.61681" stroke="#000" fill="#000">
+   <tspan y="277.43449" x="604.61681" vector-effect="non-scaling-stroke" id="svg_9">300</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 684.8721313476564,260.02572631835943) matrix(1.0033544788809046,0,0,1.0010133462954875,-1.9326348092622538,-0.10662029582726973) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1587" y="277.43443" x="644.61699" stroke="#000" fill="#000" font-style="normal" font-weight="400">
+   <tspan y="277.43443" x="644.61699" vector-effect="non-scaling-stroke" id="svg_10">334</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 724.9124755859376,260.02587890625006) matrix(1.0033544788809046,0,0,1.0010133462954875,-2.0262200883902324,-0.1065629179933012) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1588" y="277.43449" x="684.61668" stroke="#000" fill="#000">
+   <tspan y="277.43449" x="684.61668" vector-effect="non-scaling-stroke" id="svg_11">367</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" transform="rotate(90 764.9530029296876,260.02584838867193) matrix(1.0033544788809046,0,0,1.0010133462954875,-2.119875823663506,-0.10657262877612084) " xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1589" y="277.43449" x="724.61668" stroke="#000" fill="#000">
+   <tspan y="277.43449" x="724.61668" vector-effect="non-scaling-stroke" id="svg_12">400</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1590" y="361.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="361.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_13">0.001</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1591" y="401.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="401.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_14">0.0031</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1592" y="441.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="441.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_15">0.0052</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1593" y="481.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="481.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_16">0.0073</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1594" y="521.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="521.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_17">0.0094</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1595" y="561.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="561.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_18">0.0116</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1596" y="601.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="601.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_19">0.0137</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1597" y="641.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="641.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_20">0.0158</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1598" y="681.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="681.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_21">0.0179</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" data-original-layer="Material Test - Info" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1599" y="721.10869" x="220.00001" stroke="#000" fill="#000">
+   <tspan y="721.10869" x="220.00001" vector-effect="non-scaling-stroke" id="svg_22">0.02</tspan>
+  </text>
+ </g>
+</svg>

--- a/public/examples/promark_mopa_100w_color_example_2.bvg
+++ b/public/examples/promark_mopa_100w_color_example_2.bvg
@@ -1,0 +1,787 @@
+<svg id="svgcontent" width="2200" height="2200" viewBox="0 0 2200 2200" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" data-top="-102" data-left="-601" data-zoom="0.342" data-workarea="fpm1" data-en_af="false" data-en_diode="false" data-rotary_mode="0" data-engrave_dpi="medium">
+
+ <g class="layer" data-color="#333333" data-speed="1000" data-printingSpeed="60" data-strength="15" data-minPower="0" data-ink="3" data-repeat="1" data-height="-3" data-zstep="0" data-diode="0" data-module="15" data-backlash="0" data-multipass="3" data-uv="0" data-halftone="1" data-wSpeed="100" data-wInk="-12" data-wMultipass="3" data-wRepeat="1" data-cRatio="100" data-mRatio="100" data-yRatio="100" data-kRatio="100" data-printingStrength="100" data-focus="-2" data-focusStep="-2" data-fillInterval="0.01" data-fillAngle="0" data-frequency="55" data-pulseWidth="500" data-dottingTime="100">
+  <title>Layer 1</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+ </g>
+ <g data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.02" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F400</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="687.01248" width="30" height="30" stroke="#E91E63" id="svg_1477" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.02" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F367</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="687.01248" width="30" height="30" stroke="#673AB7" id="svg_1478" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.02" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F334</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="687.01248" width="30" height="30" stroke="#03A9F4" id="svg_1479" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.02" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F300</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="687.01248" width="30" height="30" stroke="#9C27B0" id="svg_1480" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.02" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F267</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="687.01248" width="30" height="30" stroke="#607D8B" id="svg_1481" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.02" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F234</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="687.01248" width="30" height="30" stroke="#9E9E9E" id="svg_1482" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#333333" data-fillInterval="0.02" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F200</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="687.01248" width="30" height="30" stroke="#333333" id="svg_1483" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.02" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F167</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="687.01248" width="30" height="30" stroke="#3F51B5" id="svg_1484" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.02" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F134</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="687.01248" width="30" height="30" stroke="#F44336" id="svg_1485" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.02" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.02-F100</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="687.01248" width="30" height="30" stroke="#FFC107" id="svg_1486" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0179" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F400</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="647.01248" width="30" height="30" stroke="#8BC34A" id="svg_1487" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0179" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F367</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="647.01248" width="30" height="30" stroke="#2196F3" id="svg_1488" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0179" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F334</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="647.01248" width="30" height="30" stroke="#009688" id="svg_1489" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0179" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F300</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="647.01248" width="30" height="30" stroke="#FF9800" id="svg_1490" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0179" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F267</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="647.01248" width="30" height="30" stroke="#CDDC39" id="svg_1491" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0179" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F234</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="647.01248" width="30" height="30" stroke="#00BCD4" id="svg_1492" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0179" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F200</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="647.01248" width="30" height="30" stroke="#FFEB3B" id="svg_1493" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0179" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F167</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="647.01248" width="30" height="30" stroke="#E91E63" id="svg_1494" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0179" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F134</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="647.01248" width="30" height="30" stroke="#673AB7" id="svg_1495" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0179" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0179-F100</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="647.01248" width="30" height="30" stroke="#03A9F4" id="svg_1496" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0179-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0158" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F400</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="607.01248" width="30" height="30" stroke="#9C27B0" id="svg_1497" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0158" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F367</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="607.01248" width="30" height="30" stroke="#607D8B" id="svg_1498" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0158" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F334</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="607.01248" width="30" height="30" stroke="#9E9E9E" id="svg_1499" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0158" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F300</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="607.01248" width="30" height="30" stroke="#333333" id="svg_1500" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0158" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F267</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="607.01248" width="30" height="30" stroke="#3F51B5" id="svg_1501" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0158" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F234</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="607.01248" width="30" height="30" stroke="#F44336" id="svg_1502" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0158" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F200</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="607.01248" width="30" height="30" stroke="#FFC107" id="svg_1503" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0158" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F167</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="607.01248" width="30" height="30" stroke="#8BC34A" id="svg_1504" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0158" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F134</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="607.01248" width="30" height="30" stroke="#2196F3" id="svg_1505" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0158" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0158-F100</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="607.01248" width="30" height="30" stroke="#009688" id="svg_1506" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0137" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F400</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="567.01248" width="30" height="30" stroke="#FF9800" id="svg_1507" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0137" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F367</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="567.01248" width="30" height="30" stroke="#CDDC39" id="svg_1508" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0137" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F334</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="567.01248" width="30" height="30" stroke="#00BCD4" id="svg_1509" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0137" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F300</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="567.01248" width="30" height="30" stroke="#FFEB3B" id="svg_1510" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0137" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F267</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="567.01248" width="30" height="30" stroke="#E91E63" id="svg_1511" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0137" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F234</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="567.01248" width="30" height="30" stroke="#673AB7" id="svg_1512" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0137" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F200</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="567.01248" width="30" height="30" stroke="#03A9F4" id="svg_1513" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0137" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F167</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="567.01248" width="30" height="30" stroke="#9C27B0" id="svg_1514" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0137" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F134</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="567.01248" width="30" height="30" stroke="#607D8B" id="svg_1515" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0137" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0137-F100</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="567.01248" width="30" height="30" stroke="#9E9E9E" id="svg_1516" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0137-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0116" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F400</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="527.01248" width="30" height="30" stroke="#333333" id="svg_1517" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0116" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F367</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="527.01248" width="30" height="30" stroke="#3F51B5" id="svg_1518" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0116" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F334</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="527.01248" width="30" height="30" stroke="#F44336" id="svg_1519" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0116" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F300</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="527.01248" width="30" height="30" stroke="#FFC107" id="svg_1520" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0116" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F267</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="527.01248" width="30" height="30" stroke="#8BC34A" id="svg_1521" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0116" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F234</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="527.01248" width="30" height="30" stroke="#2196F3" id="svg_1522" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0116" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F200</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="527.01248" width="30" height="30" stroke="#009688" id="svg_1523" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0116" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F167</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="527.01248" width="30" height="30" stroke="#FF9800" id="svg_1524" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0116" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F134</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="527.01248" width="30" height="30" stroke="#CDDC39" id="svg_1525" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0116" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0116-F100</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="527.01248" width="30" height="30" stroke="#00BCD4" id="svg_1526" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0116-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0094" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F400</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="487.01248" width="30" height="30" stroke="#FFEB3B" id="svg_1527" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0094" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F367</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="487.01248" width="30" height="30" stroke="#E91E63" id="svg_1528" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0094" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F334</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="487.01248" width="30" height="30" stroke="#673AB7" id="svg_1529" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0094" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F300</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="487.01248" width="30" height="30" stroke="#03A9F4" id="svg_1530" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0094" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F267</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="487.01248" width="30" height="30" stroke="#9C27B0" id="svg_1531" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0094" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F234</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="487.01248" width="30" height="30" stroke="#607D8B" id="svg_1532" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0094" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F200</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="487.01248" width="30" height="30" stroke="#9E9E9E" id="svg_1533" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0094" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F167</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="487.01248" width="30" height="30" stroke="#333333" id="svg_1534" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0094" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F134</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="487.01248" width="30" height="30" stroke="#3F51B5" id="svg_1535" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0094" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0094-F100</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="487.01248" width="30" height="30" stroke="#F44336" id="svg_1536" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0073" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F400</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="447.01248" width="30" height="30" stroke="#FFC107" id="svg_1537" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0073" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F367</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="447.01248" width="30" height="30" stroke="#8BC34A" id="svg_1538" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0073" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F334</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="447.01248" width="30" height="30" stroke="#2196F3" id="svg_1539" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0073" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F300</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="447.01248" width="30" height="30" stroke="#009688" id="svg_1540" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0073" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F267</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="447.01248" width="30" height="30" stroke="#FF9800" id="svg_1541" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0073" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F234</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="447.01248" width="30" height="30" stroke="#CDDC39" id="svg_1542" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0073" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F200</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="447.01248" width="30" height="30" stroke="#00BCD4" id="svg_1543" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0073" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F167</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="447.01248" width="30" height="30" stroke="#FFEB3B" id="svg_1544" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0073" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F134</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="447.01248" width="30" height="30" stroke="#E91E63" id="svg_1545" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0073" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0073-F100</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="447.01248" width="30" height="30" stroke="#673AB7" id="svg_1546" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0052" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F400</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="407.01248" width="30" height="30" stroke="#03A9F4" id="svg_1547" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0052" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F367</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="407.01248" width="30" height="30" stroke="#9C27B0" id="svg_1548" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0052" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F334</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="407.01248" width="30" height="30" stroke="#607D8B" id="svg_1549" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0052" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F300</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="407.01248" width="30" height="30" stroke="#9E9E9E" id="svg_1550" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0052" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F267</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="407.01248" width="30" height="30" stroke="#333333" id="svg_1551" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0052" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F234</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="407.01248" width="30" height="30" stroke="#3F51B5" id="svg_1552" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0052" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F200</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="407.01248" width="30" height="30" stroke="#F44336" id="svg_1553" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0052" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F167</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="407.01248" width="30" height="30" stroke="#FFC107" id="svg_1554" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0052" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F134</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="407.01248" width="30" height="30" stroke="#8BC34A" id="svg_1555" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0052" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0052-F100</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="407.01248" width="30" height="30" stroke="#2196F3" id="svg_1556" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0052-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0031" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F400</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="367.01248" width="30" height="30" stroke="#009688" id="svg_1557" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0031" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F367</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="367.01248" width="30" height="30" stroke="#FF9800" id="svg_1558" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0031" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F334</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="367.01248" width="30" height="30" stroke="#CDDC39" id="svg_1559" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0031" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F300</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="367.01248" width="30" height="30" stroke="#00BCD4" id="svg_1560" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0031" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F267</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="367.01248" width="30" height="30" stroke="#FFEB3B" id="svg_1561" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0031" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F234</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="367.01248" width="30" height="30" stroke="#E91E63" id="svg_1562" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0031" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F200</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="367.01248" width="30" height="30" stroke="#673AB7" id="svg_1563" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0031" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F167</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="367.01248" width="30" height="30" stroke="#03A9F4" id="svg_1564" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0031" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F134</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="367.01248" width="30" height="30" stroke="#9C27B0" id="svg_1565" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0031" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.0031-F100</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="367.01248" width="30" height="30" stroke="#607D8B" id="svg_1566" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0031-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.001" data-frequency="400" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F400</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="742.94824" y="327.01248" width="30" height="30" stroke="#9E9E9E" id="svg_1567" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F400"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#333333" data-fillInterval="0.001" data-frequency="367" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F367</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="702.94824" y="327.01248" width="30" height="30" stroke="#333333" id="svg_1568" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F367"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.001" data-frequency="334" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F334</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="662.94824" y="327.01248" width="30" height="30" stroke="#3F51B5" id="svg_1569" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F334"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.001" data-frequency="300" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F300</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="622.94824" y="327.01248" width="30" height="30" stroke="#F44336" id="svg_1570" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F300"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.001" data-frequency="267" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F267</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="582.94824" y="327.01248" width="30" height="30" stroke="#FFC107" id="svg_1571" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F267"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.001" data-frequency="234" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F234</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="542.94824" y="327.01248" width="30" height="30" stroke="#8BC34A" id="svg_1572" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F234"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.001" data-frequency="200" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F200</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="502.94824" y="327.01248" width="30" height="30" stroke="#2196F3" id="svg_1573" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F200"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#009688" data-fillInterval="0.001" data-frequency="167" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F167</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="462.94824" y="327.01248" width="30" height="30" stroke="#009688" id="svg_1574" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F167"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.001" data-frequency="134" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F134</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="422.94824" y="327.01248" width="30" height="30" stroke="#FF9800" id="svg_1575" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F134"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.001" data-frequency="100" data-speed="1500" data-configName="0" data-pulseWidth="15" data-strength="100">
+  <title>FI0.001-F100</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="382.94824" y="327.01248" width="30" height="30" stroke="#CDDC39" id="svg_1576" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.001-F100"/>
+ </g>
+ <g data-module="15" class="layer" data-color="#000">
+  <title>Material Test - Frame</title>
+  <filter id="filter#000" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+ </g>
+ <g data-module="15" class="layer" data-color="#000" data-strength="30" data-speed="500">
+  <title>Material Test - Info</title>
+  <filter id="filter#000" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <text vector-effect="non-scaling-stroke" fill="#000" x="-41.07857" y="116.89652" id="svg_1578" font-size="130" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" font-style="normal" font-weight="400" transform="matrix(0.39615663616001473,0,0,0.3958109374717099,396.16939275563584,147.56024016134592) " stroke="#000" data-original-layer="Material Test - Info">
+   <tspan id="svg_1" vector-effect="non-scaling-stroke" x="-41.07857" y="116.89895">Frequency (kHz)</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="548.1352" y="171.03802" id="svg_1579" font-size="130" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(-90 175.63093566894545,512.9082641601564) matrix(0.39640524983406067,0,0,0.3978394865989685,-241.64009915001134,463.17040733482645) " font-style="normal" font-weight="400" data-original-layer="Material Test - Info">
+   <tspan id="svg_2" vector-effect="non-scaling-stroke" x="548.1352" y="171.03802">Fill Interval (mm)</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="353.66388" y="276.70478" id="svg_1580" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 393.5601501464844,259.8894348144532) ">
+   <tspan id="svg_3" vector-effect="non-scaling-stroke" x="353.66388" y="276.70226">100</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="393.66388" y="276.70472" id="svg_1581" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 433.5601806640625,259.88940429687506) ">
+   <tspan id="svg_4" vector-effect="non-scaling-stroke" x="393.66388" y="276.70223">134</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="433.66385" y="276.70475" id="svg_1582" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 473.5601806640625,259.88940429687506) ">
+   <tspan id="svg_5" vector-effect="non-scaling-stroke" x="433.66385" y="276.70223">167</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="473.66379" y="276.70475" id="svg_1583" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 513.5600585937501,259.8894348144532) ">
+   <tspan id="svg_6" vector-effect="non-scaling-stroke" x="473.66379" y="276.70229">200</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="513.66364" y="276.7049" id="svg_1584" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 553.5599365234376,259.8894348144532) ">
+   <tspan id="svg_7" vector-effect="non-scaling-stroke" x="513.66364" y="276.70229">234</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="553.66364" y="276.7049" id="svg_1585" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 593.5599365234376,259.88949584960943) ">
+   <tspan id="svg_8" vector-effect="non-scaling-stroke" x="553.66364" y="276.70235">267</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="593.6637" y="276.70483" id="svg_1586" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 633.5599975585939,259.8894348144532) ">
+   <tspan id="svg_9" vector-effect="non-scaling-stroke" x="593.6637" y="276.70229">300</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="633.66364" y="276.7049" id="svg_1587" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 673.5599365234376,259.8894348144532) ">
+   <tspan id="svg_10" vector-effect="non-scaling-stroke" x="633.66364" y="276.70229">334</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="673.66373" y="276.70481" id="svg_1588" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 713.5600585937501,259.8893432617188) ">
+   <tspan id="svg_11" vector-effect="non-scaling-stroke" x="673.66373" y="276.7022">367</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="713.66367" y="276.70487" id="svg_1589" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info" transform="rotate(90 753.5599365234376,259.8894348144532) ">
+   <tspan id="svg_12" vector-effect="non-scaling-stroke" x="713.66367" y="276.70226">400</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="361.11117" id="svg_1590" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_13" vector-effect="non-scaling-stroke" x="219.89584" y="361.10869">0.001</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="401.11117" id="svg_1591" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_14" vector-effect="non-scaling-stroke" x="219.89584" y="401.10869">0.0031</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="441.11117" id="svg_1592" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_15" vector-effect="non-scaling-stroke" x="219.89584" y="441.10869">0.0052</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="481.11117" id="svg_1593" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_16" vector-effect="non-scaling-stroke" x="219.89584" y="481.10869">0.0073</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="521.11117" id="svg_1594" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_17" vector-effect="non-scaling-stroke" x="219.89584" y="521.10869">0.0094</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="561.11117" id="svg_1595" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_18" vector-effect="non-scaling-stroke" x="219.89584" y="561.10869">0.0116</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="601.11117" id="svg_1596" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_19" vector-effect="non-scaling-stroke" x="219.89584" y="601.10869">0.0137</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="641.11117" id="svg_1597" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_20" vector-effect="non-scaling-stroke" x="219.89584" y="641.10869">0.0158</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="681.11117" id="svg_1598" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_21" vector-effect="non-scaling-stroke" x="219.89584" y="681.10869">0.0179</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="219.89584" y="721.11117" id="svg_1599" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_22" vector-effect="non-scaling-stroke" x="219.89584" y="721.10869">0.02</tspan>
+  </text>
+ </g>
+</svg>

--- a/public/examples/promark_mopa_20w_color_example.bvg
+++ b/public/examples/promark_mopa_20w_color_example.bvg
@@ -1,0 +1,781 @@
+<svg id="svgcontent" width="1100" height="1100" viewBox="0 0 1100 1100" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" data-top="-304" data-left="-68" data-zoom="0.395" data-workarea="fpm1" data-en_af="false" data-en_diode="false" data-rotary_mode="0" data-engrave_dpi="medium">
+
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.02" data-frequency="450">
+  <title>FI0.02-F450</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="692.93948" width="30" height="30" stroke="#F44336" id="svg_3076" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.02" data-frequency="417">
+  <title>FI0.02-F417</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="692.93948" width="30" height="30" stroke="#FFC107" id="svg_3077" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.02" data-frequency="384">
+  <title>FI0.02-F384</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="692.93948" width="30" height="30" stroke="#8BC34A" id="svg_3078" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.02" data-frequency="350">
+  <title>FI0.02-F350</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="692.93948" width="30" height="30" stroke="#2196F3" id="svg_3079" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#009688" data-fillInterval="0.02" data-frequency="317">
+  <title>FI0.02-F317</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="692.93948" width="30" height="30" stroke="#009688" id="svg_3080" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.02" data-frequency="284">
+  <title>FI0.02-F284</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="692.93948" width="30" height="30" stroke="#FF9800" id="svg_3081" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.02" data-frequency="250">
+  <title>FI0.02-F250</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="525.85143" y="692.93948" width="30" height="30" stroke="#CDDC39" id="svg_3082" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.02" data-frequency="217">
+  <title>FI0.02-F217</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="692.93948" width="30" height="30" stroke="#00BCD4" id="svg_3083" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.02" data-frequency="184">
+  <title>FI0.02-F184</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="692.93948" width="30" height="30" stroke="#FFEB3B" id="svg_3084" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.02" data-frequency="150">
+  <title>FI0.02-F150</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="692.93948" width="30" height="30" stroke="#E91E63" id="svg_3085" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.02-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0186" data-frequency="450">
+  <title>FI0.0186-F450</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="652.93948" width="30" height="30" stroke="#673AB7" id="svg_3086" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0186" data-frequency="417">
+  <title>FI0.0186-F417</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="652.93948" width="30" height="30" stroke="#03A9F4" id="svg_3087" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0186" data-frequency="384">
+  <title>FI0.0186-F384</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="652.93948" width="30" height="30" stroke="#9C27B0" id="svg_3088" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0186" data-frequency="350">
+  <title>FI0.0186-F350</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="652.93948" width="30" height="30" stroke="#607D8B" id="svg_3089" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0186" data-frequency="317">
+  <title>FI0.0186-F317</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="652.93948" width="30" height="30" stroke="#9E9E9E" id="svg_3090" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0186" data-frequency="284">
+  <title>FI0.0186-F284</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="652.93948" width="30" height="30" stroke="#333333" id="svg_3091" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0186" data-frequency="250">
+  <title>FI0.0186-F250</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="525.85143" y="652.93948" width="30" height="30" stroke="#3F51B5" id="svg_3092" fill="#3F51B5" data-original-layer="FI0.0186-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0186" data-frequency="217">
+  <title>FI0.0186-F217</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="652.93948" width="30" height="30" stroke="#F44336" id="svg_3093" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0186" data-frequency="184">
+  <title>FI0.0186-F184</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="652.93948" width="30" height="30" stroke="#FFC107" id="svg_3094" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0186" data-frequency="150">
+  <title>FI0.0186-F150</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="652.93948" width="30" height="30" stroke="#8BC34A" id="svg_3095" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0186-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0172" data-frequency="450">
+  <title>FI0.0172-F450</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="612.93948" width="30" height="30" stroke="#2196F3" id="svg_3096" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0172" data-frequency="417">
+  <title>FI0.0172-F417</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="612.93948" width="30" height="30" stroke="#009688" id="svg_3097" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0172" data-frequency="384">
+  <title>FI0.0172-F384</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="612.93948" width="30" height="30" stroke="#FF9800" id="svg_3098" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0172" data-frequency="350">
+  <title>FI0.0172-F350</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="612.93948" width="30" height="30" stroke="#CDDC39" id="svg_3099" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0172" data-frequency="317">
+  <title>FI0.0172-F317</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="605.85143" y="612.93948" width="30" height="30" stroke="#00BCD4" id="svg_3100" fill="#00BCD4" data-original-layer="FI0.0172-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0172" data-frequency="284">
+  <title>FI0.0172-F284</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="565.85143" y="612.93948" width="30" height="30" stroke="#FFEB3B" id="svg_3101" fill="#FFEB3B" data-original-layer="FI0.0172-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0172" data-frequency="250">
+  <title>FI0.0172-F250</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="525.85143" y="612.93948" width="30" height="30" stroke="#E91E63" id="svg_3102" fill="#E91E63" data-original-layer="FI0.0172-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0172" data-frequency="217">
+  <title>FI0.0172-F217</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="612.93948" width="30" height="30" stroke="#673AB7" id="svg_3103" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0172" data-frequency="184">
+  <title>FI0.0172-F184</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="612.93948" width="30" height="30" stroke="#03A9F4" id="svg_3104" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0172" data-frequency="150">
+  <title>FI0.0172-F150</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="612.93948" width="30" height="30" stroke="#9C27B0" id="svg_3105" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0172-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0158" data-frequency="450">
+  <title>FI0.0158-F450</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="572.93948" width="30" height="30" stroke="#607D8B" id="svg_3106" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0158" data-frequency="417">
+  <title>FI0.0158-F417</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="572.93948" width="30" height="30" stroke="#9E9E9E" id="svg_3107" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0158" data-frequency="384">
+  <title>FI0.0158-F384</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="572.93948" width="30" height="30" stroke="#333333" id="svg_3108" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0158" data-frequency="350">
+  <title>FI0.0158-F350</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="572.93948" width="30" height="30" stroke="#3F51B5" id="svg_3109" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0158" data-frequency="317">
+  <title>FI0.0158-F317</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="572.93948" width="30" height="30" stroke="#F44336" id="svg_3110" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0158" data-frequency="284">
+  <title>FI0.0158-F284</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="572.93948" width="30" height="30" stroke="#FFC107" id="svg_3111" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0158" data-frequency="250">
+  <title>FI0.0158-F250</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="525.85143" y="572.93948" width="30" height="30" stroke="#8BC34A" id="svg_3112" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0158" data-frequency="217">
+  <title>FI0.0158-F217</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="572.93948" width="30" height="30" stroke="#2196F3" id="svg_3113" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0158" data-frequency="184">
+  <title>FI0.0158-F184</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="572.93948" width="30" height="30" stroke="#009688" id="svg_3114" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0158" data-frequency="150">
+  <title>FI0.0158-F150</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="572.93948" width="30" height="30" stroke="#FF9800" id="svg_3115" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0158-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0144" data-frequency="450">
+  <title>FI0.0144-F450</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="532.93948" width="30" height="30" stroke="#CDDC39" id="svg_3116" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0144" data-frequency="417">
+  <title>FI0.0144-F417</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="532.93948" width="30" height="30" stroke="#00BCD4" id="svg_3117" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0144" data-frequency="384">
+  <title>FI0.0144-F384</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="532.93948" width="30" height="30" stroke="#FFEB3B" id="svg_3118" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0144" data-frequency="350">
+  <title>FI0.0144-F350</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="532.93948" width="30" height="30" stroke="#E91E63" id="svg_3119" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0144" data-frequency="317">
+  <title>FI0.0144-F317</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="532.93948" width="30" height="30" stroke="#673AB7" id="svg_3120" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0144" data-frequency="284">
+  <title>FI0.0144-F284</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="532.93948" width="30" height="30" stroke="#03A9F4" id="svg_3121" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0144" data-frequency="250">
+  <title>FI0.0144-F250</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="525.85143" y="532.93948" width="30" height="30" stroke="#9C27B0" id="svg_3122" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0144" data-frequency="217">
+  <title>FI0.0144-F217</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="532.93948" width="30" height="30" stroke="#607D8B" id="svg_3123" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0144" data-frequency="184">
+  <title>FI0.0144-F184</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="532.93948" width="30" height="30" stroke="#9E9E9E" id="svg_3124" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0144" data-frequency="150">
+  <title>FI0.0144-F150</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="532.93948" width="30" height="30" stroke="#333333" id="svg_3125" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0144-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0131" data-frequency="450">
+  <title>FI0.0131-F450</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="492.93948" width="30" height="30" stroke="#3F51B5" id="svg_3126" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0131" data-frequency="417">
+  <title>FI0.0131-F417</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="492.93948" width="30" height="30" stroke="#F44336" id="svg_3127" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0131" data-frequency="384">
+  <title>FI0.0131-F384</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="492.93948" width="30" height="30" stroke="#FFC107" id="svg_3128" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0131" data-frequency="350">
+  <title>FI0.0131-F350</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="492.93948" width="30" height="30" stroke="#8BC34A" id="svg_3129" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0131" data-frequency="317">
+  <title>FI0.0131-F317</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="492.93948" width="30" height="30" stroke="#2196F3" id="svg_3130" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0131" data-frequency="284">
+  <title>FI0.0131-F284</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="492.93948" width="30" height="30" stroke="#009688" id="svg_3131" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0131" data-frequency="250">
+  <title>FI0.0131-F250</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="525.85143" y="492.93948" width="30" height="30" stroke="#FF9800" id="svg_3132" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0131" data-frequency="217">
+  <title>FI0.0131-F217</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="492.93948" width="30" height="30" stroke="#CDDC39" id="svg_3133" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0131" data-frequency="184">
+  <title>FI0.0131-F184</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="492.93948" width="30" height="30" stroke="#00BCD4" id="svg_3134" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0131" data-frequency="150">
+  <title>FI0.0131-F150</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="492.93948" width="30" height="30" stroke="#FFEB3B" id="svg_3135" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0131-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0117" data-frequency="450">
+  <title>FI0.0117-F450</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="452.93948" width="30" height="30" stroke="#E91E63" id="svg_3136" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0117" data-frequency="417">
+  <title>FI0.0117-F417</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="452.93948" width="30" height="30" stroke="#673AB7" id="svg_3137" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0117" data-frequency="384">
+  <title>FI0.0117-F384</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="452.93948" width="30" height="30" stroke="#03A9F4" id="svg_3138" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0117" data-frequency="350">
+  <title>FI0.0117-F350</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="452.93948" width="30" height="30" stroke="#9C27B0" id="svg_3139" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0117" data-frequency="317">
+  <title>FI0.0117-F317</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="452.93948" width="30" height="30" stroke="#607D8B" id="svg_3140" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0117" data-frequency="284">
+  <title>FI0.0117-F284</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="452.93948" width="30" height="30" stroke="#9E9E9E" id="svg_3141" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0117" data-frequency="250">
+  <title>FI0.0117-F250</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="525.85143" y="452.93948" width="30" height="30" stroke="#333333" id="svg_3142" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0117" data-frequency="217">
+  <title>FI0.0117-F217</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="452.93948" width="30" height="30" stroke="#3F51B5" id="svg_3143" fill="#3F51B5" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0117" data-frequency="184">
+  <title>FI0.0117-F184</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="452.93948" width="30" height="30" stroke="#F44336" id="svg_3144" fill="#F44336" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0117" data-frequency="150">
+  <title>FI0.0117-F150</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="452.93948" width="30" height="30" stroke="#FFC107" id="svg_3145" fill="#FFC107" vector-effect="non-scaling-stroke" data-original-layer="FI0.0117-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0103" data-frequency="450">
+  <title>FI0.0103-F450</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="412.93948" width="30" height="30" stroke="#8BC34A" id="svg_3146" fill="#8BC34A" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0103" data-frequency="417">
+  <title>FI0.0103-F417</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="412.93948" width="30" height="30" stroke="#2196F3" id="svg_3147" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0103" data-frequency="384">
+  <title>FI0.0103-F384</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="412.93948" width="30" height="30" stroke="#009688" id="svg_3148" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0103" data-frequency="350">
+  <title>FI0.0103-F350</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="412.93948" width="30" height="30" stroke="#FF9800" id="svg_3149" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0103" data-frequency="317">
+  <title>FI0.0103-F317</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="412.93948" width="30" height="30" stroke="#CDDC39" id="svg_3150" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0103" data-frequency="284">
+  <title>FI0.0103-F284</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="412.93948" width="30" height="30" stroke="#00BCD4" id="svg_3151" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0103" data-frequency="250">
+  <title>FI0.0103-F250</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="525.85143" y="412.93948" width="30" height="30" stroke="#FFEB3B" id="svg_3152" fill="#FFEB3B" data-original-layer="FI0.0103-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0103" data-frequency="217">
+  <title>FI0.0103-F217</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="485.85143" y="412.93948" width="30" height="30" stroke="#E91E63" id="svg_3153" fill="#E91E63" data-original-layer="FI0.0103-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0103" data-frequency="184">
+  <title>FI0.0103-F184</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="412.93948" width="30" height="30" stroke="#673AB7" id="svg_3154" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0103" data-frequency="150">
+  <title>FI0.0103-F150</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="412.93948" width="30" height="30" stroke="#03A9F4" id="svg_3155" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0103-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0089" data-frequency="450">
+  <title>FI0.0089-F450</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="372.93948" width="30" height="30" stroke="#9C27B0" id="svg_3156" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0089-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0089" data-frequency="417">
+  <title>FI0.0089-F417</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="372.93948" width="30" height="30" stroke="#607D8B" id="svg_3157" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0089-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0089" data-frequency="384">
+  <title>FI0.0089-F384</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="372.93948" width="30" height="30" stroke="#9E9E9E" id="svg_3158" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0089-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#333333" data-fillInterval="0.0089" data-frequency="350">
+  <title>FI0.0089-F350</title>
+  <filter id="filter#333333" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="372.93948" width="30" height="30" stroke="#333333" id="svg_3159" fill="#333333" vector-effect="non-scaling-stroke" data-original-layer="FI0.0089-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#3F51B5" data-fillInterval="0.0089" data-frequency="317">
+  <title>FI0.0089-F317</title>
+  <filter id="filter#3F51B5" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="605.85143" y="372.93948" width="30" height="30" stroke="#3F51B5" id="svg_3160" fill="#3F51B5" data-original-layer="FI0.0089-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#F44336" data-fillInterval="0.0089" data-frequency="284">
+  <title>FI0.0089-F284</title>
+  <filter id="filter#F44336" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="565.85143" y="372.93948" width="30" height="30" stroke="#F44336" id="svg_3161" fill="#F44336" data-original-layer="FI0.0089-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFC107" data-fillInterval="0.0089" data-frequency="250">
+  <title>FI0.0089-F250</title>
+  <filter id="filter#FFC107" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="525.85143" y="372.93948" width="30" height="30" stroke="#FFC107" id="svg_3162" fill="#FFC107" data-original-layer="FI0.0089-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#8BC34A" data-fillInterval="0.0089" data-frequency="217">
+  <title>FI0.0089-F217</title>
+  <filter id="filter#8BC34A" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" x="485.85143" y="372.93948" width="30" height="30" stroke="#8BC34A" id="svg_3163" fill="#8BC34A" data-original-layer="FI0.0089-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#2196F3" data-fillInterval="0.0089" data-frequency="184">
+  <title>FI0.0089-F184</title>
+  <filter id="filter#2196F3" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="372.93948" width="30" height="30" stroke="#2196F3" id="svg_3164" fill="#2196F3" vector-effect="non-scaling-stroke" data-original-layer="FI0.0089-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#009688" data-fillInterval="0.0089" data-frequency="150">
+  <title>FI0.0089-F150</title>
+  <filter id="filter#009688" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="372.93948" width="30" height="30" stroke="#009688" id="svg_3165" fill="#009688" vector-effect="non-scaling-stroke" data-original-layer="FI0.0089-F150"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FF9800" data-fillInterval="0.0075" data-frequency="450">
+  <title>FI0.0075-F450</title>
+  <filter id="filter#FF9800" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <rect x="765.85143" y="332.93948" width="30" height="30" stroke="#FF9800" id="svg_3166" fill="#FF9800" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F450"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#CDDC39" data-fillInterval="0.0075" data-frequency="417">
+  <title>FI0.0075-F417</title>
+  <filter id="filter#CDDC39" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0"/>
+  </filter>
+  <rect x="725.85143" y="332.93948" width="30" height="30" stroke="#CDDC39" id="svg_3167" fill="#CDDC39" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F417"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#00BCD4" data-fillInterval="0.0075" data-frequency="384">
+  <title>FI0.0075-F384</title>
+  <filter id="filter#00BCD4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0"/>
+  </filter>
+  <rect x="685.85143" y="332.93948" width="30" height="30" stroke="#00BCD4" id="svg_3168" fill="#00BCD4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F384"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#FFEB3B" data-fillInterval="0.0075" data-frequency="350">
+  <title>FI0.0075-F350</title>
+  <filter id="filter#FFEB3B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0"/>
+  </filter>
+  <rect x="645.85143" y="332.93948" width="30" height="30" stroke="#FFEB3B" id="svg_3169" fill="#FFEB3B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F350"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#E91E63" data-fillInterval="0.0075" data-frequency="317">
+  <title>FI0.0075-F317</title>
+  <filter id="filter#E91E63" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0"/>
+  </filter>
+  <rect x="605.85143" y="332.93948" width="30" height="30" stroke="#E91E63" id="svg_3170" fill="#E91E63" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F317"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#673AB7" data-fillInterval="0.0075" data-frequency="284">
+  <title>FI0.0075-F284</title>
+  <filter id="filter#673AB7" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0"/>
+  </filter>
+  <rect x="565.85143" y="332.93948" width="30" height="30" stroke="#673AB7" id="svg_3171" fill="#673AB7" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F284"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#03A9F4" data-fillInterval="0.0075" data-frequency="250">
+  <title>FI0.0075-F250</title>
+  <filter id="filter#03A9F4" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0"/>
+  </filter>
+  <rect x="525.85143" y="332.93948" width="30" height="30" stroke="#03A9F4" id="svg_3172" fill="#03A9F4" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F250"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9C27B0" data-fillInterval="0.0075" data-frequency="217">
+  <title>FI0.0075-F217</title>
+  <filter id="filter#9C27B0" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0"/>
+  </filter>
+  <rect x="485.85143" y="332.93948" width="30" height="30" stroke="#9C27B0" id="svg_3173" fill="#9C27B0" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F217"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#607D8B" data-fillInterval="0.0075" data-frequency="184">
+  <title>FI0.0075-F184</title>
+  <filter id="filter#607D8B" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0"/>
+  </filter>
+  <rect x="445.85143" y="332.93948" width="30" height="30" stroke="#607D8B" id="svg_3174" fill="#607D8B" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F184"/>
+ </g>
+ <g data-pulseWidth="25" data-speed="500" data-strength="100" data-module="15" class="layer" data-color="#9E9E9E" data-fillInterval="0.0075" data-frequency="150">
+  <title>FI0.0075-F150</title>
+  <filter id="filter#9E9E9E" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0"/>
+  </filter>
+  <rect x="405.85143" y="332.93948" width="30" height="30" stroke="#9E9E9E" id="svg_3175" fill="#9E9E9E" vector-effect="non-scaling-stroke" data-original-layer="FI0.0075-F150"/>
+ </g>
+ <g data-configName="stainless_steel_dark" data-fillInterval="0.01" data-frequency="25" data-pulseWidth="350" data-repeat="1" data-strength="30" data-speed="150" data-module="15" class="layer" data-color="#000">
+  <title>Material Test - Frame</title>
+  <filter id="filter#000" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+ </g>
+ <g data-configName="stainless_steel_dark" data-fillInterval="0.01" data-frequency="25" data-pulseWidth="350" data-repeat="1" data-module="15" class="layer" data-color="#000" data-strength="30" data-speed="150">
+  <title>Material Test - Info</title>
+  <filter id="filter#000" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+   <feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0"/>
+  </filter>
+  <text vector-effect="non-scaling-stroke" fill="#000" x="981.5458" y="234.63987" id="svg_3177" font-size="130" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" font-style="normal" font-weight="400" transform="matrix(0.39618870184929234,0,0,0.3879945062564321,13.28921959819786,102.98165815466226) " stroke="#000" data-original-layer="Material Test - Info">
+   <tspan id="svg_1" vector-effect="non-scaling-stroke" x="981.5458" y="234.63987">Frequency (kHz)</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" x="923.98919" y="726.61623" id="svg_3178" font-size="130" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(-90 189.3772125244141,501.1181335449219) matrix(0.3964779796400109,0,0,0.3952240685441382,-376.97847110125923,232.41148331023393) " font-style="normal" font-weight="400" stroke="#000" data-original-layer="Material Test - Info">
+   <tspan id="svg_2" vector-effect="non-scaling-stroke" x="923.98919" y="726.61623">Fill Interval (mm)</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="380.35143" y="282.93948" id="svg_3179" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 420.23968505859375,265.8108520507813) " data-original-layer="Material Test - Info">
+   <tspan id="svg_3" vector-effect="non-scaling-stroke" x="380.35143" y="282.93948">150</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="420.35143" y="282.93948" id="svg_3180" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 460.23968505859375,265.8108520507813) " data-original-layer="Material Test - Info">
+   <tspan id="svg_4" vector-effect="non-scaling-stroke" x="420.35143" y="282.93948">184</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="460.35143" y="282.93948" id="svg_3181" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 500.2396545410156,265.8108520507813) " data-original-layer="Material Test - Info">
+   <tspan id="svg_5" vector-effect="non-scaling-stroke" x="460.35143" y="282.93948">217</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="500.35143" y="282.93948" id="svg_3182" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 540.2396850585939,265.8108520507813) " data-original-layer="Material Test - Info">
+   <tspan id="svg_6" vector-effect="non-scaling-stroke" x="500.35143" y="282.93948">250</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="540.35136" y="282.93954" id="svg_3183" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 580.2396240234376,265.81091308593756) " data-original-layer="Material Test - Info">
+   <tspan id="svg_7" vector-effect="non-scaling-stroke" x="540.35136" y="282.93954">284</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="580.35136" y="282.93954" id="svg_3184" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 620.2396240234376,265.81091308593756) " data-original-layer="Material Test - Info">
+   <tspan id="svg_8" vector-effect="non-scaling-stroke" x="580.35136" y="282.93954">317</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="620.35136" y="282.93954" id="svg_3185" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 660.2395629882814,265.81091308593756) " data-original-layer="Material Test - Info">
+   <tspan id="svg_9" vector-effect="non-scaling-stroke" x="620.35136" y="282.93954">350</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="660.35143" y="282.93948" id="svg_3186" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 700.2396850585939,265.8108520507813) " data-original-layer="Material Test - Info">
+   <tspan id="svg_10" vector-effect="non-scaling-stroke" x="660.35143" y="282.93948">384</tspan>
+  </text>
+  <text transform="rotate(90 740.2372436523439,265.20422363281256) " stroke-width="2" font-weight="400" font-style="normal" vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="700.35143" y="282.93948" id="svg_3187" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_11" vector-effect="non-scaling-stroke" x="700.35143" y="282.94">417</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="740.35136" y="282.93954" id="svg_3188" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" transform="rotate(90 780.2396240234375,265.8109130859376) " data-original-layer="Material Test - Info">
+   <tspan id="svg_12" vector-effect="non-scaling-stroke" x="740.35136" y="282.93954">450</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="367.93948" id="svg_3189" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_13" vector-effect="non-scaling-stroke" x="235.85143" y="367.93948">0.0075</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="407.93948" id="svg_3190" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_14" vector-effect="non-scaling-stroke" x="235.85143" y="407.93948">0.0089</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="447.93948" id="svg_3191" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_15" vector-effect="non-scaling-stroke" x="235.85143" y="447.93948">0.0103</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="487.93948" id="svg_3192" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_16" vector-effect="non-scaling-stroke" x="235.85143" y="487.93948">0.0117</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="527.93948" id="svg_3193" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_17" vector-effect="non-scaling-stroke" x="235.85143" y="527.93948">0.0131</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="567.93948" id="svg_3194" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_18" vector-effect="non-scaling-stroke" x="235.85143" y="567.93948">0.0144</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="607.93948" id="svg_3195" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_19" vector-effect="non-scaling-stroke" x="235.85143" y="607.93948">0.0158</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="647.93948" id="svg_3196" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_20" vector-effect="non-scaling-stroke" x="235.85143" y="647.93948">0.0172</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="687.93948" id="svg_3197" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_21" vector-effect="non-scaling-stroke" x="235.85143" y="687.93948">0.0186</tspan>
+  </text>
+  <text vector-effect="non-scaling-stroke" fill="#000" stroke="#000" x="235.85143" y="727.93948" id="svg_3198" font-size="48" font-family="&#x27;STHeitiTC-Light'" font-postscript="STHeitiTC-Light" text-anchor="start" data-ratiofixed="true" xml:space="preserve" data-original-layer="Material Test - Info">
+   <tspan id="svg_22" vector-effect="non-scaling-stroke" x="235.85143" y="727.93948">0.02</tspan>
+  </text>
+ </g>
+</svg>

--- a/public/examples/promark_mopa_60w_color_example.bvg
+++ b/public/examples/promark_mopa_60w_color_example.bvg
@@ -1,0 +1,781 @@
+<svg id="svgcontent" width="2200" height="2200" viewBox="0 0 2200 2200" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" style="will-change: scroll-position, contents, transform;" data-top="-119" data-left="-494" data-zoom="0.365" data-workarea="fpm1" data-en_af="false" data-en_diode="false" data-rotary_mode="0" data-engrave_dpi="medium">
+
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.02" data-color="#00BCD4" class="layer">
+  <title>FI0.02-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F400" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1600" stroke="#00BCD4" height="30" width="30" y="695.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.02" data-color="#FFEB3B" class="layer">
+  <title>FI0.02-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F367" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1601" stroke="#FFEB3B" height="30" width="30" y="695.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.02" data-color="#E91E63" class="layer">
+  <title>FI0.02-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F334" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1602" stroke="#E91E63" height="30" width="30" y="695.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.02" data-color="#673AB7" class="layer">
+  <title>FI0.02-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F300" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1603" stroke="#673AB7" height="30" width="30" y="695.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.02" data-color="#03A9F4" class="layer">
+  <title>FI0.02-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F267" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1604" stroke="#03A9F4" height="30" width="30" y="695.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.02" data-color="#9C27B0" class="layer">
+  <title>FI0.02-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F234" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1605" stroke="#9C27B0" height="30" width="30" y="695.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.02" data-color="#607D8B" class="layer">
+  <title>FI0.02-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F200" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1606" stroke="#607D8B" height="30" width="30" y="695.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.02" data-color="#9E9E9E" class="layer">
+  <title>FI0.02-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F167" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1607" stroke="#9E9E9E" height="30" width="30" y="695.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.02" data-color="#333333" class="layer">
+  <title>FI0.02-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F134" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1608" stroke="#333333" height="30" width="30" y="695.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.02" data-color="#3F51B5" class="layer">
+  <title>FI0.02-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F100" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1609" stroke="#3F51B5" height="30" width="30" y="695.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0179" data-color="#F44336" class="layer">
+  <title>FI0.0179-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F400" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1610" stroke="#F44336" height="30" width="30" y="655.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0179" data-color="#FFC107" class="layer">
+  <title>FI0.0179-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F367" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1611" stroke="#FFC107" height="30" width="30" y="655.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0179" data-color="#8BC34A" class="layer">
+  <title>FI0.0179-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F334" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1612" stroke="#8BC34A" height="30" width="30" y="655.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0179" data-color="#2196F3" class="layer">
+  <title>FI0.0179-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F300" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1613" stroke="#2196F3" height="30" width="30" y="655.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0179" data-color="#009688" class="layer">
+  <title>FI0.0179-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F267" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1614" stroke="#009688" height="30" width="30" y="655.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0179" data-color="#FF9800" class="layer">
+  <title>FI0.0179-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F234" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1615" stroke="#FF9800" height="30" width="30" y="655.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0179" data-color="#CDDC39" class="layer">
+  <title>FI0.0179-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F200" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1616" stroke="#CDDC39" height="30" width="30" y="655.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0179" data-color="#00BCD4" class="layer">
+  <title>FI0.0179-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F167" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1617" stroke="#00BCD4" height="30" width="30" y="655.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0179" data-color="#FFEB3B" class="layer">
+  <title>FI0.0179-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F134" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1618" stroke="#FFEB3B" height="30" width="30" y="655.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0179" data-color="#E91E63" class="layer">
+  <title>FI0.0179-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F100" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1619" stroke="#E91E63" height="30" width="30" y="655.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0158" data-color="#673AB7" class="layer">
+  <title>FI0.0158-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F400" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1620" stroke="#673AB7" height="30" width="30" y="615.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0158" data-color="#03A9F4" class="layer">
+  <title>FI0.0158-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F367" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1621" stroke="#03A9F4" height="30" width="30" y="615.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0158" data-color="#9C27B0" class="layer">
+  <title>FI0.0158-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F334" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1622" stroke="#9C27B0" height="30" width="30" y="615.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0158" data-color="#607D8B" class="layer">
+  <title>FI0.0158-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F300" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1623" stroke="#607D8B" height="30" width="30" y="615.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0158" data-color="#9E9E9E" class="layer">
+  <title>FI0.0158-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F267" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1624" stroke="#9E9E9E" height="30" width="30" y="615.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0158" data-color="#333333" class="layer">
+  <title>FI0.0158-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F234" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1625" stroke="#333333" height="30" width="30" y="615.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0158" data-color="#3F51B5" class="layer">
+  <title>FI0.0158-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F200" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1626" stroke="#3F51B5" height="30" width="30" y="615.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0158" data-color="#F44336" class="layer">
+  <title>FI0.0158-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F167" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1627" stroke="#F44336" height="30" width="30" y="615.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0158" data-color="#FFC107" class="layer">
+  <title>FI0.0158-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F134" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1628" stroke="#FFC107" height="30" width="30" y="615.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0158" data-color="#8BC34A" class="layer">
+  <title>FI0.0158-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F100" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1629" stroke="#8BC34A" height="30" width="30" y="615.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0137" data-color="#2196F3" class="layer">
+  <title>FI0.0137-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F400" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1630" stroke="#2196F3" height="30" width="30" y="575.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0137" data-color="#009688" class="layer">
+  <title>FI0.0137-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F367" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1631" stroke="#009688" height="30" width="30" y="575.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0137" data-color="#FF9800" class="layer">
+  <title>FI0.0137-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F334" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1632" stroke="#FF9800" height="30" width="30" y="575.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0137" data-color="#CDDC39" class="layer">
+  <title>FI0.0137-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F300" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1633" stroke="#CDDC39" height="30" width="30" y="575.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0137" data-color="#00BCD4" class="layer">
+  <title>FI0.0137-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F267" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1634" stroke="#00BCD4" height="30" width="30" y="575.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0137" data-color="#FFEB3B" class="layer">
+  <title>FI0.0137-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F234" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1635" stroke="#FFEB3B" height="30" width="30" y="575.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0137" data-color="#E91E63" class="layer">
+  <title>FI0.0137-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F200" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1636" stroke="#E91E63" height="30" width="30" y="575.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0137" data-color="#673AB7" class="layer">
+  <title>FI0.0137-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F167" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1637" stroke="#673AB7" height="30" width="30" y="575.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0137" data-color="#03A9F4" class="layer">
+  <title>FI0.0137-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F134" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1638" stroke="#03A9F4" height="30" width="30" y="575.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0137" data-color="#9C27B0" class="layer">
+  <title>FI0.0137-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F100" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1639" stroke="#9C27B0" height="30" width="30" y="575.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0116" data-color="#607D8B" class="layer">
+  <title>FI0.0116-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F400" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1640" stroke="#607D8B" height="30" width="30" y="535.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0116" data-color="#9E9E9E" class="layer">
+  <title>FI0.0116-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F367" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1641" stroke="#9E9E9E" height="30" width="30" y="535.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0116" data-color="#333333" class="layer">
+  <title>FI0.0116-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F334" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1642" stroke="#333333" height="30" width="30" y="535.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0116" data-color="#3F51B5" class="layer">
+  <title>FI0.0116-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F300" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1643" stroke="#3F51B5" height="30" width="30" y="535.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0116" data-color="#F44336" class="layer">
+  <title>FI0.0116-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F267" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1644" stroke="#F44336" height="30" width="30" y="535.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0116" data-color="#FFC107" class="layer">
+  <title>FI0.0116-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F234" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1645" stroke="#FFC107" height="30" width="30" y="535.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0116" data-color="#8BC34A" class="layer">
+  <title>FI0.0116-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F200" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1646" stroke="#8BC34A" height="30" width="30" y="535.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0116" data-color="#2196F3" class="layer">
+  <title>FI0.0116-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F167" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1647" stroke="#2196F3" height="30" width="30" y="535.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0116" data-color="#009688" class="layer">
+  <title>FI0.0116-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F134" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1648" stroke="#009688" height="30" width="30" y="535.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0116" data-color="#FF9800" class="layer">
+  <title>FI0.0116-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F100" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1649" stroke="#FF9800" height="30" width="30" y="535.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0094" data-color="#CDDC39" class="layer">
+  <title>FI0.0094-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F400" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1650" stroke="#CDDC39" height="30" width="30" y="495.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0094" data-color="#00BCD4" class="layer">
+  <title>FI0.0094-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F367" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1651" stroke="#00BCD4" height="30" width="30" y="495.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0094" data-color="#FFEB3B" class="layer">
+  <title>FI0.0094-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F334" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1652" stroke="#FFEB3B" height="30" width="30" y="495.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0094" data-color="#E91E63" class="layer">
+  <title>FI0.0094-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F300" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1653" stroke="#E91E63" height="30" width="30" y="495.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0094" data-color="#673AB7" class="layer">
+  <title>FI0.0094-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F267" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1654" stroke="#673AB7" height="30" width="30" y="495.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0094" data-color="#03A9F4" class="layer">
+  <title>FI0.0094-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F234" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1655" stroke="#03A9F4" height="30" width="30" y="495.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0094" data-color="#9C27B0" class="layer">
+  <title>FI0.0094-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F200" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1656" stroke="#9C27B0" height="30" width="30" y="495.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0094" data-color="#607D8B" class="layer">
+  <title>FI0.0094-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F167" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1657" stroke="#607D8B" height="30" width="30" y="495.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0094" data-color="#9E9E9E" class="layer">
+  <title>FI0.0094-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F134" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1658" stroke="#9E9E9E" height="30" width="30" y="495.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0094" data-color="#333333" class="layer">
+  <title>FI0.0094-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F100" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1659" stroke="#333333" height="30" width="30" y="495.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0073" data-color="#3F51B5" class="layer">
+  <title>FI0.0073-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F400" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1660" stroke="#3F51B5" height="30" width="30" y="455.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0073" data-color="#F44336" class="layer">
+  <title>FI0.0073-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F367" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1661" stroke="#F44336" height="30" width="30" y="455.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0073" data-color="#FFC107" class="layer">
+  <title>FI0.0073-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F334" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1662" stroke="#FFC107" height="30" width="30" y="455.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0073" data-color="#8BC34A" class="layer">
+  <title>FI0.0073-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F300" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1663" stroke="#8BC34A" height="30" width="30" y="455.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0073" data-color="#2196F3" class="layer">
+  <title>FI0.0073-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F267" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1664" stroke="#2196F3" height="30" width="30" y="455.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0073" data-color="#009688" class="layer">
+  <title>FI0.0073-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F234" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1665" stroke="#009688" height="30" width="30" y="455.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0073" data-color="#FF9800" class="layer">
+  <title>FI0.0073-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F200" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1666" stroke="#FF9800" height="30" width="30" y="455.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0073" data-color="#CDDC39" class="layer">
+  <title>FI0.0073-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F167" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1667" stroke="#CDDC39" height="30" width="30" y="455.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0073" data-color="#00BCD4" class="layer">
+  <title>FI0.0073-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F134" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1668" stroke="#00BCD4" height="30" width="30" y="455.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0073" data-color="#FFEB3B" class="layer">
+  <title>FI0.0073-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F100" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1669" stroke="#FFEB3B" height="30" width="30" y="455.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0052" data-color="#E91E63" class="layer">
+  <title>FI0.0052-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F400" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1670" stroke="#E91E63" height="30" width="30" y="415.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0052" data-color="#673AB7" class="layer">
+  <title>FI0.0052-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F367" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1671" stroke="#673AB7" height="30" width="30" y="415.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0052" data-color="#03A9F4" class="layer">
+  <title>FI0.0052-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F334" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1672" stroke="#03A9F4" height="30" width="30" y="415.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0052" data-color="#9C27B0" class="layer">
+  <title>FI0.0052-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F300" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1673" stroke="#9C27B0" height="30" width="30" y="415.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0052" data-color="#607D8B" class="layer">
+  <title>FI0.0052-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F267" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1674" stroke="#607D8B" height="30" width="30" y="415.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0052" data-color="#9E9E9E" class="layer">
+  <title>FI0.0052-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F234" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1675" stroke="#9E9E9E" height="30" width="30" y="415.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0052" data-color="#333333" class="layer">
+  <title>FI0.0052-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F200" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1676" stroke="#333333" height="30" width="30" y="415.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0052" data-color="#3F51B5" class="layer">
+  <title>FI0.0052-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F167" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1677" stroke="#3F51B5" height="30" width="30" y="415.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0052" data-color="#F44336" class="layer">
+  <title>FI0.0052-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F134" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1678" stroke="#F44336" height="30" width="30" y="415.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0052" data-color="#FFC107" class="layer">
+  <title>FI0.0052-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F100" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1679" stroke="#FFC107" height="30" width="30" y="415.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.0031" data-color="#8BC34A" class="layer">
+  <title>FI0.0031-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F400" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1680" stroke="#8BC34A" height="30" width="30" y="375.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.0031" data-color="#2196F3" class="layer">
+  <title>FI0.0031-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F367" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1681" stroke="#2196F3" height="30" width="30" y="375.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.0031" data-color="#009688" class="layer">
+  <title>FI0.0031-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F334" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1682" stroke="#009688" height="30" width="30" y="375.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.0031" data-color="#FF9800" class="layer">
+  <title>FI0.0031-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F300" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1683" stroke="#FF9800" height="30" width="30" y="375.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.0031" data-color="#CDDC39" class="layer">
+  <title>FI0.0031-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F267" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1684" stroke="#CDDC39" height="30" width="30" y="375.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.0031" data-color="#00BCD4" class="layer">
+  <title>FI0.0031-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F234" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1685" stroke="#00BCD4" height="30" width="30" y="375.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.0031" data-color="#FFEB3B" class="layer">
+  <title>FI0.0031-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F200" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1686" stroke="#FFEB3B" height="30" width="30" y="375.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.0031" data-color="#E91E63" class="layer">
+  <title>FI0.0031-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F167" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1687" stroke="#E91E63" height="30" width="30" y="375.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.0031" data-color="#673AB7" class="layer">
+  <title>FI0.0031-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F134" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1688" stroke="#673AB7" height="30" width="30" y="375.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.0031" data-color="#03A9F4" class="layer">
+  <title>FI0.0031-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F100" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1689" stroke="#03A9F4" height="30" width="30" y="375.15498" x="408.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="400" data-fillInterval="0.001" data-color="#9C27B0" class="layer">
+  <title>FI0.001-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F400" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1690" stroke="#9C27B0" height="30" width="30" y="335.15498" x="768.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="367" data-fillInterval="0.001" data-color="#607D8B" class="layer">
+  <title>FI0.001-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F367" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1691" stroke="#607D8B" height="30" width="30" y="335.15498" x="728.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="334" data-fillInterval="0.001" data-color="#9E9E9E" class="layer">
+  <title>FI0.001-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F334" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1692" stroke="#9E9E9E" height="30" width="30" y="335.15498" x="688.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="300" data-fillInterval="0.001" data-color="#333333" class="layer">
+  <title>FI0.001-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F300" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1693" stroke="#333333" height="30" width="30" y="335.15498" x="648.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="267" data-fillInterval="0.001" data-color="#3F51B5" class="layer">
+  <title>FI0.001-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F267" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1694" stroke="#3F51B5" height="30" width="30" y="335.15498" x="608.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="234" data-fillInterval="0.001" data-color="#F44336" class="layer">
+  <title>FI0.001-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F234" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1695" stroke="#F44336" height="30" width="30" y="335.15498" x="568.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="200" data-fillInterval="0.001" data-color="#FFC107" class="layer">
+  <title>FI0.001-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F200" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1696" stroke="#FFC107" height="30" width="30" y="335.15498" x="528.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="167" data-fillInterval="0.001" data-color="#8BC34A" class="layer">
+  <title>FI0.001-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F167" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1697" stroke="#8BC34A" height="30" width="30" y="335.15498" x="488.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="134" data-fillInterval="0.001" data-color="#2196F3" class="layer">
+  <title>FI0.001-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F134" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1698" stroke="#2196F3" height="30" width="30" y="335.15498" x="448.4563"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="750" data-configName="0" data-strength="100" data-frequency="100" data-fillInterval="0.001" data-color="#009688" class="layer">
+  <title>FI0.001-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F100" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1699" stroke="#009688" height="30" width="30" y="335.15498" x="408.4563"/>
+ </g>
+ <g data-color="#000" class="layer">
+  <title>Material Test - Frame</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#000">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+ </g>
+ <g display="inline" data-speed="500" data-strength="50" data-color="#000" class="layer">
+  <title>Material Test - Info</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#000">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <text data-original-layer="Material Test - Info" transform="matrix(0.3961530923843384,0,0,0.3975520730018616,-3.985389532676038,23.072052210460697) " font-weight="400" font-style="normal" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="130" id="svg_1701" y="429.76618" x="1038.60714" stroke="#000" fill="#000">
+   <tspan y="429.76618" x="1038.60714" vector-effect="non-scaling-stroke">Frequency (kHz)</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" font-weight="400" font-style="normal" transform="rotate(-90 175.39608764648452,525.2949218750001) matrix(0.39640524983406067,0,0,0.3978394865989685,-241.64009915001134,463.17040733482645) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="130" id="svg_1702" y="202.73489" x="547.565" stroke="#000" fill="#000">
+   <tspan y="202.73709" x="547.565" vector-effect="non-scaling-stroke">Fill Interval (mm)</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 422.8445739746094,268.02636718750006) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1703" y="285.15498" x="382.9563" stroke="#000" fill="#000">
+   <tspan y="285.15498" x="382.9563" vector-effect="non-scaling-stroke">100</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 462.8445739746094,268.02636718750006) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1704" y="285.15498" x="422.9563" stroke="#000" fill="#000">
+   <tspan y="285.15498" x="422.9563" vector-effect="non-scaling-stroke">134</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 502.84454345703125,268.02636718750006) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1705" y="285.15498" x="462.9563" stroke="#000" fill="#000">
+   <tspan y="285.15498" x="462.9563" vector-effect="non-scaling-stroke">167</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 542.8445434570314,268.02636718750006) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1706" y="285.15498" x="502.9563" stroke="#000" fill="#000">
+   <tspan y="285.15498" x="502.9563" vector-effect="non-scaling-stroke">200</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 582.8444824218751,268.0263977050782) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1707" y="285.15504" x="542.95624" stroke="#000" fill="#000">
+   <tspan y="285.15504" x="542.95624" vector-effect="non-scaling-stroke">234</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 622.8444824218751,268.0263977050782) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1708" y="285.15504" x="582.95624" stroke="#000" fill="#000">
+   <tspan y="285.15504" x="582.95624" vector-effect="non-scaling-stroke">267</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 662.8444824218751,268.0263977050782) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1709" y="285.15504" x="622.95624" stroke="#000" fill="#000">
+   <tspan y="285.15504" x="622.95624" vector-effect="non-scaling-stroke">300</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 702.8445434570314,268.02636718750006) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1710" y="285.15498" x="662.9563" stroke="#000" fill="#000">
+   <tspan y="285.15498" x="662.9563" vector-effect="non-scaling-stroke">334</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 742.8445434570314,268.02636718750006) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1711" y="285.15498" x="702.9563" stroke="#000" fill="#000">
+   <tspan y="285.15498" x="702.9563" vector-effect="non-scaling-stroke">367</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" transform="rotate(90 782.844482421875,268.02639770507824) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1712" y="285.15504" x="742.95624" stroke="#000" fill="#000">
+   <tspan y="285.15504" x="742.95624" vector-effect="non-scaling-stroke">400</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1713" y="370.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="370.15498" x="228.4563" vector-effect="non-scaling-stroke">0.001</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1714" y="410.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="410.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0031</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1715" y="450.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="450.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0052</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1716" y="490.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="490.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0073</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1717" y="530.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="530.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0094</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1718" y="570.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="570.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0116</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1719" y="610.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="610.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0137</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1720" y="650.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="650.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0158</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1721" y="690.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="690.15498" x="228.4563" vector-effect="non-scaling-stroke">0.0179</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1722" y="730.15498" x="228.4563" stroke="#000" fill="#000">
+   <tspan y="730.15498" x="228.4563" vector-effect="non-scaling-stroke">0.02</tspan>
+  </text>
+ </g>
+</svg>

--- a/public/examples/promark_mopa_60w_color_example_2.bvg
+++ b/public/examples/promark_mopa_60w_color_example_2.bvg
@@ -1,0 +1,787 @@
+<svg id="svgcontent" width="2200" height="2200" viewBox="0 0 2200 2200" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" data-top="-181" data-left="-601" data-zoom="0.342" data-workarea="fpm1" data-en_af="false" data-en_diode="false" data-rotary_mode="0" data-engrave_dpi="medium" style="will-change: scroll-position, contents, transform;">
+
+ <g data-dottingTime="100" data-pulseWidth="500" data-frequency="40" data-fillAngle="0" data-fillInterval="0.01" data-focusStep="-2" data-focus="-2" data-printingStrength="100" data-kRatio="100" data-yRatio="100" data-mRatio="100" data-cRatio="100" data-wRepeat="1" data-wMultipass="3" data-wInk="-12" data-wSpeed="100" data-halftone="1" data-uv="0" data-multipass="3" data-backlash="0" data-module="15" data-diode="0" data-zstep="0" data-height="-3" data-repeat="1" data-ink="3" data-minPower="0" data-strength="15" data-printingSpeed="60" data-speed="1000" data-color="#333333" class="layer">
+  <title>Layer 1</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.02" data-color="#00BCD4" class="layer">
+  <title>FI0.02-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F400" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1600" stroke="#00BCD4" height="30" width="30" y="721.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.02" data-color="#FFEB3B" class="layer">
+  <title>FI0.02-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F367" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1601" stroke="#FFEB3B" height="30" width="30" y="721.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.02" data-color="#E91E63" class="layer">
+  <title>FI0.02-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F334" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1602" stroke="#E91E63" height="30" width="30" y="721.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.02" data-color="#673AB7" class="layer">
+  <title>FI0.02-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F300" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1603" stroke="#673AB7" height="30" width="30" y="721.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.02" data-color="#03A9F4" class="layer">
+  <title>FI0.02-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F267" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1604" stroke="#03A9F4" height="30" width="30" y="721.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.02" data-color="#9C27B0" class="layer">
+  <title>FI0.02-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F234" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1605" stroke="#9C27B0" height="30" width="30" y="721.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.02" data-color="#607D8B" class="layer">
+  <title>FI0.02-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F200" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1606" stroke="#607D8B" height="30" width="30" y="721.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.02" data-color="#9E9E9E" class="layer">
+  <title>FI0.02-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F167" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1607" stroke="#9E9E9E" height="30" width="30" y="721.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.02" data-color="#333333" class="layer">
+  <title>FI0.02-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F134" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1608" stroke="#333333" height="30" width="30" y="721.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.02" data-color="#3F51B5" class="layer">
+  <title>FI0.02-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.02-F100" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1609" stroke="#3F51B5" height="30" width="30" y="721.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0179" data-color="#F44336" class="layer">
+  <title>FI0.0179-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F400" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1610" stroke="#F44336" height="30" width="30" y="681.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0179" data-color="#FFC107" class="layer">
+  <title>FI0.0179-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F367" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1611" stroke="#FFC107" height="30" width="30" y="681.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0179" data-color="#8BC34A" class="layer">
+  <title>FI0.0179-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F334" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1612" stroke="#8BC34A" height="30" width="30" y="681.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0179" data-color="#2196F3" class="layer">
+  <title>FI0.0179-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F300" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1613" stroke="#2196F3" height="30" width="30" y="681.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0179" data-color="#009688" class="layer">
+  <title>FI0.0179-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F267" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1614" stroke="#009688" height="30" width="30" y="681.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0179" data-color="#FF9800" class="layer">
+  <title>FI0.0179-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F234" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1615" stroke="#FF9800" height="30" width="30" y="681.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0179" data-color="#CDDC39" class="layer">
+  <title>FI0.0179-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F200" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1616" stroke="#CDDC39" height="30" width="30" y="681.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0179" data-color="#00BCD4" class="layer">
+  <title>FI0.0179-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F167" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1617" stroke="#00BCD4" height="30" width="30" y="681.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0179" data-color="#FFEB3B" class="layer">
+  <title>FI0.0179-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F134" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1618" stroke="#FFEB3B" height="30" width="30" y="681.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0179" data-color="#E91E63" class="layer">
+  <title>FI0.0179-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0179-F100" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1619" stroke="#E91E63" height="30" width="30" y="681.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0158" data-color="#673AB7" class="layer">
+  <title>FI0.0158-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F400" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1620" stroke="#673AB7" height="30" width="30" y="641.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0158" data-color="#03A9F4" class="layer">
+  <title>FI0.0158-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F367" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1621" stroke="#03A9F4" height="30" width="30" y="641.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0158" data-color="#9C27B0" class="layer">
+  <title>FI0.0158-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F334" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1622" stroke="#9C27B0" height="30" width="30" y="641.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0158" data-color="#607D8B" class="layer">
+  <title>FI0.0158-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F300" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1623" stroke="#607D8B" height="30" width="30" y="641.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0158" data-color="#9E9E9E" class="layer">
+  <title>FI0.0158-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F267" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1624" stroke="#9E9E9E" height="30" width="30" y="641.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0158" data-color="#333333" class="layer">
+  <title>FI0.0158-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F234" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1625" stroke="#333333" height="30" width="30" y="641.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0158" data-color="#3F51B5" class="layer">
+  <title>FI0.0158-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F200" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1626" stroke="#3F51B5" height="30" width="30" y="641.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0158" data-color="#F44336" class="layer">
+  <title>FI0.0158-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F167" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1627" stroke="#F44336" height="30" width="30" y="641.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0158" data-color="#FFC107" class="layer">
+  <title>FI0.0158-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F134" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1628" stroke="#FFC107" height="30" width="30" y="641.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0158" data-color="#8BC34A" class="layer">
+  <title>FI0.0158-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0158-F100" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1629" stroke="#8BC34A" height="30" width="30" y="641.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0137" data-color="#2196F3" class="layer">
+  <title>FI0.0137-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F400" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1630" stroke="#2196F3" height="30" width="30" y="601.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0137" data-color="#009688" class="layer">
+  <title>FI0.0137-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F367" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1631" stroke="#009688" height="30" width="30" y="601.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0137" data-color="#FF9800" class="layer">
+  <title>FI0.0137-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F334" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1632" stroke="#FF9800" height="30" width="30" y="601.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0137" data-color="#CDDC39" class="layer">
+  <title>FI0.0137-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F300" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1633" stroke="#CDDC39" height="30" width="30" y="601.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0137" data-color="#00BCD4" class="layer">
+  <title>FI0.0137-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F267" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1634" stroke="#00BCD4" height="30" width="30" y="601.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0137" data-color="#FFEB3B" class="layer">
+  <title>FI0.0137-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F234" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1635" stroke="#FFEB3B" height="30" width="30" y="601.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0137" data-color="#E91E63" class="layer">
+  <title>FI0.0137-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F200" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1636" stroke="#E91E63" height="30" width="30" y="601.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0137" data-color="#673AB7" class="layer">
+  <title>FI0.0137-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F167" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1637" stroke="#673AB7" height="30" width="30" y="601.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0137" data-color="#03A9F4" class="layer">
+  <title>FI0.0137-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F134" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1638" stroke="#03A9F4" height="30" width="30" y="601.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0137" data-color="#9C27B0" class="layer">
+  <title>FI0.0137-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0137-F100" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1639" stroke="#9C27B0" height="30" width="30" y="601.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0116" data-color="#607D8B" class="layer">
+  <title>FI0.0116-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F400" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1640" stroke="#607D8B" height="30" width="30" y="561.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0116" data-color="#9E9E9E" class="layer">
+  <title>FI0.0116-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F367" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1641" stroke="#9E9E9E" height="30" width="30" y="561.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0116" data-color="#333333" class="layer">
+  <title>FI0.0116-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F334" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1642" stroke="#333333" height="30" width="30" y="561.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0116" data-color="#3F51B5" class="layer">
+  <title>FI0.0116-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F300" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1643" stroke="#3F51B5" height="30" width="30" y="561.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0116" data-color="#F44336" class="layer">
+  <title>FI0.0116-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F267" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1644" stroke="#F44336" height="30" width="30" y="561.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0116" data-color="#FFC107" class="layer">
+  <title>FI0.0116-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F234" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1645" stroke="#FFC107" height="30" width="30" y="561.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0116" data-color="#8BC34A" class="layer">
+  <title>FI0.0116-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F200" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1646" stroke="#8BC34A" height="30" width="30" y="561.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0116" data-color="#2196F3" class="layer">
+  <title>FI0.0116-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F167" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1647" stroke="#2196F3" height="30" width="30" y="561.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0116" data-color="#009688" class="layer">
+  <title>FI0.0116-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F134" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1648" stroke="#009688" height="30" width="30" y="561.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0116" data-color="#FF9800" class="layer">
+  <title>FI0.0116-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0116-F100" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1649" stroke="#FF9800" height="30" width="30" y="561.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0094" data-color="#CDDC39" class="layer">
+  <title>FI0.0094-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F400" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1650" stroke="#CDDC39" height="30" width="30" y="521.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0094" data-color="#00BCD4" class="layer">
+  <title>FI0.0094-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F367" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1651" stroke="#00BCD4" height="30" width="30" y="521.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0094" data-color="#FFEB3B" class="layer">
+  <title>FI0.0094-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" data-original-layer="FI0.0094-F334" fill="#FFEB3B" id="svg_1652" stroke="#FFEB3B" height="30" width="30" y="521.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0094" data-color="#E91E63" class="layer">
+  <title>FI0.0094-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F300" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1653" stroke="#E91E63" height="30" width="30" y="521.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0094" data-color="#673AB7" class="layer">
+  <title>FI0.0094-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F267" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1654" stroke="#673AB7" height="30" width="30" y="521.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0094" data-color="#03A9F4" class="layer">
+  <title>FI0.0094-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F234" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1655" stroke="#03A9F4" height="30" width="30" y="521.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0094" data-color="#9C27B0" class="layer">
+  <title>FI0.0094-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F200" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1656" stroke="#9C27B0" height="30" width="30" y="521.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0094" data-color="#607D8B" class="layer">
+  <title>FI0.0094-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F167" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1657" stroke="#607D8B" height="30" width="30" y="521.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0094" data-color="#9E9E9E" class="layer">
+  <title>FI0.0094-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F134" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1658" stroke="#9E9E9E" height="30" width="30" y="521.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0094" data-color="#333333" class="layer">
+  <title>FI0.0094-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0094-F100" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1659" stroke="#333333" height="30" width="30" y="521.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0073" data-color="#3F51B5" class="layer">
+  <title>FI0.0073-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F400" fill="#3F51B5" id="svg_1660" stroke="#3F51B5" height="30" width="30" y="481.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0073" data-color="#F44336" class="layer">
+  <title>FI0.0073-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F367" fill="#F44336" id="svg_1661" stroke="#F44336" height="30" width="30" y="481.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0073" data-color="#FFC107" class="layer">
+  <title>FI0.0073-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F334" fill="#FFC107" id="svg_1662" stroke="#FFC107" height="30" width="30" y="481.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0073" data-color="#8BC34A" class="layer">
+  <title>FI0.0073-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F300" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1663" stroke="#8BC34A" height="30" width="30" y="481.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0073" data-color="#2196F3" class="layer">
+  <title>FI0.0073-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect vector-effect="non-scaling-stroke" data-original-layer="FI0.0073-F267" fill="#2196F3" id="svg_1664" stroke="#2196F3" height="30" width="30" y="481.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0073" data-color="#009688" class="layer">
+  <title>FI0.0073-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F234" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1665" stroke="#009688" height="30" width="30" y="481.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0073" data-color="#FF9800" class="layer">
+  <title>FI0.0073-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F200" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1666" stroke="#FF9800" height="30" width="30" y="481.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0073" data-color="#CDDC39" class="layer">
+  <title>FI0.0073-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F167" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1667" stroke="#CDDC39" height="30" width="30" y="481.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0073" data-color="#00BCD4" class="layer">
+  <title>FI0.0073-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F134" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1668" stroke="#00BCD4" height="30" width="30" y="481.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0073" data-color="#FFEB3B" class="layer">
+  <title>FI0.0073-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0073-F100" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1669" stroke="#FFEB3B" height="30" width="30" y="481.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0052" data-color="#E91E63" class="layer">
+  <title>FI0.0052-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F400" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1670" stroke="#E91E63" height="30" width="30" y="441.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0052" data-color="#673AB7" class="layer">
+  <title>FI0.0052-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F367" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1671" stroke="#673AB7" height="30" width="30" y="441.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0052" data-color="#03A9F4" class="layer">
+  <title>FI0.0052-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F334" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1672" stroke="#03A9F4" height="30" width="30" y="441.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0052" data-color="#9C27B0" class="layer">
+  <title>FI0.0052-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F300" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1673" stroke="#9C27B0" height="30" width="30" y="441.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0052" data-color="#607D8B" class="layer">
+  <title>FI0.0052-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F267" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1674" stroke="#607D8B" height="30" width="30" y="441.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0052" data-color="#9E9E9E" class="layer">
+  <title>FI0.0052-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F234" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1675" stroke="#9E9E9E" height="30" width="30" y="441.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0052" data-color="#333333" class="layer">
+  <title>FI0.0052-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F200" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1676" stroke="#333333" height="30" width="30" y="441.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0052" data-color="#3F51B5" class="layer">
+  <title>FI0.0052-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F167" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1677" stroke="#3F51B5" height="30" width="30" y="441.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0052" data-color="#F44336" class="layer">
+  <title>FI0.0052-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F134" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1678" stroke="#F44336" height="30" width="30" y="441.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0052" data-color="#FFC107" class="layer">
+  <title>FI0.0052-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0052-F100" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1679" stroke="#FFC107" height="30" width="30" y="441.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.0031" data-color="#8BC34A" class="layer">
+  <title>FI0.0031-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F400" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1680" stroke="#8BC34A" height="30" width="30" y="401.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.0031" data-color="#2196F3" class="layer">
+  <title>FI0.0031-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F367" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1681" stroke="#2196F3" height="30" width="30" y="401.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.0031" data-color="#009688" class="layer">
+  <title>FI0.0031-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F334" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1682" stroke="#009688" height="30" width="30" y="401.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.0031" data-color="#FF9800" class="layer">
+  <title>FI0.0031-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FF9800">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.596078431372549, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F300" vector-effect="non-scaling-stroke" fill="#FF9800" id="svg_1683" stroke="#FF9800" height="30" width="30" y="401.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.0031" data-color="#CDDC39" class="layer">
+  <title>FI0.0031-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#CDDC39">
+   <feColorMatrix values="1 0 0 0 0.803921568627451, 0 1 0 0 0.8627450980392157, 0 0 1 0 0.2235294117647059, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F267" vector-effect="non-scaling-stroke" fill="#CDDC39" id="svg_1684" stroke="#CDDC39" height="30" width="30" y="401.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.0031" data-color="#00BCD4" class="layer">
+  <title>FI0.0031-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#00BCD4">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.7372549019607844, 0 0 1 0 0.8313725490196079, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F234" vector-effect="non-scaling-stroke" fill="#00BCD4" id="svg_1685" stroke="#00BCD4" height="30" width="30" y="401.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.0031" data-color="#FFEB3B" class="layer">
+  <title>FI0.0031-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFEB3B">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.9215686274509803, 0 0 1 0 0.23137254901960785, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F200" vector-effect="non-scaling-stroke" fill="#FFEB3B" id="svg_1686" stroke="#FFEB3B" height="30" width="30" y="401.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.0031" data-color="#E91E63" class="layer">
+  <title>FI0.0031-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#E91E63">
+   <feColorMatrix values="1 0 0 0 0.9137254901960784, 0 1 0 0 0.11764705882352941, 0 0 1 0 0.38823529411764707, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F167" vector-effect="non-scaling-stroke" fill="#E91E63" id="svg_1687" stroke="#E91E63" height="30" width="30" y="401.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.0031" data-color="#673AB7" class="layer">
+  <title>FI0.0031-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#673AB7">
+   <feColorMatrix values="1 0 0 0 0.403921568627451, 0 1 0 0 0.22745098039215686, 0 0 1 0 0.7176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F134" vector-effect="non-scaling-stroke" fill="#673AB7" id="svg_1688" stroke="#673AB7" height="30" width="30" y="401.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.0031" data-color="#03A9F4" class="layer">
+  <title>FI0.0031-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#03A9F4">
+   <feColorMatrix values="1 0 0 0 0.011764705882352941, 0 1 0 0 0.6627450980392157, 0 0 1 0 0.9568627450980393, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.0031-F100" vector-effect="non-scaling-stroke" fill="#03A9F4" id="svg_1689" stroke="#03A9F4" height="30" width="30" y="401.34337" x="414.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="400" data-fillInterval="0.001" data-color="#9C27B0" class="layer">
+  <title>FI0.001-F400</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9C27B0">
+   <feColorMatrix values="1 0 0 0 0.611764705882353, 0 1 0 0 0.15294117647058825, 0 0 1 0 0.6901960784313725, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F400" vector-effect="non-scaling-stroke" fill="#9C27B0" id="svg_1690" stroke="#9C27B0" height="30" width="30" y="361.34337" x="774.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="367" data-fillInterval="0.001" data-color="#607D8B" class="layer">
+  <title>FI0.001-F367</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#607D8B">
+   <feColorMatrix values="1 0 0 0 0.3764705882352941, 0 1 0 0 0.49019607843137253, 0 0 1 0 0.5450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F367" vector-effect="non-scaling-stroke" fill="#607D8B" id="svg_1691" stroke="#607D8B" height="30" width="30" y="361.34337" x="734.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="334" data-fillInterval="0.001" data-color="#9E9E9E" class="layer">
+  <title>FI0.001-F334</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#9E9E9E">
+   <feColorMatrix values="1 0 0 0 0.6196078431372549, 0 1 0 0 0.6196078431372549, 0 0 1 0 0.6196078431372549, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F334" vector-effect="non-scaling-stroke" fill="#9E9E9E" id="svg_1692" stroke="#9E9E9E" height="30" width="30" y="361.34337" x="694.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="300" data-fillInterval="0.001" data-color="#333333" class="layer">
+  <title>FI0.001-F300</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#333333">
+   <feColorMatrix values="1 0 0 0 0.2, 0 1 0 0 0.2, 0 0 1 0 0.2, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F300" vector-effect="non-scaling-stroke" fill="#333333" id="svg_1693" stroke="#333333" height="30" width="30" y="361.34337" x="654.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="267" data-fillInterval="0.001" data-color="#3F51B5" class="layer">
+  <title>FI0.001-F267</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#3F51B5">
+   <feColorMatrix values="1 0 0 0 0.24705882352941178, 0 1 0 0 0.3176470588235294, 0 0 1 0 0.7098039215686275, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F267" vector-effect="non-scaling-stroke" fill="#3F51B5" id="svg_1694" stroke="#3F51B5" height="30" width="30" y="361.34337" x="614.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="234" data-fillInterval="0.001" data-color="#F44336" class="layer">
+  <title>FI0.001-F234</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#F44336">
+   <feColorMatrix values="1 0 0 0 0.9568627450980393, 0 1 0 0 0.2627450980392157, 0 0 1 0 0.21176470588235294, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F234" vector-effect="non-scaling-stroke" fill="#F44336" id="svg_1695" stroke="#F44336" height="30" width="30" y="361.34337" x="574.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="200" data-fillInterval="0.001" data-color="#FFC107" class="layer">
+  <title>FI0.001-F200</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#FFC107">
+   <feColorMatrix values="1 0 0 0 1, 0 1 0 0 0.7568627450980392, 0 0 1 0 0.027450980392156862, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F200" vector-effect="non-scaling-stroke" fill="#FFC107" id="svg_1696" stroke="#FFC107" height="30" width="30" y="361.34337" x="534.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="167" data-fillInterval="0.001" data-color="#8BC34A" class="layer">
+  <title>FI0.001-F167</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#8BC34A">
+   <feColorMatrix values="1 0 0 0 0.5450980392156862, 0 1 0 0 0.7647058823529411, 0 0 1 0 0.2901960784313726, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F167" vector-effect="non-scaling-stroke" fill="#8BC34A" id="svg_1697" stroke="#8BC34A" height="30" width="30" y="361.34337" x="494.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="134" data-fillInterval="0.001" data-color="#2196F3" class="layer">
+  <title>FI0.001-F134</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#2196F3">
+   <feColorMatrix values="1 0 0 0 0.12941176470588237, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.9529411764705882, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F134" vector-effect="non-scaling-stroke" fill="#2196F3" id="svg_1698" stroke="#2196F3" height="30" width="30" y="361.34337" x="454.15762"/>
+ </g>
+ <g data-pulseWidth="10" data-speed="1500" data-configName="0" data-strength="50" data-frequency="100" data-fillInterval="0.001" data-color="#009688" class="layer">
+  <title>FI0.001-F100</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#009688">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0.5882352941176471, 0 0 1 0 0.5333333333333333, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <rect data-original-layer="FI0.001-F100" vector-effect="non-scaling-stroke" fill="#009688" id="svg_1699" stroke="#009688" height="30" width="30" y="361.34337" x="414.15762"/>
+ </g>
+ <g data-color="#000" class="layer">
+  <title>Material Test - Frame</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#000">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+ </g>
+ <g data-speed="500" data-strength="50" data-color="#000" class="layer">
+  <title>Material Test - Info</title>
+  <filter color-interpolation-filters="sRGB" primitiveUnits="userSpaceOnUse" filterUnits="objectBoundingBox" id="filter#000">
+   <feColorMatrix values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0" type="matrix"/>
+  </filter>
+  <text data-original-layer="Material Test - Info" transform="matrix(0.3961449563503265,0,0,0.3953711092472076,419.55908469330205,154.5110842423718) " font-weight="400" font-style="normal" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="130" id="svg_1701" y="150" x="-6.55" stroke="#000" fill="#000">
+   <tspan y="150" x="-6.55" vector-effect="non-scaling-stroke">Frequency (kHz)</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" font-weight="400" font-style="normal" transform="rotate(-90 175.57295227050795,556.1008911132814) matrix(0.396420302783561,0,0,0.3960506809421672,938.3043945909967,725.0213256229869) " data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="130" id="svg_1702" y="-380.39098" x="-2428.55553" stroke="#000" fill="#000">
+   <tspan y="-380.39098" x="-2428.55553" vector-effect="non-scaling-stroke">Fill Interval (mm)</tspan>
+  </text>
+  <text transform="rotate(90 428.553955078125,294.5304565429688) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1703" y="311.34334" x="388.65765" stroke="#000" fill="#000">
+   <tspan y="311.34334" x="388.65765" vector-effect="non-scaling-stroke">100</tspan>
+  </text>
+  <text transform="rotate(90 468.55389404296875,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1704" y="311.34337" x="428.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="428.65762" vector-effect="non-scaling-stroke">134</tspan>
+  </text>
+  <text transform="rotate(90 508.55389404296875,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1705" y="311.34337" x="468.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="468.65762" vector-effect="non-scaling-stroke">167</tspan>
+  </text>
+  <text transform="rotate(90 548.5537719726564,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1706" y="311.3434" x="508.65746" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="508.65746" vector-effect="non-scaling-stroke">200</tspan>
+  </text>
+  <text transform="rotate(90 588.5539550781251,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1707" y="311.34337" x="548.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="548.65762" vector-effect="non-scaling-stroke">234</tspan>
+  </text>
+  <text transform="rotate(90 628.5538940429689,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1708" y="311.34337" x="588.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="588.65762" vector-effect="non-scaling-stroke">267</tspan>
+  </text>
+  <text transform="rotate(90 668.5539550781251,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1709" y="311.34337" x="628.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="628.65762" vector-effect="non-scaling-stroke">300</tspan>
+  </text>
+  <text transform="rotate(90 708.5539550781251,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1710" y="311.34337" x="668.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="668.65762" vector-effect="non-scaling-stroke">334</tspan>
+  </text>
+  <text transform="rotate(90 748.5538940429689,294.5305480957032) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1711" y="311.34343" x="708.65755" stroke="#000" fill="#000">
+   <tspan y="311.34343" x="708.65755" vector-effect="non-scaling-stroke">367</tspan>
+  </text>
+  <text transform="rotate(90 788.5540161132814,294.53048706054693) " data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1712" y="311.34337" x="748.65762" stroke="#000" fill="#000">
+   <tspan y="311.34337" x="748.65762" vector-effect="non-scaling-stroke">400</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1713" y="396.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="396.34337" x="234.15762" vector-effect="non-scaling-stroke">0.001</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1714" y="436.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="436.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0031</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1715" y="476.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="476.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0052</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1716" y="516.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="516.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0073</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1717" y="556.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="556.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0094</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1718" y="596.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="596.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0116</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1719" y="636.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="636.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0137</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1720" y="676.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="676.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0158</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1721" y="716.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="716.34337" x="234.15762" vector-effect="non-scaling-stroke">0.0179</tspan>
+  </text>
+  <text data-original-layer="Material Test - Info" data-font-family="Heiti TC" vector-effect="non-scaling-stroke" xml:space="preserve" data-ratiofixed="true" text-anchor="start" font-postscript="STHeitiTC-Light" font-family="&#x27;STHeitiTC-Light'" font-size="48" id="svg_1722" y="756.34337" x="234.15762" stroke="#000" fill="#000">
+   <tspan y="756.34337" x="234.15762" vector-effect="non-scaling-stroke">0.02</tspan>
+  </text>
+ </g>
+</svg>

--- a/src/node/menu/fileMenu.ts
+++ b/src/node/menu/fileMenu.ts
@@ -131,6 +131,37 @@ export function buildFileMenu(
             },
           ],
         },
+        {
+          id: 'PROMARK_COLOR_TEST',
+          label: r.promark_color_test,
+          submenu: [
+            {
+              id: 'IMPORT_EXAMPLE_PROMARK_MOPA_20W_COLOR',
+              label: r.import_promark_mopa_20w_color,
+              click: callback,
+            },
+            {
+              id: 'IMPORT_EXAMPLE_PROMARK_MOPA_60W_COLOR',
+              label: r.import_promark_mopa_60w_color,
+              click: callback,
+            },
+            {
+              id: 'IMPORT_EXAMPLE_PROMARK_MOPA_60W_COLOR_2',
+              label: `${r.import_promark_mopa_60w_color} - 2`,
+              click: callback,
+            },
+            {
+              id: 'IMPORT_EXAMPLE_PROMARK_MOPA_100W_COLOR',
+              label: r.import_promark_mopa_100w_color,
+              click: callback,
+            },
+            {
+              id: 'IMPORT_EXAMPLE_PROMARK_MOPA_100W_COLOR_2',
+              label: `${r.import_promark_mopa_100w_color} - 2`,
+              click: callback,
+            },
+          ],
+        },
         { id: 'IMPORT_ACRYLIC_FOCUS_PROBE', label: r.import_acrylic_focus_probe, click: callback },
         {
           id: 'IMPORT_BEAMBOX_2_FOCUS_PROBE',


### PR DESCRIPTION
##Overview

1. [feat(examples): add mopa color examples](https://github.com/flux3dp/beam-studio/commit/e011d7ae1836e329d4e9f87e6549830d9244f5e9)
