### PR TITLE
Fix imageSymbol bbox upon import

### DIFF
--- a/packages/core/src/web/helpers/symbol-helper/symbolMaker.ts
+++ b/packages/core/src/web/helpers/symbol-helper/symbolMaker.ts
@@ -14,7 +14,7 @@ import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
 import { getSVGAsync } from '../svg-editor-helper';
 
-import updateImageSymbol from './updateImageSymbol';
+import updateImageSymbol, { waitForImageSymbolUrl } from './updateImageSymbol';
 
 let svgCanvas: ISVGCanvas;
 let svgedit: any;
@@ -446,12 +446,18 @@ const makeImageSymbol = async (
 
     const svgString = new XMLSerializer().serializeToString(tempSvg);
     const svgBlob = (await sendTaskToWorker({ svgString, type: 'svgStringToBlob' })) as Blob;
+    let isNewImageSymbol = false;
 
-    if (!imageSymbol) imageSymbol = createImageSymbol(symbol);
-
-    resolve(imageSymbol);
+    if (!imageSymbol) {
+      imageSymbol = createImageSymbol(symbol);
+      isNewImageSymbol = true;
+    }
 
     updateImageSymbol({ bb, fullColor, imageRatio, imageSymbol, strokeWidth, svgBlob });
+
+    if (isNewImageSymbol) await waitForImageSymbolUrl(imageSymbol);
+
+    resolve(imageSymbol);
   });
 };
 

--- a/packages/core/src/web/helpers/symbol-helper/updateImageSymbol.ts
+++ b/packages/core/src/web/helpers/symbol-helper/updateImageSymbol.ts
@@ -220,4 +220,23 @@ export const updateImageSymbol = async (param: UpdateImageSymbolParams) => {
   input$.next(param);
 };
 
+export const waitForImageSymbolUrl = async (symbol: SVGSymbolElement): Promise<void> => {
+  const image = symbol.querySelector('image') as SVGImageElement;
+
+  if (!image) return;
+
+  if (image.getAttribute('href')) return;
+
+  return new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      if (image.getAttribute('href')) {
+        observer.disconnect();
+        resolve();
+      }
+    });
+
+    observer.observe(image, { attributeFilter: ['href'] });
+  });
+};
+
 export default updateImageSymbol;


### PR DESCRIPTION
Fix bbox display when importing SVG objects.
In `makeImageSymbol` await for the `imageSymbol` url to appear if the `imageSymbol` is new created