### PR TITLE
Fix promark resume and text

### DIFF
--- a/packages/core/src/web/app/views/monitor/MonitorControl.tsx
+++ b/packages/core/src/web/app/views/monitor/MonitorControl.tsx
@@ -26,7 +26,8 @@ const MonitorControl = ({ isFraming, isPromark, setEstimateTaskTime }: Props): R
 
   const triggerOnPlay = () => {
     setIsOnPlaying(true);
-    onPlay(isPromark);
+    // force resend framing and normal task after abortion in Promark
+    onPlay(isPromark && report.st_id !== DeviceConstants.status.PAUSED_FROM_RUNNING);
     clearInterval(estimateTaskTimeTimer.current as NodeJS.Timeout);
     estimateTaskTimeTimer.current = setInterval(() => {
       setEstimateTaskTime((time) => time - 1);
@@ -43,7 +44,15 @@ const MonitorControl = ({ isFraming, isPromark, setEstimateTaskTime }: Props): R
         return (
           <Button disabled={!enabled} key={type} onClick={triggerOnPlay} shape={buttonShape} type="primary">
             <PlayCircleFilled />
-            {report.st_id !== DeviceConstants.status.PAUSED ? tMonitor.go : tMonitor.resume}
+            {tMonitor.go}
+          </Button>
+        );
+      case ButtonTypes.RESUME:
+      case ButtonTypes.DISABLED_RESUME:
+        return (
+          <Button disabled={!enabled} key={type} onClick={triggerOnPlay} shape={buttonShape} type="primary">
+            <PlayCircleFilled />
+            {tMonitor.resume}
           </Button>
         );
       case ButtonTypes.PAUSE:

--- a/packages/core/src/web/helpers/monitor-status.spec.ts
+++ b/packages/core/src/web/helpers/monitor-status.spec.ts
@@ -45,5 +45,9 @@ describe('test monitor-status', () => {
       ButtonTypes.STOP,
       ButtonTypes.PAUSE,
     ]);
+    expect(MonitorStatus.getControlButtonType({ st_id: DeviceConstants.status.PAUSED } as IReport)).toEqual([
+      ButtonTypes.STOP,
+      ButtonTypes.RESUME,
+    ]);
   });
 });

--- a/packages/core/src/web/helpers/monitor-status.ts
+++ b/packages/core/src/web/helpers/monitor-status.ts
@@ -5,10 +5,12 @@ import type { IReport } from '@core/interfaces/IDevice';
 export enum ButtonTypes {
   DISABLED_PAUSE = 4,
   DISABLED_PLAY = 2,
+  DISABLED_RESUME = 8,
   DISABLED_STOP = 6,
   NONE = 0,
   PAUSE = 3,
   PLAY = 1,
+  RESUME = 7,
   STOP = 5,
 }
 
@@ -22,11 +24,11 @@ statusButtonTypeMap[DeviceConstants.status.RESUME_TO_STARTING] = [
 ];
 statusButtonTypeMap[DeviceConstants.status.RUNNING] = [ButtonTypes.STOP, ButtonTypes.PAUSE];
 statusButtonTypeMap[DeviceConstants.status.RESUME_TO_RUNNING] = [ButtonTypes.DISABLED_STOP, ButtonTypes.DISABLED_PAUSE];
-statusButtonTypeMap[DeviceConstants.status.PAUSED] = [ButtonTypes.STOP, ButtonTypes.PLAY];
-statusButtonTypeMap[DeviceConstants.status.PAUSED_FROM_STARTING] = [ButtonTypes.STOP, ButtonTypes.PLAY];
-statusButtonTypeMap[DeviceConstants.status.PAUSING_FROM_STARTING] = [ButtonTypes.STOP, ButtonTypes.DISABLED_PLAY];
-statusButtonTypeMap[DeviceConstants.status.PAUSED_FROM_RUNNING] = [ButtonTypes.STOP, ButtonTypes.PLAY];
-statusButtonTypeMap[DeviceConstants.status.PAUSING_FROM_RUNNING] = [ButtonTypes.STOP, ButtonTypes.DISABLED_PLAY];
+statusButtonTypeMap[DeviceConstants.status.PAUSED] = [ButtonTypes.STOP, ButtonTypes.RESUME];
+statusButtonTypeMap[DeviceConstants.status.PAUSED_FROM_STARTING] = [ButtonTypes.STOP, ButtonTypes.RESUME];
+statusButtonTypeMap[DeviceConstants.status.PAUSING_FROM_STARTING] = [ButtonTypes.STOP, ButtonTypes.DISABLED_RESUME];
+statusButtonTypeMap[DeviceConstants.status.PAUSED_FROM_RUNNING] = [ButtonTypes.STOP, ButtonTypes.RESUME];
+statusButtonTypeMap[DeviceConstants.status.PAUSING_FROM_RUNNING] = [ButtonTypes.STOP, ButtonTypes.DISABLED_RESUME];
 statusButtonTypeMap[DeviceConstants.status.COMPLETED] = [ButtonTypes.PLAY];
 statusButtonTypeMap[DeviceConstants.status.COMPLETING] = [ButtonTypes.DISABLED_STOP, ButtonTypes.DISABLED_PAUSE];
 statusButtonTypeMap[DeviceConstants.status.PREPARING] = [ButtonTypes.DISABLED_STOP, ButtonTypes.DISABLED_PLAY];

--- a/packages/core/src/web/helpers/monitor-status.ts
+++ b/packages/core/src/web/helpers/monitor-status.ts
@@ -2,17 +2,19 @@ import DeviceConstants from '@core/app/constants/device-constants';
 import i18n from '@core/helpers/i18n';
 import type { IReport } from '@core/interfaces/IDevice';
 
+/* eslint-disable perfectionist/sort-enums */
 export enum ButtonTypes {
-  DISABLED_PAUSE = 4,
-  DISABLED_PLAY = 2,
-  DISABLED_RESUME = 8,
-  DISABLED_STOP = 6,
   NONE = 0,
-  PAUSE = 3,
   PLAY = 1,
-  RESUME = 7,
+  DISABLED_PLAY = 2,
+  PAUSE = 3,
+  DISABLED_PAUSE = 4,
   STOP = 5,
+  DISABLED_STOP = 6,
+  RESUME = 7,
+  DISABLED_RESUME = 8,
 }
+/* eslint-enable perfectionist/sort-enums */
 
 const statusButtonTypeMap: { [status: number]: ButtonTypes[] } = {};
 


### PR DESCRIPTION
Allow resuming task when status id is paused(48) in Promark
Use `resume` instead of `start` for status id 48 (pause status for newer machines)