### PR TITLE
Fix path preview layout

### DIFF
--- a/packages/core/src/web/app/components/beambox/ZoomBlock.module.scss
+++ b/packages/core/src/web/app/components/beambox/ZoomBlock.module.scss
@@ -7,10 +7,6 @@
   font-size: 16px;
   z-index: 1;
 
-  &.path-preview {
-    bottom: 65px;
-  }
-
   &.mobile {
     left: 15px;
     bottom: 70px;

--- a/packages/core/src/web/app/components/beambox/ZoomBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/ZoomBlock.tsx
@@ -126,12 +126,11 @@ const getDpmm = async (): Promise<number> => {
 interface Props {
   className?: string;
   getZoom?: () => number;
-  isPathPreviewing?: boolean;
   resetView: () => void;
   setZoom: (zoom: number) => void;
 }
 
-const ZoomBlock = ({ className, getZoom, isPathPreviewing, resetView, setZoom }: Props): React.JSX.Element => {
+const ZoomBlock = ({ className, getZoom, resetView, setZoom }: Props): React.JSX.Element => {
   const lang = useI18n().beambox.zoom_block;
   const [dpmm, setDpmm] = useState(96 / 25.4);
   const [displayRatio, setDisplayRatio] = useState(1);
@@ -212,13 +211,7 @@ const ZoomBlock = ({ className, getZoom, isPathPreviewing, resetView, setZoom }:
   );
 
   return (
-    <div
-      className={classNames(
-        styles.container,
-        { [styles.mobile]: isMobile, [styles['path-preview']]: isPathPreviewing },
-        className,
-      )}
-    >
+    <div className={classNames(styles.container, { [styles.mobile]: isMobile }, className)}>
       <ContextMenuTrigger holdToDisplay={-1} holdToDisplayMouse={-1} id={contextMenuId}>
         <div className={styles.btn} onClick={() => zoomOut(displayRatio)}>
           <img src="img/icon-minus.svg" />

--- a/packages/core/src/web/app/components/beambox/ZoomBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/ZoomBlock.tsx
@@ -192,8 +192,8 @@ const ZoomBlock = ({ className, getZoom, isPathPreviewing, resetView, setZoom }:
   const zoomIn = useCallback(
     (currentRatio: number) => {
       const ratioInPercent = Math.round(currentRatio * 100);
-      const factor = ratioInPercent <= 500 ? 10 : 100;
-      const targetRatio = ratioInPercent + (factor - (ratioInPercent % factor || factor));
+      const factor = ratioInPercent < 500 ? 10 : 100;
+      const targetRatio = ratioInPercent + (factor - (ratioInPercent % factor) || factor);
 
       setRatio(targetRatio);
     },

--- a/packages/core/src/web/app/components/beambox/path-preview/PathPreview.module.scss
+++ b/packages/core/src/web/app/components/beambox/path-preview/PathPreview.module.scss
@@ -38,7 +38,7 @@
         align-items: center;
         line-height: 18px;
 
-        input[type="range"] {
+        input[type='range'] {
           width: 75px;
           height: 10px;
           margin: 0 10px;

--- a/packages/core/src/web/app/components/beambox/path-preview/PathPreview.module.scss
+++ b/packages/core/src/web/app/components/beambox/path-preview/PathPreview.module.scss
@@ -1,4 +1,6 @@
 .container {
+  position: relative;
+
   .tools-panel {
     height: 100px;
     padding: 40px 20px 0;
@@ -28,7 +30,7 @@
         align-items: center;
         line-height: 18px;
 
-        input[type='range'] {
+        input[type="range"] {
           width: 75px;
           height: 10px;
           margin: 0 10px;
@@ -74,5 +76,9 @@
       line-height: 16px;
       width: 160px;
     }
+  }
+
+  .zoom-block {
+    bottom: 65px;
   }
 }

--- a/packages/core/src/web/app/components/beambox/path-preview/PathPreview.module.scss
+++ b/packages/core/src/web/app/components/beambox/path-preview/PathPreview.module.scss
@@ -1,5 +1,13 @@
 .container {
+  flex: 1 1 auto;
+  display: flex;
+  overflow: hidden;
+}
+
+.main {
+  flex: 1 1 auto;
   position: relative;
+  overflow: hidden;
 
   .tools-panel {
     height: 100px;

--- a/packages/core/src/web/app/components/beambox/path-preview/PathPreview.tsx
+++ b/packages/core/src/web/app/components/beambox/path-preview/PathPreview.tsx
@@ -2006,8 +2006,8 @@ class PathPreview extends React.Component<Props, State> {
           </div>
         </div>
         <ZoomBlock
+          className={styles['zoom-block']}
           getZoom={() => this.camera.scale}
-          isPathPreviewing
           resetView={this.resetView}
           setZoom={this.setScale}
         />

--- a/packages/core/src/web/app/components/beambox/path-preview/Pointable.tsx
+++ b/packages/core/src/web/app/components/beambox/path-preview/Pointable.tsx
@@ -94,6 +94,7 @@ const updateNodeWithPE = (node, prevProps, nextProps) => {
 };
 
 interface Props {
+  children?: React.ReactNode;
   onPointerCancel?: any;
   onPointerDown?: any;
   onPointerEnter?: any;

--- a/packages/core/src/web/app/components/beambox/path-preview/SidePanel.module.scss
+++ b/packages/core/src/web/app/components/beambox/path-preview/SidePanel.module.scss
@@ -1,19 +1,14 @@
 @use '@core/styles/variables' as variables;
 
 .container {
-  // TODO: change position to relative and hide original right panel
+  flex: 0 0 auto;
   border: none;
-  position: fixed;
   background-color: #f8f8f8;
   width: variables.$sidePanelWidth;
   padding: 0px;
   opacity: 1;
   overflow-x: visible;
   overflow-y: scroll;
-  z-index: 2;
-  top: 40px;
-  height: calc(100% - 40px);
-  right: 0;
   transition: opacity 0.3s;
   border: 1px solid #e0e0e0;
   border-width: 0 0 0 1px;

--- a/packages/core/src/web/app/components/beambox/right-panel/RightPanel.tsx
+++ b/packages/core/src/web/app/components/beambox/right-panel/RightPanel.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import React, { memo, useCallback, useContext, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
@@ -5,6 +6,7 @@ import { match, P } from 'ts-pattern';
 
 import LayerPanel from '@core/app/components/beambox/right-panel/LayerPanel';
 import Tab from '@core/app/components/beambox/right-panel/Tab';
+import CanvasMode from '@core/app/constants/canvasMode';
 import { PanelType } from '@core/app/constants/right-panel-types';
 import { CanvasContext } from '@core/app/contexts/CanvasContext';
 import { SelectedElementContext } from '@core/app/contexts/SelectedElementContext';
@@ -21,8 +23,8 @@ import styles from './RightPanel.module.scss';
 
 const rightPanelEventEmitter = eventEmitterFactory.createEventEmitter('right-panel');
 
-const RightPanel = (): React.JSX.Element => {
-  const { isPathEditing } = useContext(CanvasContext);
+const RightPanel = (): ReactNode => {
+  const { isPathEditing, mode } = useContext(CanvasContext);
   const { selectedElement } = useContext(SelectedElementContext);
   const isMobile = useIsMobile();
   const [panelType, setPanelType] = useState(isMobile ? PanelType.None : PanelType.Layer);
@@ -95,6 +97,8 @@ const RightPanel = (): React.JSX.Element => {
       return PanelType.Layer;
     });
   }, [isPathEditing]);
+
+  if (mode === CanvasMode.PathPreview) return null;
 
   const sideClass = classNames(styles.sidepanels, {
     [styles.short]: window.os === 'Windows' && !isWeb(),


### PR DESCRIPTION
1. fix zoom block `zoomIn` broken when the `value % 10 === 0` (logic was changed accidentally in https://github.com/flux3dp/beam-studio/commit/c8be77dca1b538bdb73469fb88ceb268c436d9f7)
2. Fix path preview, layout, make thing flex & hide RightPanel when path previwing
3. Slight fix ts error in `PathPreview` (still a lot of ts error that don't know how to fix)