### PR TITLE
Add memory clipboard

### DIFF
--- a/packages/core/src/web/app/actions/beambox/menuActions.ts
+++ b/packages/core/src/web/app/actions/beambox/menuActions.ts
@@ -250,7 +250,7 @@ export default {
   PASTE_IN_PLACE: (): Promise<null | {
     cmd: IBatchCommand;
     elems: Element[];
-  }> => clipboard.pasteElements('in_place'),
+  }> => clipboard.pasteElements({ type: 'in_place' }),
   PREFERENCE: async (): Promise<void> => {
     Dialog.clearAllDialogComponents();
 

--- a/packages/core/src/web/app/components/beambox/svg-editor/Workarea.tsx
+++ b/packages/core/src/web/app/components/beambox/svg-editor/Workarea.tsx
@@ -132,10 +132,10 @@ export default class Workarea extends React.PureComponent<{ className: string },
           <MenuItem disabled={!select} onClick={() => svgEditor.copySelected()}>
             {LANG.copy}
           </MenuItem>
-          <MenuItem disabled={!paste} onClick={() => clipboard.pasteElements('mouse')}>
+          <MenuItem disabled={!paste} onClick={() => clipboard.pasteElements({ type: 'mouse' })}>
             {LANG.paste}
           </MenuItem>
-          <MenuItem disabled={!paste} onClick={() => clipboard.pasteElements('in_place')}>
+          <MenuItem disabled={!paste} onClick={() => clipboard.pasteElements({ type: 'in_place' })}>
             {LANG.paste_in_place}
           </MenuItem>
           <MenuItem disabled={!select} onClick={async () => svgCanvas.cloneSelectedElements(20, 20)}>

--- a/packages/core/src/web/app/svgedit/interaction/mouse/index.ts
+++ b/packages/core/src/web/app/svgedit/interaction/mouse/index.ts
@@ -12,7 +12,7 @@ import rotaryAxis from '@core/app/actions/canvas/rotary-axis';
 import { MouseButtons } from '@core/app/constants/mouse-constants';
 import TutorialConstants from '@core/app/constants/tutorial-constants';
 import history from '@core/app/svgedit/history/history';
-import clipboard, { isValidNativeClipboard } from '@core/app/svgedit/operations/clipboard';
+import clipboard, { hasClipboardData } from '@core/app/svgedit/operations/clipboard';
 import createNewText from '@core/app/svgedit/text/createNewText';
 import textEdit from '@core/app/svgedit/text/textedit';
 import touchEvents from '@core/app/svgedit/touchEvents';
@@ -91,7 +91,7 @@ const mouseDown = async (evt: MouseEvent) => {
   if (checkShouldIgnore() || svgCanvas.spaceKey || evt.button === MouseButtons.Mid) return;
 
   // Check if the element in the clipboard can be pasted
-  isValidNativeClipboard().then((paste) => {
+  hasClipboardData().then((paste) => {
     workareaEvents.emit('update-context-menu', { paste });
   });
 

--- a/packages/core/src/web/app/svgedit/operations/clipboard/MemoryClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/MemoryClipboard.ts
@@ -1,0 +1,21 @@
+import type { ClipboardCore } from '@core/interfaces/Clipboard';
+
+import BaseClipboardCore from './base';
+
+export class MemoryClipboard extends BaseClipboardCore implements ClipboardCore {
+  private clipboardData: Element[] = [];
+
+  protected writeDataToClipboard = async (elems: Element[]): Promise<void> => {
+    this.clipboardData = [...elems];
+  };
+
+  getData = async (): Promise<Element[]> => {
+    return this.clipboardData;
+  };
+
+  hasData = async (): Promise<boolean> => {
+    return this.clipboardData.length > 0;
+  };
+}
+
+export default MemoryClipboard;

--- a/packages/core/src/web/app/svgedit/operations/clipboard/NativeClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/NativeClipboard.ts
@@ -1,0 +1,244 @@
+import { match } from 'ts-pattern';
+
+import { getSVGAsync } from '@core/helpers/svg-editor-helper';
+import type { ClipboardCore, ClipboardElement } from '@core/interfaces/Clipboard';
+import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
+
+import BaseClipboardCore from './base';
+import { updateSymbolStyle } from './utils';
+
+let svgCanvas: ISVGCanvas;
+
+getSVGAsync(({ Canvas }) => {
+  svgCanvas = Canvas;
+});
+
+interface ClipboardData {
+  elements: ClipboardElement[];
+  imageData: Record<string, string>;
+  refs: Record<string, ClipboardElement>;
+}
+
+const serializeElement = ({
+  attributes,
+  childNodes,
+  innerHTML,
+  namespaceURI,
+  nodeName,
+  nodeType,
+  nodeValue,
+}: Element) => {
+  const result: ClipboardElement = {
+    attributes: [],
+    childNodes: [],
+    innerHTML,
+    namespaceURI,
+    nodeName,
+    nodeType,
+    nodeValue,
+  };
+
+  for (let i = 0; i < attributes?.length; i += 1) {
+    const { namespaceURI, nodeName, value } = attributes[i];
+
+    result.attributes.push({ namespaceURI, nodeName, value });
+  }
+
+  childNodes?.forEach((node) => {
+    result.childNodes.push(serializeElement(node as Element));
+  });
+
+  return result;
+};
+
+export class NativeClipboard extends BaseClipboardCore implements ClipboardCore {
+  protected writeDataToClipboard = async (elems: Element[]): Promise<void> => {
+    const serializedData: ClipboardData = {
+      elements: [],
+      imageData: {},
+      refs: {},
+    };
+
+    elems.forEach((elem) => serializedData.elements.push(serializeElement(elem)));
+
+    const keys = Object.keys(this.refClipboard);
+
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+
+      serializedData.refs[key] = serializeElement(this.refClipboard[key]);
+    }
+
+    // save original image data as base64
+    const origImageUrls = Array.from(
+      new Set(elems.filter((elem) => elem.tagName === 'image').map((elem) => elem.getAttribute('origImage'))),
+    );
+    const promises = [];
+
+    for (let i = 0; i < origImageUrls.length; i += 1) {
+      const origImage = origImageUrls[i]!;
+
+      if (!origImage) continue;
+
+      promises.push(
+        // eslint-disable-next-line no-async-promise-executor
+        new Promise<void>(async (resolve) => {
+          try {
+            const resp = await fetch(origImage);
+            const blob = await resp.blob();
+            const base64 = await new Promise<string>((resolve) => {
+              const reader = new FileReader();
+
+              reader.onload = () => resolve(reader.result as string);
+              reader.readAsDataURL(blob);
+            });
+
+            serializedData.imageData[origImage] = base64;
+          } finally {
+            resolve();
+          }
+        }),
+      );
+    }
+    await Promise.allSettled(promises);
+
+    try {
+      await navigator.clipboard.writeText(`BX clip:${JSON.stringify(serializedData)}`);
+    } catch (err) {
+      console.log('🚀 ~ file: clipboard.ts:131 ~ copyElements ~ err:', err);
+    }
+  };
+
+  getData = async (): Promise<Element[]> => {
+    const clipboardData = await navigator.clipboard.readText();
+
+    if (!clipboardData.startsWith('BX clip:')) {
+      return [];
+    }
+
+    const drawing = svgCanvas.getCurrentDrawing();
+    const data = JSON.parse(clipboardData.substring(8)) as ClipboardData;
+    const { elements, imageData, refs } = data;
+
+    const keys = Object.keys(refs);
+
+    this.refClipboard = {};
+
+    for (const key of keys) {
+      const symbolElemData = refs[key];
+      const id = symbolElemData.attributes.find(({ nodeName }) => nodeName === 'id')?.value!;
+      const newSymbol = drawing.copyElemData(symbolElemData) as SVGSymbolElement;
+
+      updateSymbolStyle(newSymbol, id);
+      this.refClipboard[key] = newSymbol;
+    }
+
+    // retrieve image data and convert to blob url
+    await Promise.allSettled(
+      Object.keys(imageData).map(async (key) => {
+        try {
+          const base64 = imageData[key];
+          const resp = await fetch(base64);
+          const blob = await resp.blob();
+          const url = URL.createObjectURL(blob);
+
+          imageData[key] = url;
+        } catch (error) {
+          console.error('Failed to fetch image data', error);
+        }
+      }),
+    );
+
+    const newElements = elements.map((element) => drawing.copyElemData(element));
+
+    // use clipboard image data if original image is not available
+    await Promise.allSettled(
+      newElements.map(async (element: Element) => {
+        if (element.tagName === 'image') {
+          const origImage = element.getAttribute('origImage');
+
+          if (origImage && imageData[origImage]) {
+            try {
+              await fetch(origImage);
+            } catch {
+              element.setAttribute('origImage', imageData[origImage]);
+            }
+          }
+        }
+      }),
+    );
+
+    return newElements;
+  };
+
+  hasData = async (): Promise<boolean> => {
+    try {
+      const clipboardData = await navigator.clipboard.readText();
+
+      return clipboardData.startsWith('BX clip:');
+    } catch (err) {
+      console.log('🚀 ~ file: clipboard.ts:45 ~ isValidNativeClipboard ~ err:', err);
+
+      return false;
+    }
+  };
+}
+
+const checkNativeClipboardByPermissions = async (): Promise<boolean | undefined> => {
+  try {
+    // eslint-disable-next-line no-undef
+    const readState = (await navigator.permissions.query({ name: 'clipboard-read' as PermissionName })).state;
+    // eslint-disable-next-line no-undef
+    const writeState = (await navigator.permissions.query({ name: 'clipboard-write' as PermissionName })).state;
+
+    return match([readState, writeState])
+      .with(['granted', 'granted'], () => true)
+      .when(
+        ([r, w]) => r === 'denied' || w === 'denied',
+        () => false,
+      )
+      .otherwise(() => undefined);
+  } catch (err) {
+    console.log('Failed to access native clipboard permission.', err);
+
+    // some browsers do not support clipboard permission
+    return undefined;
+  }
+};
+
+const checkNativeClipboardByReadWrite = async (): Promise<boolean> => {
+  if (!document.hasFocus()) {
+    console.log('not focused, wait for 1000ms');
+    // If the document is not focused, we cannot access the clipboard
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return checkNativeClipboardByReadWrite();
+  }
+
+  try {
+    const origClipboard = await navigator.clipboard.readText();
+
+    await navigator.clipboard.writeText('BX Clipboard test');
+
+    const clipboardData = await navigator.clipboard.readText();
+    const res = clipboardData.startsWith('BX Clipboard test');
+
+    await navigator.clipboard.writeText(origClipboard);
+
+    return res;
+  } catch (err) {
+    console.log('Failed to access native clipboard.', err);
+
+    return false;
+  }
+};
+
+export const checkNativeClipboardSupport = async (): Promise<boolean> => {
+  const permissionResult = await checkNativeClipboardByPermissions();
+
+  if (permissionResult !== undefined) return permissionResult;
+
+  return checkNativeClipboardByReadWrite();
+};
+
+export default NativeClipboard;

--- a/packages/core/src/web/app/svgedit/operations/clipboard/NativeClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/NativeClipboard.ts
@@ -105,7 +105,7 @@ export class NativeClipboard extends BaseClipboardCore implements ClipboardCore 
     try {
       await navigator.clipboard.writeText(`BX clip:${JSON.stringify(serializedData)}`);
     } catch (err) {
-      console.log('🚀 ~ file: clipboard.ts:131 ~ copyElements ~ err:', err);
+      console.log('🚀 ~ file: NativeClipboard:108 ~ writeDataToClipboard ~ err:', err);
     }
   };
 
@@ -177,7 +177,7 @@ export class NativeClipboard extends BaseClipboardCore implements ClipboardCore 
 
       return clipboardData.startsWith('BX clip:');
     } catch (err) {
-      console.log('🚀 ~ file: clipboard.ts:45 ~ isValidNativeClipboard ~ err:', err);
+      console.log('🚀 ~ file: NativeClipboard.ts:180 ~ hasData ~ err:', err);
 
       return false;
     }

--- a/packages/core/src/web/app/svgedit/operations/clipboard/base.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/base.ts
@@ -1,0 +1,65 @@
+import type { ClipboardCore } from '@core/interfaces/Clipboard';
+
+// TODO: decouple with svgcanvas
+const { svgedit } = window;
+
+export class BaseClipboardCore implements ClipboardCore {
+  protected refClipboard: Record<string, Element> = {};
+
+  addRefToClipboard = (useElement: SVGUseElement): void => {
+    const symbolId = svgedit.utilities.getHref(useElement);
+    const symbolElement = document.querySelector(symbolId);
+    const originalSymbolElement =
+      document.getElementById(symbolElement?.getAttribute('data-origin-symbol')) || symbolElement;
+
+    if (originalSymbolElement) {
+      this.refClipboard[symbolId] = originalSymbolElement;
+    }
+  };
+
+  getRefFromClipboard = (id: string): Element | undefined => this.refClipboard[id];
+
+  // eslint-disable-next-line ts/no-unused-vars
+  protected writeDataToClipboard = async (elems: Element[]): Promise<void> => {
+    throw new Error('Method not implemented.');
+  };
+
+  copyElements = async (elems: Element[]): Promise<void> => {
+    const layerNames = new Set<string>();
+    let layerCount = 0;
+
+    this.refClipboard = {};
+
+    for (let i = 0; i < elems.length; i += 1) {
+      const elem = elems[i];
+      const layerName = elem.closest('g.layer')?.querySelector('title')?.textContent;
+
+      if (layerName) elem.setAttribute('data-origin-layer', layerName);
+
+      if (elem.tagName === 'use') this.addRefToClipboard(elem as SVGUseElement);
+      else Array.from(elem.querySelectorAll('use')).forEach((use: SVGUseElement) => this.addRefToClipboard(use));
+
+      if (layerName && !layerNames.has(layerName)) {
+        layerNames.add(layerName);
+        layerCount += 1;
+      }
+    }
+
+    // If there is only one layer selected, don't force user to paste on the same layer
+    if (layerCount === 1) {
+      elems.forEach((elem) => elem?.removeAttribute('data-origin-layer'));
+    }
+
+    await this.writeDataToClipboard(elems);
+  };
+
+  getData = async (): Promise<Element[]> => {
+    throw new Error('Method not implemented.');
+  };
+
+  hasData = async (): Promise<boolean> => {
+    return false;
+  };
+}
+
+export default BaseClipboardCore;

--- a/packages/core/src/web/app/svgedit/operations/clipboard/utils.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/utils.ts
@@ -1,0 +1,14 @@
+export const updateSymbolStyle = (symbol: SVGSymbolElement, oldId: string) => {
+  const styles = symbol.querySelectorAll('style, STYLE');
+
+  for (let i = 0; i < styles.length; i += 1) {
+    const style = styles[i];
+    const { textContent } = style;
+
+    if (!textContent) continue;
+
+    const newContent = textContent.replace(RegExp(oldId, 'g'), symbol.id);
+
+    style.textContent = newContent;
+  }
+};

--- a/packages/core/src/web/interfaces/Clipboard.ts
+++ b/packages/core/src/web/interfaces/Clipboard.ts
@@ -1,0 +1,30 @@
+export interface ClipboardCore {
+  addRefToClipboard(useElement: SVGUseElement): void;
+
+  /**
+   * Copy the given elements to the clipboard.
+   * @param elems The elements to copy.
+   */
+  copyElements(elems: Element[]): Promise<void>;
+
+  /**
+   * Get the data from the clipboard.
+   */
+  getData(): Promise<Element[]>;
+
+  getRefFromClipboard(id: string): Element | undefined;
+
+  hasData(): Promise<boolean>;
+}
+
+export interface ClipboardElement {
+  attributes: Array<Record<'namespaceURI' | 'nodeName' | 'value', null | string>>;
+  childNodes: ClipboardElement[];
+  dataGSVG?: string;
+  dataSymbol?: string;
+  innerHTML: string;
+  namespaceURI: null | string;
+  nodeName: string;
+  nodeType: number;
+  nodeValue: null | string;
+}

--- a/packages/core/src/web/interfaces/ISVGDrawing.d.ts
+++ b/packages/core/src/web/interfaces/ISVGDrawing.d.ts
@@ -1,12 +1,15 @@
 import type { ISVGLayerConscrtuctor } from '@core/interfaces/ISVGLayer';
 import type ISVGLayer from '@core/interfaces/ISVGLayer';
 
+import type { ClipboardElement } from './Clipboard';
+
 export default interface ISVGDrawing {
   all_layers: ISVGLayer[];
   browser: {
     isTouch: () => boolean;
   };
   copyElem: (elem: Element) => Element;
+  copyElemData: (elem: ClipboardElement) => Element;
   createLayer: (name: string) => SVGGElement;
   draw: {
     Layer: ISVGLayerConscrtuctor;


### PR DESCRIPTION
Refactor clipboard,
Separate clipboard core to store data.
Add memory clipboard core to store data in memory for browser not supports native clipboard (mainly web).
Detect native clipboard available by 1. `navigator.permissions` if browser supported 2. Call `navigator.clipboard` directly.