### PR TITLE
Fix handleFile failed to recognize dxf in some cases

### DIFF
--- a/packages/core/src/web/app/actions/beambox/svg-editor.ts
+++ b/packages/core/src/web/app/actions/beambox/svg-editor.ts
@@ -1899,6 +1899,10 @@ const svgEditor = (window['svgEditor'] = (function () {
             return 'bvg';
           }
 
+          if (file.name.toLowerCase().includes('.dxf')) {
+            return 'dxf';
+          }
+
           if (file.type.toLowerCase().includes('image')) {
             if (file.type.toLowerCase().includes('svg')) {
               return 'svg';
@@ -1907,10 +1911,6 @@ const svgEditor = (window['svgEditor'] = (function () {
             } else {
               return 'bitmap';
             }
-          }
-
-          if (file.name.toLowerCase().includes('.dxf')) {
-            return 'dxf';
           }
 
           if (file.name.toLowerCase().includes('.json')) {

--- a/packages/core/src/web/app/actions/beambox/svg-editor.ts
+++ b/packages/core/src/web/app/actions/beambox/svg-editor.ts
@@ -1899,7 +1899,7 @@ const svgEditor = (window['svgEditor'] = (function () {
             return 'bvg';
           }
 
-          if (file.name.toLowerCase().includes('.dxf')) {
+          if (file.name.toLowerCase().endsWith('.dxf')) {
             return 'dxf';
           }
 
@@ -1913,11 +1913,11 @@ const svgEditor = (window['svgEditor'] = (function () {
             }
           }
 
-          if (file.name.toLowerCase().includes('.json')) {
+          if (file.name.toLowerCase().endsWith('.json')) {
             return 'json';
           }
 
-          if (file.name.toLowerCase().includes('.js')) {
+          if (file.name.toLowerCase().endsWith('.js')) {
             return 'js';
           }
 


### PR DESCRIPTION
dxf mimetype may be [image/vnd.dwg](https://mimetype.io/image/vnd.dwg) in some cases and handled as `bitmap`, detect `dxf` by extension first
also change extension detection to `endsWith`