### PR TITLE
Fix setCustomTitleBarDraggable

### DIFF
--- a/packages/core/src/web/app/actions/tabController.ts
+++ b/packages/core/src/web/app/actions/tabController.ts
@@ -104,7 +104,7 @@ class TabController extends EventEmitter {
   setCustomTitleBarDraggable = (isDraggable: boolean): void => {
     const cetDragRegion = document.querySelector('.cet-drag-region') as HTMLDivElement;
 
-    if (cetDragRegion) cetDragRegion.style.display = isDraggable ? 'block' : 'none';
+    if (cetDragRegion) cetDragRegion.style.width = isDraggable ? '' : '0';
   };
 }
 


### PR DESCRIPTION
because `cet-drag-region` `display` will be changed by custrom electron titlbar
change to overriding width instead