### PR TITLE
fix(action-panel): convert-text-to-path not handle by undo-manager

### DIFF
--- a/packages/core/src/web/app/views/beambox/Right-Panels/ActionsPanel.spec.tsx
+++ b/packages/core/src/web/app/views/beambox/Right-Panels/ActionsPanel.spec.tsx
@@ -254,7 +254,7 @@ describe('should render correctly', () => {
     expect(clearSelection).toHaveBeenCalledTimes(1);
     expect(convertTextToPath).toHaveBeenCalledTimes(1);
     expect(convertTextToPath).toHaveBeenNthCalledWith(1, document.getElementById('svg_1'), {
-      isSubCommand: true,
+      isSubCommand: false,
       weldingTexts: false,
     });
 
@@ -265,7 +265,7 @@ describe('should render correctly', () => {
     expect(clearSelection).toHaveBeenCalledTimes(2);
     expect(convertTextToPath).toHaveBeenCalledTimes(2);
     expect(convertTextToPath).toHaveBeenNthCalledWith(2, document.getElementById('svg_1'), {
-      isSubCommand: true,
+      isSubCommand: false,
       weldingTexts: true,
     });
 
@@ -530,7 +530,7 @@ describe('should render correctly in mobile', () => {
     expect(clearSelection).toHaveBeenCalledTimes(1);
     expect(convertTextToPath).toHaveBeenCalledTimes(1);
     expect(convertTextToPath).toHaveBeenNthCalledWith(1, document.getElementById('svg_1'), {
-      isSubCommand: true,
+      isSubCommand: false,
       weldingTexts: false,
     });
 
@@ -541,7 +541,7 @@ describe('should render correctly in mobile', () => {
     expect(clearSelection).toHaveBeenCalledTimes(2);
     expect(convertTextToPath).toHaveBeenCalledTimes(2);
     expect(convertTextToPath).toHaveBeenNthCalledWith(2, document.getElementById('svg_1'), {
-      isSubCommand: true,
+      isSubCommand: false,
       weldingTexts: true,
     });
 

--- a/packages/core/src/web/app/views/beambox/Right-Panels/ActionsPanel.tsx
+++ b/packages/core/src/web/app/views/beambox/Right-Panels/ActionsPanel.tsx
@@ -94,7 +94,7 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
     return { bbox: path.getBBox(), command };
   };
 
-  const convertTextToPath = async (weldingTexts = false): Promise<ConvertPathResult> => {
+  const convertTextToPath = async ({ isSubCommand = false, weldingTexts = false }): Promise<ConvertPathResult> => {
     const isTextPath = elem.getAttribute('data-textpath-g');
     const textElem = isTextPath ? elem.querySelector('text') : elem;
 
@@ -102,7 +102,7 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
 
     svgCanvas.clearSelection();
 
-    const { command, path } = await FontFuncs.convertTextToPath(textElem!, { isSubCommand: true, weldingTexts });
+    const { command, path } = await FontFuncs.convertTextToPath(textElem!, { isSubCommand, weldingTexts });
 
     if (path) svgCanvas.selectOnly([path]);
 
@@ -203,7 +203,7 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
     renderButtons(
       'convert_to_path',
       lang.convert_to_path,
-      () => (isText ? convertTextToPath() : svgCanvas.convertToPath(elem as SVGElement)),
+      () => (isText ? convertTextToPath({ isSubCommand: false }) : svgCanvas.convertToPath(elem as SVGElement)),
       <ActionPanelIcons.ConvertToPath />,
       <ActionPanelIcons.ConvertToPathMobile />,
       { isFullLine: true, mobileLabel: lang.outline, ...opts },
@@ -395,14 +395,14 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
     renderButtons(
       'weld',
       lang.weld_text,
-      () => convertTextToPath(true),
+      () => convertTextToPath({ isSubCommand: false, weldingTexts: true }),
       <ActionPanelIcons.WeldText />,
       <ActionPanelIcons.WeldText />,
       { isFullLine: true },
     ),
     renderSmartNestButton(),
     renderArrayButton({ isFullLine: true }),
-    renderTabButton({ convertToPath: convertTextToPath }),
+    renderTabButton({ convertToPath: () => convertTextToPath({ isSubCommand: true }) }),
   ];
 
   const renderTextPathActions = (): React.JSX.Element[] => [


### PR DESCRIPTION
## Overview

1. [fix(action-panel): convert-text-to-path not handle by undo-manager](https://github.com/flux3dp/beam-studio/commit/675127231e65f011226042ad6cc65aa30e709d25)