### PR TITLE
Fix getPathForFile

### DIFF
--- a/apps/app/src/implementations/fileSystem.ts
+++ b/apps/app/src/implementations/fileSystem.ts
@@ -24,7 +24,7 @@ export default {
     return app.getPath(path);
   },
   getPathForFile(file: File): string | undefined {
-    return electron.webUtils.getPathForFile(file);
+    return file.path || electron.webUtils.getPathForFile(file);
   },
   isDirectory(input: string): boolean {
     return fs.lstatSync(input).isDirectory();

--- a/apps/app/src/implementations/pdfHelper.ts
+++ b/apps/app/src/implementations/pdfHelper.ts
@@ -39,13 +39,13 @@ const pdfToSvgBlob = async (file: File): Promise<{ blob?: Blob; errorMessage?: s
     await init();
   }
 
+  const filePath = fileSystem.getPathForFile(file);
+
   if (pdf2svgPath) {
     const outPath = path.join(tempDir, 'out.svg');
 
     // mac or windows, using packed binary executable
     try {
-      const filePath = fileSystem.getPathForFile(file);
-
       if (!filePath) throw new Error('Failed to load file path');
 
       fs.copyFileSync(filePath, tempFilePath);
@@ -83,7 +83,7 @@ const pdfToSvgBlob = async (file: File): Promise<{ blob?: Blob; errorMessage?: s
       return { errorMessage: lang.error_pdf2svg_not_found };
     }
     try {
-      const { stderr, stdout } = await exec(`pdf2svg "${file.path}" "${outPath}"`);
+      const { stderr, stdout } = await exec(`pdf2svg "${filePath}" "${outPath}"`);
 
       console.log('out', stdout, 'err', stderr);
 


### PR DESCRIPTION
fix getPathForFile, sometimes file may have path but `getPathForFile` return `''`, use `file.path` and fallback to `getPathForFile`