### PR TITLE
Swiftray progress bar and cancellation

### DIFF
--- a/packages/core/src/web/app/actions/beambox/export-funcs-swiftray.ts
+++ b/packages/core/src/web/app/actions/beambox/export-funcs-swiftray.ts
@@ -134,7 +134,7 @@ const uploadToParser = async (uploadFile: IWrappedSwiftrayTaskFile): Promise<boo
   return !isCanceled && !errorMessage;
 };
 
-const getTaskCode = (codeType: 'fcode' | 'gcode', taskOptions) =>
+const getTaskCode = (codeType: 'fcode' | 'gcode' | 'preview', taskOptions) =>
   new Promise<{
     fileTimeCost: null | number;
     metadata: Record<string, string>;
@@ -317,7 +317,7 @@ const fetchTaskCodeSwiftray = async (
       (taskConfig as IFcodeConfig).mfg = false;
     }
 
-    const fcodeRes = await getTaskCode('fcode', taskConfig);
+    const fcodeRes = await getTaskCode('preview', taskConfig);
 
     fileTimeCost = fcodeRes.fileTimeCost;
   }

--- a/packages/core/src/web/app/actions/beambox/export-funcs-swiftray.ts
+++ b/packages/core/src/web/app/actions/beambox/export-funcs-swiftray.ts
@@ -311,6 +311,10 @@ const fetchTaskCodeSwiftray = async (
   const { metadata, taskCodeBlob } = getTaskCodeResult;
   let { fileTimeCost } = getTaskCodeResult;
 
+  if (isCanceled || taskCodeBlob == null) {
+    return {};
+  }
+
   if (isNonFGCode && !isPromark) {
     if (shouldUseFastGradient) {
       (taskConfig as IFcodeConfig).fg = true;

--- a/packages/core/src/web/app/actions/beambox/export-funcs-swiftray.ts
+++ b/packages/core/src/web/app/actions/beambox/export-funcs-swiftray.ts
@@ -167,7 +167,7 @@ const getTaskCode = (codeType: 'fcode' | 'gcode' | 'preview', taskOptions) =>
             taskCodeBlob: null,
           });
         },
-        onFinished: (taskBlob, fileName, timeCost, metadata) => {
+        onFinished: (taskBlob, timeCost, metadata) => {
           Progress.update('fetch-task', { message: lang.message.uploading_fcode, percentage: 100 });
           resolve({ fileTimeCost: timeCost, metadata, taskCodeBlob: taskBlob });
         },

--- a/packages/core/src/web/app/components/beambox/path-preview/PathPreview.tsx
+++ b/packages/core/src/web/app/components/beambox/path-preview/PathPreview.tsx
@@ -751,12 +751,14 @@ class PathPreview extends React.Component<Props, State> {
 
     const { fileTimeCost, gcodeBlob, useSwiftray } = await exportFuncs.getGcode();
 
-    if (!gcodeBlob) {
-      togglePathPreview();
-    }
-
     if (svgEditor) {
       svgEditor.style.display = 'none';
+    }
+
+    if (!gcodeBlob) {
+      togglePathPreview();
+
+      return;
     }
 
     progressCaller.openNonstopProgress({

--- a/packages/core/src/web/app/views/dialogs/NonStopProgress.tsx
+++ b/packages/core/src/web/app/views/dialogs/NonStopProgress.tsx
@@ -33,7 +33,7 @@ const NonStopProgress = ({ data }: { data: IProgressDialog }): React.JSX.Element
       okButtonProps={{ style: { display: 'none' } }}
       onCancel={() => {
         popById(id);
-        onCancel();
+        onCancel?.();
       }}
       open
       style={{

--- a/packages/core/src/web/app/views/dialogs/Progress.module.scss
+++ b/packages/core/src/web/app/views/dialogs/Progress.module.scss
@@ -1,0 +1,5 @@
+.progress {
+  :global(.ant-progress-text) {
+    min-width: 46px;
+  }
+}

--- a/packages/core/src/web/app/views/dialogs/Progress.tsx
+++ b/packages/core/src/web/app/views/dialogs/Progress.tsx
@@ -7,6 +7,8 @@ import { useIsMobile } from '@core/helpers/system-helper';
 import useI18n from '@core/helpers/useI18n';
 import type { IProgressDialog } from '@core/interfaces/IProgress';
 
+import styles from './Progress.module.scss';
+
 const Progress = ({ data }: { data: IProgressDialog }): React.JSX.Element => {
   const lang = useI18n();
   const isMobile = useIsMobile();
@@ -38,7 +40,7 @@ const Progress = ({ data }: { data: IProgressDialog }): React.JSX.Element => {
       okButtonProps={{ style: { display: 'none' } }}
       onCancel={() => {
         popById(id);
-        onCancel();
+        onCancel?.();
       }}
       open
       style={{
@@ -49,6 +51,7 @@ const Progress = ({ data }: { data: IProgressDialog }): React.JSX.Element => {
     >
       {renderMessage()}
       <AntdProgress
+        className={styles.progress}
         percent={Number(Number(percentage).toFixed(2))}
         status="active"
         strokeColor={{ '0%': '#108ee9', '100%': '#87d068' }}

--- a/packages/core/src/web/app/views/dialogs/__snapshots__/Progress.spec.tsx.snap
+++ b/packages/core/src/web/app/views/dialogs/__snapshots__/Progress.spec.tsx.snap
@@ -50,7 +50,7 @@ exports[`test Progress should render correctly 1`] = `
                   aria-valuemax="100"
                   aria-valuemin="0"
                   aria-valuenow="0"
-                  class="ant-progress ant-progress-status-active ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-dev-only-do-not-override-hash"
+                  class="ant-progress ant-progress-status-active ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default progress css-dev-only-do-not-override-hash"
                   role="progressbar"
                 >
                   <div

--- a/packages/core/src/web/helpers/api/swiftray-client.ts
+++ b/packages/core/src/web/helpers/api/swiftray-client.ts
@@ -216,8 +216,6 @@ class SwiftrayClient extends EventEmitter {
       };
 
       handlers?.forEach(({ handler, type }) => {
-        if (!handler) return;
-
         const listener = (data: any) => {
           if (data.id === id) {
             handler(data.result);

--- a/packages/core/src/web/helpers/api/swiftray-client.ts
+++ b/packages/core/src/web/helpers/api/swiftray-client.ts
@@ -178,8 +178,15 @@ class SwiftrayClient extends EventEmitter {
     this.emit(data.type, data);
   }
 
-  public async action<T>(path: string, action: string, params?: any): Promise<T> {
-    return new Promise((resolve) => {
+  public async action<T>(
+    path: string,
+    action: string,
+    params?: any,
+    handlers?: Array<{ handler: (data: any) => void; type: string }>,
+  ): Promise<T> {
+    const eventListeners: Array<{ listener: (data: any) => void; type: string }> = [];
+
+    const res: T = await new Promise((resolve) => {
       const id = Math.random().toString(36).substr(2, 9);
       const payload = { action, id, params };
 
@@ -191,7 +198,14 @@ class SwiftrayClient extends EventEmitter {
         });
       }
 
-      this.socket.send(JSON.stringify({ data: payload, path, type: 'action' }));
+      const dataString = JSON.stringify({ data: payload, path, type: 'action' });
+
+      if (dataString.length < 4096) {
+        this.socket.send(dataString);
+      } else {
+        // Change to binary string to avoid non-utf8 characters due to frame size limit
+        this.socket.send(Buffer.from(dataString));
+      }
 
       const callback = (data) => {
         if (data.id === id) {
@@ -201,8 +215,26 @@ class SwiftrayClient extends EventEmitter {
         }
       };
 
+      handlers?.forEach(({ handler, type }) => {
+        if (!handler) return;
+
+        const listener = (data: any) => {
+          if (data.id === id) {
+            handler(data.result);
+          }
+        };
+
+        eventListeners.push({ listener, type });
+        this.addListener(type, listener);
+      });
       this.addListener('callback', callback);
     });
+
+    eventListeners.forEach(({ listener, type }) => {
+      this.removeListener(type, listener);
+    });
+
+    return res;
   }
 
   // Parser API
@@ -231,6 +263,10 @@ class SwiftrayClient extends EventEmitter {
       rotaryMode: loadOptions.rotaryMode,
     });
 
+    if (!uploadRes.success) {
+      eventListeners.onError(uploadRes.error?.message ?? 'Unknown error');
+    }
+
     return uploadRes;
   }
 
@@ -238,8 +274,8 @@ class SwiftrayClient extends EventEmitter {
     type: 'fcode' | 'gcode' | 'preview',
     eventListeners: {
       onError: (message: string) => void;
-      onFinished: (taskBlob: Blob, fileName: string, timeCost: number, metadata: Record<string, string>) => void;
-      onProgressing: (progress) => void;
+      onFinished: (taskBlob: Blob, timeCost: number, metadata: Record<string, string>) => void;
+      onProgressing: (progress: { message: string; percentage: number }) => void;
     },
     convertOptions: {
       enableAutoFocus?: boolean;
@@ -257,6 +293,8 @@ class SwiftrayClient extends EventEmitter {
     success: boolean;
   }> {
     const workarea = getWorkarea(convertOptions.model);
+
+    let fullCode = '';
     const convertResult = await this.action<{
       error?: ErrorObject;
       estimatedTime?: number;
@@ -266,19 +304,42 @@ class SwiftrayClient extends EventEmitter {
       metadata?: Record<string, string>;
       success: boolean;
       timeCost?: number;
-    }>('/parser', 'convert', {
-      type,
-      workarea: {
-        height: workarea.displayHeight || workarea.height,
-        width: workarea.width,
+    }>(
+      '/parser',
+      'convert',
+      {
+        type,
+        workarea: {
+          height: workarea.displayHeight || workarea.height,
+          width: workarea.width,
+        },
+        ...convertOptions,
       },
-      ...convertOptions,
-    });
-    const taskBlob = new Blob([type === 'fcode' ? Buffer.from(convertResult.fcode, 'base64') : convertResult.gcode], {
-      type: 'text/plain',
-    });
+      [
+        { handler: eventListeners.onProgressing, type: 'progress' },
+        {
+          handler: (data: { chunk: string }) => {
+            fullCode += data.chunk;
+          },
+          type: 'chunk',
+        },
+      ],
+    );
 
-    eventListeners.onFinished(taskBlob, convertResult.fileName, convertResult.timeCost, convertResult.metadata);
+    if (convertResult.success) {
+      const taskBlob = new Blob(
+        [
+          type === 'fcode'
+            ? Buffer.from(fullCode.length ? fullCode : convertResult.fcode!, 'base64')
+            : convertResult.gcode!,
+        ],
+        { type: 'text/plain' },
+      );
+
+      eventListeners.onFinished(taskBlob, convertResult.timeCost ?? 0, convertResult.metadata ?? {});
+    } else {
+      eventListeners.onError(convertResult.error?.message ?? 'Unknown error');
+    }
 
     return {
       error: convertResult.error,

--- a/packages/core/src/web/interfaces/ITaskConfig.ts
+++ b/packages/core/src/web/interfaces/ITaskConfig.ts
@@ -2,7 +2,7 @@ import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import type { BBox } from '@core/interfaces/ICurveEngraving';
 
 export interface IBaseConfig {
-  codeType?: 'fcode' | 'gcode';
+  codeType?: 'fcode' | 'gcode' | 'preview';
   enableAutoFocus?: boolean;
   enableDiode?: boolean;
   isPromark?: boolean;


### PR DESCRIPTION
Handle onProgress listener
Update onError with cancel and Swiftray worker busy

Convert long messenge to binary data to fix QT web socket error: Invalid UTF-8 code encountered (Occasionally)
Split long fcode string to small chunks to fix missing return (Occasionally)

Use type `preview` to get metadata and timeCost without fcode data
Skip parsing gcode and return to canvas directly if gcode is empty
Set min-width to progress label so that width of progress bar is more stable