### PR TITLE
Support for ador auto feeder

### DIFF
--- a/packages/core/src/__mocks__/@core/helpers/checkFeature.ts
+++ b/packages/core/src/__mocks__/@core/helpers/checkFeature.ts
@@ -1,3 +1,5 @@
+export const checkAdo1AutoFeeder = (): boolean => true;
+export const checkFbm1AutoFeeder = (): boolean => true;
 export const checkFbb2AutoFeeder = (): boolean => true;
 export const checkFpm1 = (): boolean => true;
 export const checkHxRf = (): boolean => true;

--- a/packages/core/src/web/app/actions/canvas/autoFeederBoundaryDrawer.ts
+++ b/packages/core/src/web/app/actions/canvas/autoFeederBoundaryDrawer.ts
@@ -71,7 +71,7 @@ export class AutoFeederBoundaryDrawer {
     const { height: workareaH, model, width: workareaW } = workareaManager;
     const { autoFeeder } = getSupportInfo(model);
 
-    if (!enabled || !autoFeeder) {
+    if (!enabled || !autoFeeder?.xRange) {
       this.path?.setAttribute('d', '');
       this.container?.setAttribute('display', 'none');
 

--- a/packages/core/src/web/app/actions/canvas/module-boundary-drawer.ts
+++ b/packages/core/src/web/app/actions/canvas/module-boundary-drawer.ts
@@ -44,6 +44,7 @@ const createBoundary = () => {
   boundaryDescText.setAttribute('stroke', 'none');
   boundaryDescText.setAttribute('paint-order', 'stroke');
   boundaryDescText.setAttribute('style', 'pointer-events:none');
+  boundaryDescText.setAttribute('text-anchor', 'middle');
 
   const textNode = document.createTextNode(i18n.lang.layer_module.non_working_area);
 
@@ -60,7 +61,7 @@ const updateCanvasSize = (): void => {
 canvasEventEmitter.on('canvas-change', updateCanvasSize);
 
 const update = (module: LayerModule): void => {
-  const { height: h, model, width: w } = workareaManager;
+  const { expansion, height: h, model, width: w } = workareaManager;
 
   if (!modelsWithModules.has(model)) {
     boundaryPath?.setAttribute('d', '');
@@ -136,12 +137,19 @@ const update = (module: LayerModule): void => {
   boundaryPath?.setAttribute('d', `${d1} ${d2}`);
   boundaryDescText?.removeAttribute('display');
 
-  if (top >= bottom) {
-    boundaryDescText?.setAttribute('x', `${top / 2 - 40}`);
-    boundaryDescText?.setAttribute('y', `${top / 2 + 40} `);
+  const fontSize = Math.max(top / 10, bottom / 10, 80);
+
+  boundaryDescText?.setAttribute('font-size', `${fontSize}`);
+
+  if (top === 0 && bottom === 0) {
+    boundaryDescText?.setAttribute('x', '0');
+    boundaryDescText?.setAttribute('y', '0');
+  } else if (top >= bottom) {
+    boundaryDescText?.setAttribute('x', (w / 2).toString());
+    boundaryDescText?.setAttribute('y', `${(top + fontSize) / 2} `);
   } else {
-    boundaryDescText?.setAttribute('x', `${bottom / 2 - 40}`);
-    boundaryDescText?.setAttribute('y', `${h - bottom / 2 + 40}`);
+    boundaryDescText?.setAttribute('x', (w / 2).toString());
+    boundaryDescText?.setAttribute('y', `${h + (-bottom + fontSize) / 2}`);
   }
 };
 

--- a/packages/core/src/web/app/actions/canvas/module-boundary-drawer.ts
+++ b/packages/core/src/web/app/actions/canvas/module-boundary-drawer.ts
@@ -79,12 +79,7 @@ const update = (module: LayerModule): void => {
 
   const d1 = `M0,0H${w}V${h}H0V0`;
   const { dpmm } = constant;
-  let { bottom, left, right, top } = moduleBoundary[module] || {
-    bottom: 0,
-    left: 0,
-    right: 0,
-    top: 0,
-  };
+  let { bottom, left, right, top } = moduleBoundary[module] || { bottom: 0, left: 0, right: 0, top: 0 };
   const offsets = structuredClone(BeamboxPreference.read('module-offsets'));
   const [offsetX, offsetY] = offsets[module] || [0, 0];
 
@@ -98,7 +93,9 @@ const update = (module: LayerModule): void => {
     right = Math.max(right, -offsetX);
   }
 
-  const rotaryMode = BeamboxPreference.read('rotary_mode');
+  const isRotary = Boolean(BeamboxPreference.read('rotary_mode') && getSupportInfo(model).rotary);
+  const isAutoFeeder = Boolean(BeamboxPreference.read('auto-feeder') && getSupportInfo(model).autoFeeder);
+  const isPassThrough = Boolean(BeamboxPreference.read('pass-through') && getSupportInfo(model).passThrough);
 
   if (offsetY >= 0) {
     top = Math.max(top, offsetY);
@@ -107,11 +104,17 @@ const update = (module: LayerModule): void => {
     bottom = Math.max(bottom, -offsetY);
   }
 
-  if (rotaryMode) {
+  if (isRotary || isAutoFeeder) {
     top = 0;
     bottom = 0;
-  } else if (BeamboxPreference.read('pass-through') && getSupportInfo(model).passThrough) {
-    bottom = 0;
+  } else if (isPassThrough) {
+    if (expansion[0] > 0) {
+      top += expansion[0] / dpmm;
+    }
+
+    if (expansion[1] > 0) {
+      bottom += expansion[1] / dpmm;
+    }
   }
 
   bottom = Math.max(bottom, 0);

--- a/packages/core/src/web/app/components/dialogs/__snapshots__/DocumentSettings.spec.tsx.snap
+++ b/packages/core/src/web/app/components/dialogs/__snapshots__/DocumentSettings.spec.tsx.snap
@@ -404,6 +404,44 @@ exports[`test DocumentSettings should render correctly 1`] = `
                         </button>
                       </div>
                     </div>
+                    <div
+                      class="row full"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          for="auto_feeder"
+                        >
+                          Auto Feeder
+                        </label>
+                      </div>
+                      <div
+                        class="control"
+                      >
+                        <button
+                          aria-checked="false"
+                          class="ant-switch switch css-dev-only-do-not-override-hash"
+                          id="auto_feeder"
+                          role="switch"
+                          type="button"
+                        >
+                          <div
+                            class="ant-switch-handle"
+                          />
+                          <span
+                            class="ant-switch-inner"
+                          >
+                            <span
+                              class="ant-switch-inner-checked"
+                            />
+                            <span
+                              class="ant-switch-inner-unchecked"
+                            />
+                          </span>
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -825,6 +863,44 @@ exports[`test DocumentSettings should render correctly 2`] = `
                           aria-checked="false"
                           class="ant-switch switch css-dev-only-do-not-override-hash"
                           id="pass_through"
+                          role="switch"
+                          type="button"
+                        >
+                          <div
+                            class="ant-switch-handle"
+                          />
+                          <span
+                            class="ant-switch-inner"
+                          >
+                            <span
+                              class="ant-switch-inner-checked"
+                            />
+                            <span
+                              class="ant-switch-inner-unchecked"
+                            />
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="row full"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          for="auto_feeder"
+                        >
+                          Auto Feeder
+                        </label>
+                      </div>
+                      <div
+                        class="control"
+                      >
+                        <button
+                          aria-checked="false"
+                          class="ant-switch switch css-dev-only-do-not-override-hash"
+                          id="auto_feeder"
                           role="switch"
                           type="button"
                         >
@@ -2475,6 +2551,44 @@ exports[`test DocumentSettings should render correctly for ador 1`] = `
                         </button>
                       </div>
                     </div>
+                    <div
+                      class="row full"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          for="auto_feeder"
+                        >
+                          Auto Feeder
+                        </label>
+                      </div>
+                      <div
+                        class="control"
+                      >
+                        <button
+                          aria-checked="false"
+                          class="ant-switch switch css-dev-only-do-not-override-hash"
+                          id="auto_feeder"
+                          role="switch"
+                          type="button"
+                        >
+                          <div
+                            class="ant-switch-handle"
+                          />
+                          <span
+                            class="ant-switch-inner"
+                          >
+                            <span
+                              class="ant-switch-inner-checked"
+                            />
+                            <span
+                              class="ant-switch-inner-unchecked"
+                            />
+                          </span>
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -3147,6 +3261,44 @@ exports[`test DocumentSettings should render correctly for ador 2`] = `
                           aria-checked="false"
                           class="ant-switch switch css-dev-only-do-not-override-hash"
                           id="pass_through"
+                          role="switch"
+                          type="button"
+                        >
+                          <div
+                            class="ant-switch-handle"
+                          />
+                          <span
+                            class="ant-switch-inner"
+                          >
+                            <span
+                              class="ant-switch-inner-checked"
+                            />
+                            <span
+                              class="ant-switch-inner-unchecked"
+                            />
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="row full"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          for="auto_feeder"
+                        >
+                          Auto Feeder
+                        </label>
+                      </div>
+                      <div
+                        class="control"
+                      >
+                        <button
+                          aria-checked="false"
+                          class="ant-switch switch css-dev-only-do-not-override-hash"
+                          id="auto_feeder"
                           role="switch"
                           type="button"
                         >

--- a/packages/core/src/web/app/constants/add-on.ts
+++ b/packages/core/src/web/app/constants/add-on.ts
@@ -8,7 +8,8 @@ export enum RotaryType {
 }
 
 export const CHUCK_ROTARY_DIAMETER = 133;
-export const FBB2_FEEDER_DIAMETER = 167.08;
+export const FBB2_FEEDER_DIAMETER = 167.08; // FIXME: This might be wrong due to PCB issue
+export const FEEDER_DIAMETER = 83.54;
 
 export interface SupportInfo {
   autoFeeder?: { maxHeight: number; rotaryRatio: number; xRange?: [number, number] }; // [x, width] in mm, no limit is not set
@@ -44,7 +45,7 @@ const hexaSupportInfo: SupportInfo = {
 const supportList: Record<WorkAreaModel, SupportInfo> = {
   ado1: {
     autoFeeder: checkAdo1AutoFeeder()
-      ? { maxHeight: 2000, rotaryRatio: CHUCK_ROTARY_DIAMETER / FBB2_FEEDER_DIAMETER }
+      ? { maxHeight: 2000, rotaryRatio: CHUCK_ROTARY_DIAMETER / FEEDER_DIAMETER }
       : undefined,
     framingLowLaser: true,
     jobOrigin: true,

--- a/packages/core/src/web/app/constants/add-on.ts
+++ b/packages/core/src/web/app/constants/add-on.ts
@@ -1,4 +1,4 @@
-import { checkFbb2AutoFeeder } from '@core/helpers/checkFeature';
+import { checkAdo1AutoFeeder, checkFbb2AutoFeeder } from '@core/helpers/checkFeature';
 
 import type { WorkAreaModel } from './workarea-constants';
 
@@ -11,7 +11,7 @@ export const CHUCK_ROTARY_DIAMETER = 133;
 export const FBB2_FEEDER_DIAMETER = 167.08;
 
 export interface SupportInfo {
-  autoFeeder?: { maxHeight: number; rotaryRatio: number; xRange: [number, number] }; // [x, width] in mm
+  autoFeeder?: { maxHeight: number; rotaryRatio: number; xRange?: [number, number] }; // [x, width] in mm, no limit is not set
   autoFocus?: boolean;
   curveEngraving?: boolean;
   framingLowLaser?: boolean;
@@ -43,6 +43,9 @@ const hexaSupportInfo: SupportInfo = {
 
 const supportList: Record<WorkAreaModel, SupportInfo> = {
   ado1: {
+    autoFeeder: checkAdo1AutoFeeder()
+      ? { maxHeight: 2000, rotaryRatio: CHUCK_ROTARY_DIAMETER / FBB2_FEEDER_DIAMETER }
+      : undefined,
     framingLowLaser: true,
     jobOrigin: true,
     lowerFocus: true,

--- a/packages/core/src/web/helpers/api/svg-laser-parser.ts
+++ b/packages/core/src/web/helpers/api/svg-laser-parser.ts
@@ -98,6 +98,7 @@ export const getExportOpt = (
     }
   } else if (autoFeeder) {
     config.rotary_y_ratio = supportInfo.autoFeeder!.rotaryRatio;
+    config.rotary_z_motion = false;
 
     if (config.job_origin) {
       config.spin = config.job_origin[1] * constant.dpmm;
@@ -291,9 +292,11 @@ export const getExportOpt = (
 
   if (args) {
     (Object.keys(config) as Array<keyof IFcodeConfig>).forEach((key) => {
-      if (['curve_engraving', 'loop_compensation', 'model', 'z_offset'].includes(key)) {
+      if (['curve_engraving', 'loop_compensation', 'z_offset'].includes(key)) {
         // Skip special keys
       } else if (key === 'hardware_name') {
+        // hardware_name is deprecated, replaced with model, keep now for web version ghost
+        // may be removed in the future
         args.push(`-${config[key]}`);
       } else if (key === 'af' && config.z_offset) {
         // Handle optional -af value
@@ -303,6 +306,8 @@ export const getExportOpt = (
 
         if (config[key] === true) {
           args.push(keyArg);
+        } else if (config[key] === false) {
+          args.push(keyArg, 'false');
         } else if (typeof config[key] === 'number') {
           args.push(keyArg, config[key].toString());
         } else if (Array.isArray(config[key])) {
@@ -771,6 +776,8 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
             args.push(JSON.stringify([width / constant.dpmm, height / constant.dpmm]));
           }
 
+          // deprecated, replaced with model, keep now for web version ghost
+          // may be removed in the future
           if (model === 'fhexa1') {
             args.push('-hexa');
           } else if (model === 'fbb1p') {
@@ -780,6 +787,8 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
           } else {
             args.push(`-${model}`);
           }
+
+          args.push('-model', model);
 
           if (typeof engraveDpi === 'number') {
             args.push(`-dpi ${engraveDpi}`);

--- a/packages/core/src/web/helpers/checkFeature.ts
+++ b/packages/core/src/web/helpers/checkFeature.ts
@@ -2,6 +2,8 @@ import isDev from './is-dev';
 import isWeb from './is-web';
 import localeHelper from './locale-helper';
 
+export const checkAdo1AutoFeeder = (): boolean => isDev();
+export const checkFbm1AutoFeeder = (): boolean => isDev();
 export const checkFbb2AutoFeeder = (): boolean => isDev();
 export const checkFpm1 = (): boolean => (localeHelper.isTwOrHk || isDev()) && !isWeb();
 export const checkHxRf = (): boolean => isDev();

--- a/packages/core/src/web/interfaces/ITaskConfig.ts
+++ b/packages/core/src/web/interfaces/ITaskConfig.ts
@@ -53,6 +53,7 @@ export type TFcodeOptionalConfig = Partial<{
   pts: number; // path travel speed
   rev: boolean; // reverse engraving
   rotary_y_ratio: number;
+  rotary_z_motion?: boolean; // whether to move z axis in rotary task to avoid collision, default is true in backend
   spin: number; // rotary position, px
   ts: number; // travel speed
   vsc: boolean; // with vector speed constraint, used for ghost 2.3.4 and before


### PR DESCRIPTION
Major changes:
1. Support ador1 auto feeder support
2. Add `rotary_z_motion` to disable ador z motion in rotary job (auto feeder)
Other changes:
1. Change model name from `-beamo` to `-model fbm1` in, deprecate usage of `-hardware_name` for ghost