### PR TITLE
feat(core): add hexa rf document settings

### DIFF
--- a/packages/core/src/__mocks__/@core/helpers/checkFeature.ts
+++ b/packages/core/src/__mocks__/@core/helpers/checkFeature.ts
@@ -1,4 +1,3 @@
 export const checkFbb2AutoFeeder = (): boolean => true;
 export const checkFpm1 = (): boolean => true;
-export const checkChuckRotary = (): boolean => true;
 export const checkHxRf = (): boolean => true;

--- a/packages/core/src/__mocks__/@core/helpers/checkFeature.ts
+++ b/packages/core/src/__mocks__/@core/helpers/checkFeature.ts
@@ -1,2 +1,4 @@
 export const checkFbb2AutoFeeder = (): boolean => true;
 export const checkFpm1 = (): boolean => true;
+export const checkChuckRotary = (): boolean => true;
+export const checkHxRf = (): boolean => true;

--- a/packages/core/src/web/app/actions/beambox/constant.ts
+++ b/packages/core/src/web/app/actions/beambox/constant.ts
@@ -1,6 +1,6 @@
 const removeReadonly = <T extends string>(arr: ReadonlyArray<T[number]> | T[]) => arr as string[];
 
-export const supportUsbModelsArray = ['ado1', 'fhexa1', 'fpm1', 'fbb2'] as const;
+export const supportUsbModelsArray = ['ado1', 'fhexa1', 'fhx2rf3', 'fhx2rf6', 'fpm1', 'fbb2'] as const;
 export type SupportUsbModels = (typeof supportUsbModelsArray)[number];
 export const supportUsbModelsStrict = new Set(supportUsbModelsArray);
 export const supportUsbModels = new Set(removeReadonly(supportUsbModelsArray));
@@ -9,6 +9,11 @@ export const bb2ModelsArray = ['fbb2'] as const;
 export type Bb2Models = (typeof bb2ModelsArray)[number];
 export const bb2ModelsStrict = new Set(bb2ModelsArray);
 export const bb2Models = new Set(removeReadonly(bb2ModelsArray));
+
+export const hexaRfModelsArray = ['fhx2rf3', 'fhx2rf6'] as const;
+export type HexaRfModels = (typeof hexaRfModelsArray)[number];
+export const hexaRfModelsStrict = new Set(hexaRfModelsArray);
+export const hexaRfModels = new Set(removeReadonly(hexaRfModelsArray));
 
 export const adorModels = new Set(['ado1', 'fad1']);
 export const promarkModels = new Set(['fpm1']);
@@ -28,6 +33,8 @@ export default {
     fbb2: ['fbb2'],
     fbm1: ['fbm1'],
     fhexa1: ['fhexa1', 'fbb1p', 'fbb1b', 'fbm1'],
+    fhx2rf3: ['fhx2rf3', 'fhx2rf6', 'fhexa1', 'fbb1p', 'fbb1b', 'fbm1'],
+    fhx2rf6: ['fhx2rf3', 'fhx2rf6', 'fhexa1', 'fbb1p', 'fbb1b', 'fbm1'],
     flv1: ['flv1'],
     fpm1: ['fpm1'],
     'laser-b1': ['fhexa1', 'fbb1p', 'fbb1b', 'fbm1'],
@@ -74,5 +81,5 @@ export default {
   },
   dpmm: 10,
   fcodeV2Models: new Set(['ado1', 'fbb2']),
-  highPowerModels: ['fhexa1', 'ado1', 'flv1', 'fpm1'],
+  highPowerModels: ['fhx2rf3', 'fhx2rf6', 'fhexa1', 'ado1', 'flv1', 'fpm1'],
 };

--- a/packages/core/src/web/app/components/dialogs/DocumentSettings.tsx
+++ b/packages/core/src/web/app/components/dialogs/DocumentSettings.tsx
@@ -20,7 +20,7 @@ import { getWorkarea } from '@core/app/constants/workarea-constants';
 import changeWorkarea from '@core/app/svgedit/operations/changeWorkarea';
 import Select from '@core/app/widgets/AntdSelect';
 import UnitInput from '@core/app/widgets/UnitInput';
-import { checkFpm1 } from '@core/helpers/checkFeature';
+import { checkFpm1, checkHxRf } from '@core/helpers/checkFeature';
 import { getPromarkInfo, setPromarkInfo } from '@core/helpers/device/promark/promark-info';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import isDev from '@core/helpers/is-dev';
@@ -37,7 +37,7 @@ const workareaOptions = [
   { label: 'Beambox Pro', value: 'fbb1p' },
   { label: 'HEXA', value: 'fhexa1' },
   // use HEXA RF 3 as default, due to there is no difference between 3 and 6
-  { label: 'HEXA RF', value: 'fhx2rf3' },
+  checkHxRf() && { label: 'HEXA RF', value: 'fhx2rf3' },
   { label: 'Ador', value: 'ado1' },
   checkFpm1() && { label: 'Promark', value: 'fpm1' },
   { label: 'Beambox II', value: 'fbb2' },

--- a/packages/core/src/web/app/components/dialogs/DocumentSettings.tsx
+++ b/packages/core/src/web/app/components/dialogs/DocumentSettings.tsx
@@ -36,6 +36,8 @@ const workareaOptions = [
   { label: 'Beambox', value: 'fbb1b' },
   { label: 'Beambox Pro', value: 'fbb1p' },
   { label: 'HEXA', value: 'fhexa1' },
+  // use HEXA RF 3 as default, due to there is no difference between 3 and 6
+  { label: 'HEXA RF', value: 'fhx2rf3' },
   { label: 'Ador', value: 'ado1' },
   checkFpm1() && { label: 'Promark', value: 'fpm1' },
   { label: 'Beambox II', value: 'fbb2' },

--- a/packages/core/src/web/app/components/dialogs/__snapshots__/DocumentSettings.spec.tsx.snap
+++ b/packages/core/src/web/app/components/dialogs/__snapshots__/DocumentSettings.spec.tsx.snap
@@ -1818,10 +1818,12 @@ exports[`test DocumentSettings should render correctly 3`] = `
             class="rc-virtual-list-holder"
             style="max-height: 256px; overflow-y: hidden;"
           >
-            <div>
+            <div
+              style="height: 288px; position: relative; overflow: hidden;"
+            >
               <div
                 class="rc-virtual-list-holder-inner"
-                style="display: flex; flex-direction: column;"
+                style="display: flex; flex-direction: column; transform: translateY(0px); margin-left: 0px; position: absolute; left: 0px; right: 0px; top: 0px;"
               >
                 <div
                   aria-selected="true"
@@ -1883,6 +1885,23 @@ exports[`test DocumentSettings should render correctly 3`] = `
                     class="ant-select-item-option-content"
                   >
                     HEXA
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="HEXA RF"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    HEXA RF
                   </div>
                   <span
                     aria-hidden="true"
@@ -1961,6 +1980,15 @@ exports[`test DocumentSettings should render correctly 3`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            class="rc-virtual-list-scrollbar rc-virtual-list-scrollbar-vertical rc-virtual-list-scrollbar-visible"
+            style="position: absolute; width: 8px; top: 0px; bottom: 0px; right: 0px;"
+          >
+            <div
+              class="rc-virtual-list-scrollbar-thumb"
+              style="position: absolute; background: rgba(0, 0, 0, 0.5); border-radius: 99px; cursor: pointer; user-select: none; width: 100%; height: 227px; top: 0px;"
+            />
           </div>
         </div>
       </div>
@@ -2526,10 +2554,12 @@ exports[`test DocumentSettings should render correctly for ador 1`] = `
             class="rc-virtual-list-holder"
             style="max-height: 256px; overflow-y: hidden;"
           >
-            <div>
+            <div
+              style="height: 288px; position: relative; overflow: hidden;"
+            >
               <div
                 class="rc-virtual-list-holder-inner"
-                style="display: flex; flex-direction: column;"
+                style="display: flex; flex-direction: column; transform: translateY(0px); margin-left: 0px; position: absolute; left: 0px; right: 0px; top: 0px;"
               >
                 <div
                   aria-selected="false"
@@ -2591,6 +2621,23 @@ exports[`test DocumentSettings should render correctly for ador 1`] = `
                     class="ant-select-item-option-content"
                   >
                     HEXA
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="HEXA RF"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    HEXA RF
                   </div>
                   <span
                     aria-hidden="true"
@@ -2669,6 +2716,15 @@ exports[`test DocumentSettings should render correctly for ador 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            class="rc-virtual-list-scrollbar rc-virtual-list-scrollbar-vertical rc-virtual-list-scrollbar-visible"
+            style="position: absolute; width: 8px; top: 0px; bottom: 0px; right: 0px;"
+          >
+            <div
+              class="rc-virtual-list-scrollbar-thumb"
+              style="position: absolute; background: rgba(0, 0, 0, 0.5); border-radius: 99px; cursor: pointer; user-select: none; width: 100%; height: 227px; top: 0px;"
+            />
           </div>
         </div>
       </div>
@@ -3192,10 +3248,12 @@ exports[`test DocumentSettings should render correctly for ador 2`] = `
             class="rc-virtual-list-holder"
             style="max-height: 256px; overflow-y: hidden;"
           >
-            <div>
+            <div
+              style="height: 288px; position: relative; overflow: hidden;"
+            >
               <div
                 class="rc-virtual-list-holder-inner"
-                style="display: flex; flex-direction: column;"
+                style="display: flex; flex-direction: column; transform: translateY(0px); margin-left: 0px; position: absolute; left: 0px; right: 0px; top: 0px;"
               >
                 <div
                   aria-selected="false"
@@ -3257,6 +3315,23 @@ exports[`test DocumentSettings should render correctly for ador 2`] = `
                     class="ant-select-item-option-content"
                   >
                     HEXA
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="HEXA RF"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    HEXA RF
                   </div>
                   <span
                     aria-hidden="true"
@@ -3335,6 +3410,15 @@ exports[`test DocumentSettings should render correctly for ador 2`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            class="rc-virtual-list-scrollbar rc-virtual-list-scrollbar-vertical rc-virtual-list-scrollbar-visible"
+            style="position: absolute; width: 8px; top: 0px; bottom: 0px; right: 0px;"
+          >
+            <div
+              class="rc-virtual-list-scrollbar-thumb"
+              style="position: absolute; background: rgba(0, 0, 0, 0.5); border-radius: 99px; cursor: pointer; user-select: none; width: 100%; height: 227px; top: 0px;"
+            />
           </div>
         </div>
       </div>
@@ -3927,10 +4011,12 @@ exports[`test DocumentSettings should render correctly for promark 1`] = `
             class="rc-virtual-list-holder"
             style="max-height: 256px; overflow-y: hidden;"
           >
-            <div>
+            <div
+              style="height: 288px; position: relative; overflow: hidden;"
+            >
               <div
                 class="rc-virtual-list-holder-inner"
-                style="display: flex; flex-direction: column;"
+                style="display: flex; flex-direction: column; transform: translateY(0px); margin-left: 0px; position: absolute; left: 0px; right: 0px; top: 0px;"
               >
                 <div
                   aria-selected="false"
@@ -3992,6 +4078,23 @@ exports[`test DocumentSettings should render correctly for promark 1`] = `
                     class="ant-select-item-option-content"
                   >
                     HEXA
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="HEXA RF"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    HEXA RF
                   </div>
                   <span
                     aria-hidden="true"
@@ -4070,6 +4173,15 @@ exports[`test DocumentSettings should render correctly for promark 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            class="rc-virtual-list-scrollbar rc-virtual-list-scrollbar-vertical rc-virtual-list-scrollbar-visible"
+            style="position: absolute; width: 8px; top: 0px; bottom: 0px; right: 0px;"
+          >
+            <div
+              class="rc-virtual-list-scrollbar-thumb"
+              style="position: absolute; background: rgba(0, 0, 0, 0.5); border-radius: 99px; cursor: pointer; user-select: none; width: 100%; height: 227px; top: 0px;"
+            />
           </div>
         </div>
       </div>

--- a/packages/core/src/web/app/components/settings/Editor.tsx
+++ b/packages/core/src/web/app/components/settings/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 import FontFuncs from '@core/app/actions/beambox/font-funcs';
 import Controls from '@core/app/components/settings/Control';
@@ -8,7 +8,7 @@ import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
 import UnitInput from '@core/app/widgets/Unit-Input-v2';
 import { hasSwiftray } from '@core/helpers/api/swiftray-client';
-import { checkFpm1 } from '@core/helpers/checkFeature';
+import { checkFpm1, checkHxRf } from '@core/helpers/checkFeature';
 import isDev from '@core/helpers/is-dev';
 import useI18n from '@core/helpers/useI18n';
 import storage from '@core/implementations/storage';
@@ -92,8 +92,6 @@ function Editor({
     });
   };
 
-  const isDevMode = useMemo(() => isDev(), []);
-
   const modelOptions = [
     {
       label: 'beamo',
@@ -115,7 +113,7 @@ function Editor({
       selected: selectedModel === 'fhexa1',
       value: 'fhexa1',
     },
-    {
+    checkHxRf() && {
       label: 'HEXA RF',
       selectedModel: ['fhx2rf3', 'fhx2rf6'].includes(selectedModel),
       // send to rf3 for now since they don't have different workarea at the moment
@@ -131,7 +129,7 @@ function Editor({
       selected: selectedModel === 'fpm1',
       value: 'fpm1',
     },
-    isDevMode && {
+    isDev() && {
       label: 'Lazervida',
       selected: selectedModel === 'flv1',
       value: 'flv1',
@@ -286,7 +284,7 @@ function Editor({
           url={lang.settings.help_center_urls.calculation_optimization}
         />
       )}
-      {isDevMode && (
+      {isDev() && (
         <SelectControl
           id="set-enable-custom-backlash"
           label={lang.settings.enable_custom_backlash}

--- a/packages/core/src/web/app/components/settings/Editor.tsx
+++ b/packages/core/src/web/app/components/settings/Editor.tsx
@@ -116,6 +116,12 @@ function Editor({
       value: 'fhexa1',
     },
     {
+      label: 'HEXA RF',
+      selectedModel: ['fhx2rf3', 'fhx2rf6'].includes(selectedModel),
+      // send to rf3 for now since they don't have different workarea at the moment
+      value: 'fhx2rf3',
+    },
+    {
       label: 'Ador',
       selected: selectedModel === 'ado1',
       value: 'ado1',

--- a/packages/core/src/web/app/components/settings/Engraving.tsx
+++ b/packages/core/src/web/app/components/settings/Engraving.tsx
@@ -47,7 +47,7 @@ function Engraving({ getBeamboxPreferenceEditingValue, updateBeamboxPreferenceCh
               defaultValue={getBeamboxPreferenceEditingValue('padding_accel') || 5000}
               getValue={(val) => updateBeamboxPreferenceChange('padding_accel', val)}
               id="hardware-acceleration"
-              max={12000}
+              max={40000}
               min={1}
               unit="mm/s^2"
             />

--- a/packages/core/src/web/app/components/settings/__snapshots__/Editor.spec.tsx.snap
+++ b/packages/core/src/web/app/components/settings/__snapshots__/Editor.spec.tsx.snap
@@ -50,7 +50,7 @@ exports[`settings/Editor initially no warning 1`] = `
     Default Document Setting
     url:
     options:
-    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
+    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"HEXA RF","selectedModel":false,"value":"fhx2rf3"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
     <input
       class="select-control"
     />
@@ -277,7 +277,7 @@ exports[`settings/Editor initially no warning 2`] = `
     Default Document Setting
     url:
     options:
-    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
+    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"HEXA RF","selectedModel":false,"value":"fhx2rf3"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
     <input
       class="select-control"
     />
@@ -504,7 +504,7 @@ exports[`settings/Editor initially no warning 3`] = `
     Default Document Setting
     url:
     options:
-    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
+    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"HEXA RF","selectedModel":false,"value":"fhx2rf3"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
     <input
       class="select-control"
     />
@@ -731,7 +731,7 @@ exports[`settings/Editor initially no warning 4`] = `
     Default Document Setting
     url:
     options:
-    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
+    [{"label":"beamo","selected":false,"value":"fbm1"},{"label":"Beambox","selected":true,"value":"fbb1b"},{"label":"Beambox Pro","selected":false,"value":"fbb1p"},{"label":"HEXA","selected":false,"value":"fhexa1"},{"label":"HEXA RF","selectedModel":false,"value":"fhx2rf3"},{"label":"Ador","selected":false,"value":"ado1"},{"label":"Promark","selected":false,"value":"fpm1"},{"label":"Lazervida","selected":false,"value":"flv1"},{"label":"Beambox II","selected":false,"value":"fbb2"}]
     <input
       class="select-control"
     />

--- a/packages/core/src/web/app/constants/add-on.ts
+++ b/packages/core/src/web/app/constants/add-on.ts
@@ -30,6 +30,17 @@ export interface SupportInfo {
   };
 }
 
+const hexaSupportInfo: SupportInfo = {
+  jobOrigin: true,
+  lowerFocus: true,
+  rotary: {
+    chuck: true,
+    extendWorkarea: false,
+    mirror: false,
+    roller: true,
+  },
+};
+
 const supportList: Record<WorkAreaModel, SupportInfo> = {
   ado1: {
     framingLowLaser: true,
@@ -92,16 +103,9 @@ const supportList: Record<WorkAreaModel, SupportInfo> = {
       roller: true,
     },
   },
-  fhexa1: {
-    jobOrigin: true,
-    lowerFocus: true,
-    rotary: {
-      chuck: true,
-      extendWorkarea: false,
-      mirror: false,
-      roller: true,
-    },
-  },
+  fhexa1: hexaSupportInfo,
+  fhx2rf3: hexaSupportInfo,
+  fhx2rf6: hexaSupportInfo,
   flv1: {
     jobOrigin: true,
     rotary: {

--- a/packages/core/src/web/app/constants/workarea-constants.ts
+++ b/packages/core/src/web/app/constants/workarea-constants.ts
@@ -8,10 +8,24 @@ export type WorkAreaLabel =
   | 'Beambox Pro'
   | 'beamo'
   | 'HEXA'
+  | 'HEXA RF'
   | 'Lazervida'
   | 'Promark';
-export type WorkAreaModel = 'ado1' | 'fbb1b' | 'fbb1p' | 'fbb2' | 'fbm1' | 'fhexa1' | 'flv1' | 'fpm1';
-export const allWorkareas = new Set(['fbm1', 'fbb1b', 'fbb1p', 'fhexa1', 'ado1', 'fpm1', 'flv1', 'fbb2']);
+
+export const workArea = [
+  'fbm1',
+  'fbb1b',
+  'fbb1p',
+  'fhexa1',
+  'fhx2rf3',
+  'fhx2rf6',
+  'ado1',
+  'fpm1',
+  'flv1',
+  'fbb2',
+] as const;
+export type WorkAreaModel = (typeof workArea)[number];
+export const allWorkareas = new Set(workArea);
 
 const { dpmm } = constant;
 
@@ -37,7 +51,21 @@ export interface WorkArea {
   width: number; // mm
 }
 
-const workareaConstants: { [key in WorkAreaModel]: WorkArea } = {
+const hexaRfWorkAreaInfo: WorkArea = {
+  autoFocusOffset: [31.13, 1.2, 6.5],
+  height: 410,
+  label: 'HEXA RF',
+  maxSpeed: 2000,
+  minPower: 10,
+  minSpeed: 0.5,
+  minSpeedWarning: 3,
+  pxHeight: 410 * dpmm,
+  pxWidth: 740 * dpmm,
+  vectorSpeedLimit: 20,
+  width: 740,
+};
+
+const workareaConstants: Record<WorkAreaModel, WorkArea> = {
   ado1: {
     autoFocusOffset: [20.9, -40.38, 7.5],
     cameraCenter: [215, 150],
@@ -118,6 +146,8 @@ const workareaConstants: { [key in WorkAreaModel]: WorkArea } = {
     vectorSpeedLimit: 20,
     width: 740,
   },
+  fhx2rf3: hexaRfWorkAreaInfo,
+  fhx2rf6: hexaRfWorkAreaInfo,
   flv1: {
     height: 400,
     label: 'Lazervida',

--- a/packages/core/src/web/helpers/checkFeature.ts
+++ b/packages/core/src/web/helpers/checkFeature.ts
@@ -4,3 +4,5 @@ import localeHelper from './locale-helper';
 
 export const checkFbb2AutoFeeder = (): boolean => isDev();
 export const checkFpm1 = (): boolean => (localeHelper.isTwOrHk || isDev()) && !isWeb();
+export const checkChuckRotary = (): boolean => localeHelper.isTwOrHk || isDev();
+export const checkHxRf = (): boolean => isDev();

--- a/packages/core/src/web/helpers/checkFeature.ts
+++ b/packages/core/src/web/helpers/checkFeature.ts
@@ -4,5 +4,4 @@ import localeHelper from './locale-helper';
 
 export const checkFbb2AutoFeeder = (): boolean => isDev();
 export const checkFpm1 = (): boolean => (localeHelper.isTwOrHk || isDev()) && !isWeb();
-export const checkChuckRotary = (): boolean => localeHelper.isTwOrHk || isDev();
 export const checkHxRf = (): boolean => isDev();


### PR DESCRIPTION
## Overview 

1.[feat(core): add hexa rf document settings](https://github.com/flux3dp/beam-studio/commit/a90cb62e9be8bda86d9491bd1d8585435978cbc3) [[clickup]](https://app.clickup.com/t/86erf9q0d)
2.[feat(check): add check-hx-rf](https://github.com/flux3dp/beam-studio/commit/1d595ac866416d689095d694c1c5797e0f095a7c)