### PR TITLE
Fix coords with empty groups

### DIFF
--- a/apps/app/src/main.ts
+++ b/apps/app/src/main.ts
@@ -1,17 +1,16 @@
 import { app, session } from '@electron/remote';
-// This module setup global window variable, Should be put at top
 import { Titlebar, TitlebarColor } from 'custom-electron-titlebar';
+
+// This module setup global window variable when imported, Should be put at top
+import '@core/helpers/global-helper';
 
 import globalEvents from '@core/app/actions/global';
 import router from '@core/app/router';
 import fileExportHelper from '@core/helpers/file-export-helper';
-import globalHelper from '@core/helpers/global-helper';
 import communicator from '@core/implementations/communicator';
 
 import initBackendEvents from './init-backend-events';
 import './loader';
-
-globalHelper.setWindowMember();
 
 declare global {
   var requireNode: (_name: string) => any;

--- a/packages/core/src/web/app/components/dialogs/FramingModal/index.module.scss
+++ b/packages/core/src/web/app/components/dialogs/FramingModal/index.module.scss
@@ -82,6 +82,7 @@
   justify-content: center;
   width: 100%;
   height: auto;
+  padding: 4px 15px;
 }
 
 .icon-text-container {

--- a/packages/core/src/web/app/router.tsx
+++ b/packages/core/src/web/app/router.tsx
@@ -91,7 +91,7 @@ const App = (): React.JSX.Element => {
             token: { screenMD: 601, screenMDMin: 601, screenSMMax: 600 },
           }}
         >
-          <StyleProvider hashPriority="high">
+          <StyleProvider hashPriority="low">
             <Dialog />
             <AlertsAndProgress />
             {contextHolder}

--- a/packages/core/src/web/helpers/device/framing.ts
+++ b/packages/core/src/web/helpers/device/framing.ts
@@ -76,12 +76,18 @@ const getCoords = (mm?: boolean): Coordinates => {
 
     const bboxs = svgCanvas.getVisibleElementsAndBBoxes([layer]);
 
-    bboxs.forEach(({ bbox }) => {
-      const { x, y } = bbox;
-      const right = x + bbox.width;
-      const bottom = y + bbox.height;
+    bboxs.forEach(({ bbox, elem }) => {
+      const { height, width, x, y } = bbox;
+      const right = x + width;
+      const bottom = y + height;
 
-      if (right < 0 || bottom < 0 || x > workareaWidth || y > workareaHeight) {
+      if (
+        right < 0 ||
+        bottom < 0 ||
+        x > workareaWidth ||
+        y > workareaHeight ||
+        (width === 0 && height === 0 && elem.tagName === 'g')
+      ) {
         return;
       }
 


### PR DESCRIPTION
1. Skip empty groups if both width and height are zero.
2. Fix window.os when init
3. Fix antd styles priority
4. Fix button padding