### PR TITLE
Update UI for electron and windows

### DIFF
--- a/apps/app/src/implementations/menu.ts
+++ b/apps/app/src/implementations/menu.ts
@@ -98,7 +98,7 @@ class Menu extends AbstractMenu {
     this.updateMenuByWorkarea(BeamboxPreference.read('workarea'));
   };
 
-  attach(enabledItems: string[]) {
+  attach(enabledItems?: string[]) {
     super.attach(enabledItems);
     updateWindowsMenu();
   }

--- a/apps/app/src/node/electron-main.ts
+++ b/apps/app/src/node/electron-main.ts
@@ -296,16 +296,16 @@ function createWindow() {
   });
   networkHelper.registerEvents();
 
+  // see https://github.com/AlexTorresDev/custom-electron-titlebar/blob/2471c5a4df6c9146f7f8d8598e503789cfc1190c/src/main/attach-titlebar-to-window.ts
+  mainWindow.on('enter-full-screen', () => {
+    tabManager?.sendToAllViews('window-fullscreen', true);
+  });
+  mainWindow.on('leave-full-screen', () => {
+    tabManager?.sendToAllViews('window-fullscreen', false);
+  });
+
   if (process.platform === 'win32') {
     // original attachTitlebarToWindow for windows
-
-    // see https://github.com/AlexTorresDev/custom-electron-titlebar/blob/2471c5a4df6c9146f7f8d8598e503789cfc1190c/src/main/attach-titlebar-to-window.ts
-    mainWindow.on('enter-full-screen', () => {
-      tabManager?.sendToAllViews('window-fullscreen', true);
-    });
-    mainWindow.on('leave-full-screen', () => {
-      tabManager?.sendToAllViews('window-fullscreen', false);
-    });
     mainWindow.on('focus', () => {
       tabManager?.sendToFocusedView('window-focus', true);
     });

--- a/apps/app/src/node/menu-manager.ts
+++ b/apps/app/src/node/menu-manager.ts
@@ -439,6 +439,7 @@ class MenuManager extends EventEmitter {
 
     menuItems.push(buildFileMenu(fnKey, r, callback, this.isDevMode));
     menuItems.push({
+      enabled: false,
       id: '_edit',
       label: r.edit,
       submenu: [
@@ -555,6 +556,7 @@ class MenuManager extends EventEmitter {
     });
 
     menuItems.push({
+      enabled: false,
       id: '_view',
       label: r.view,
       submenu: [
@@ -622,12 +624,13 @@ class MenuManager extends EventEmitter {
           id: 'ADD_NEW_MACHINE',
           label: r.add_new_machine || 'Add New Machine',
         },
-        { click: callback, id: 'NETWORK_TESTING', label: r.network_testing || 'Test Network' },
+        { click: callback, enabled: false, id: 'NETWORK_TESTING', label: r.network_testing || 'Test Network' },
         { type: 'separator' },
       ],
     });
 
     menuItems.push({
+      enabled: false,
       id: '_tools',
       label: r.tools.title,
       submenu: [
@@ -677,8 +680,8 @@ class MenuManager extends EventEmitter {
 
     helpSubmenu.push(
       ...[
-        { click: callback, id: 'START_TUTORIAL', label: r.show_start_tutorial },
-        { click: callback, id: 'START_UI_INTRO', label: r.show_ui_intro },
+        { click: callback, enabled: false, id: 'START_TUTORIAL', label: r.show_start_tutorial },
+        { click: callback, enabled: false, id: 'START_UI_INTRO', label: r.show_ui_intro },
         { click: callback, id: 'QUESTIONNAIRE', label: r.questionnaire },
         { click: callback, id: 'CHANGE_LOGS', label: r.change_logs },
         {

--- a/apps/app/src/node/menu/fileMenu.ts
+++ b/apps/app/src/node/menu/fileMenu.ts
@@ -32,25 +32,29 @@ export function buildFileMenu(
     {
       accelerator: `${fnKey}+O`,
       click: callback,
+      enabled: false,
       id: 'OPEN',
       label: r.open || 'Open',
     },
-    { id: 'RECENT', label: r.recent || 'Open Recent', submenu: [] },
+    { enabled: false, id: 'RECENT', label: r.recent || 'Open Recent', submenu: [] },
     { type: 'separator' },
     {
       accelerator: `${fnKey}+S`,
       click: callback,
+      enabled: false,
       id: 'SAVE_SCENE',
       label: r.save_scene || 'Save Scene',
     },
     {
       accelerator: `Shift+${fnKey}+S`,
       click: callback,
+      enabled: false,
       id: 'SAVE_AS',
       label: r.save_as,
     },
     {
       click: callback,
+      enabled: false,
       id: 'SAVE_TO_CLOUD',
       label: r.save_to_cloud,
     },
@@ -71,6 +75,7 @@ export function buildFileMenu(
     },
     { type: 'separator' },
     {
+      enabled: false,
       id: 'SAMPLES',
       label: r.samples || 'Examples',
       submenu: [
@@ -132,6 +137,7 @@ export function buildFileMenu(
     },
     { type: 'separator' },
     {
+      enabled: false,
       id: 'EXPORT_TO',
       label: r.export_to || 'Export to',
       submenu: [

--- a/apps/app/src/node/tabManager.ts
+++ b/apps/app/src/node/tabManager.ts
@@ -348,9 +348,11 @@ class TabManager {
     id: number,
     {
       allowEmpty = false,
+      keepWelcomeTab = true,
       shouldCloseWindow = false,
     }: {
       allowEmpty?: boolean;
+      keepWelcomeTab?: boolean;
       shouldCloseWindow?: boolean;
     } = {},
   ): Promise<boolean> => {
@@ -359,7 +361,7 @@ class TabManager {
 
     if (!tabsMap[id]) return false;
 
-    if (this.welcomeTabId === id) {
+    if (this.welcomeTabId === id && keepWelcomeTab) {
       isClosable = allowEmpty && this.tabsList.length === 1;
     } else {
       isClosable = allowEmpty || this.tabsList.length > 1;
@@ -421,7 +423,7 @@ class TabManager {
     for (let i = 0; i < ids.length; i += 1) {
       const id = Number.parseInt(ids[i], 10);
 
-      const res = await this.closeTab(id, { allowEmpty: true, shouldCloseWindow });
+      const res = await this.closeTab(id, { allowEmpty: true, keepWelcomeTab: false, shouldCloseWindow });
 
       if (!res) {
         return false;

--- a/apps/app/src/node/tabManager.ts
+++ b/apps/app/src/node/tabManager.ts
@@ -90,6 +90,7 @@ class TabManager {
         }
 
         this.sendToView(id, id === this.focusedId ? TabEvents.TabFocused : TabEvents.TabBlurred);
+        this.sendToView(id, 'window-fullscreen', this.mainWindow.isFullScreen());
         this.notifyTabUpdated();
       }
     });

--- a/apps/app/src/node/tabManager.ts
+++ b/apps/app/src/node/tabManager.ts
@@ -355,8 +355,17 @@ class TabManager {
     } = {},
   ): Promise<boolean> => {
     const { focusedId, tabsMap } = this;
+    let isClosable: boolean;
 
-    if (tabsMap[id] && (allowEmpty || this.tabsList.length > 1)) {
+    if (!tabsMap[id]) return false;
+
+    if (this.welcomeTabId === id) {
+      isClosable = allowEmpty && this.tabsList.length === 1;
+    } else {
+      isClosable = allowEmpty || this.tabsList.length > 1;
+    }
+
+    if (isClosable) {
       const res = await this.closeWebContentsView(
         tabsMap[id].view,
         tabsMap[id].isLoading || tabsMap[id] === this.preloadedTab,

--- a/packages/core/src/web/app/actions/beambox/beambox-global-interaction.ts
+++ b/packages/core/src/web/app/actions/beambox/beambox-global-interaction.ts
@@ -1,4 +1,5 @@
 import tabController from '@core/app/actions/tabController';
+import { isAtPage } from '@core/helpers/hashHelper';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import menu from '@core/implementations/menu';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
@@ -12,30 +13,22 @@ getSVGAsync((globalSVG) => {
 class BeamboxGlobalInteraction {
   constructor() {
     tabController.onFocused(() => {
+      this.attach();
       this.onObjectBlur();
       this.onObjectFocus();
     });
   }
 
   attach() {
-    menu.attach([
-      'IMPORT',
-      'SAVE_SCENE',
-      'UNDO',
-      'REDO',
-      'EXPORT_FLUX_TASK',
-      'DOCUMENT_SETTING',
-      'CLEAR_SCENE',
-      'ZOOM_IN',
-      'ZOOM_OUT',
-      'AUTO_ALIGN',
-      'FITS_TO_WINDOW',
-      'ZOOM_WITH_WINDOW',
-      'SHOW_GRIDS',
-      'SHOW_LAYER_COLOR',
-      'NETWORK_TESTING',
-      'ABOUT_BEAM_STUDIO',
-    ]);
+    if (isAtPage('welcome')) {
+      menu.attach(['CLEAR_SCENE', 'OPEN', 'RECENT', 'SAMPLES']);
+    } else if (isAtPage('editor')) {
+      // enable all
+      menu.attach();
+    } else {
+      // disable all
+      menu.attach([]);
+    }
   }
 
   onObjectFocus(elems?: Element[]) {

--- a/packages/core/src/web/app/actions/beambox/menuActions.ts
+++ b/packages/core/src/web/app/actions/beambox/menuActions.ts
@@ -165,7 +165,6 @@ export default {
     });
   },
   START_UI_INTRO: (): void => Tutorials.startInterfaceTutorial(() => {}),
-  SVG_NEST: (): void => Dialog.showSvgNestButtons(),
   UNDO: (): void => {
     if (shortcuts.isInBaseScope()) {
       historyUtils.undo();

--- a/packages/core/src/web/app/actions/canvas/boundaryDrawer.ts
+++ b/packages/core/src/web/app/actions/canvas/boundaryDrawer.ts
@@ -293,7 +293,8 @@ export class BoundaryDrawer {
       if (isRotary || isAutoFeeder) {
         top = this.boundaries.autoFeeder?.top ?? 0;
         bottom = 0;
-      } else {
+      } else if (module !== LayerModule.PRINTER) {
+        // FIXME: Ador printer spec: height 270; Ignoring module offsets to keep workarea height consistent
         top += offsetY;
         bottom -= offsetY;
 

--- a/packages/core/src/web/app/actions/global.ts
+++ b/packages/core/src/web/app/actions/global.ts
@@ -35,7 +35,7 @@ export default (callback: () => void): void => {
   const { hash } = window.location;
   const isInitializePage = Boolean(hash.match(/^#\/?initialize/));
   const onFinished = (isReady: boolean) => {
-    if (isReady === true && (hash === '' || isInitializePage)) {
+    if ((isReady === true || window.homePage === hashMap.editor) && (hash === '' || isInitializePage)) {
       window.location.hash = getHomePage();
     } else if (isReady === false && !isInitializePage) {
       window.location.hash = hashMap.root;

--- a/packages/core/src/web/app/components/beambox/path-preview/SidePanel.module.scss
+++ b/packages/core/src/web/app/components/beambox/path-preview/SidePanel.module.scss
@@ -8,7 +8,7 @@
   padding: 0px;
   opacity: 1;
   overflow-x: visible;
-  overflow-y: scroll;
+  overflow-y: auto;
   transition: opacity 0.3s;
   border: 1px solid #e0e0e0;
   border-width: 0 0 0 1px;

--- a/packages/core/src/web/app/components/beambox/top-bar/TopBar.module.scss
+++ b/packages/core/src/web/app/components/beambox/top-bar/TopBar.module.scss
@@ -33,7 +33,6 @@
   .left {
     flex: 0 1 auto;
     overflow: hidden;
-    margin-left: 8px;
 
     &.space {
       margin-left: 80px;

--- a/packages/core/src/web/app/components/beambox/top-bar/TopBar.tsx
+++ b/packages/core/src/web/app/components/beambox/top-bar/TopBar.tsx
@@ -22,6 +22,7 @@ import ObjectPanelController from '@core/app/views/beambox/Right-Panels/contexts
 import Discover from '@core/helpers/api/discover';
 import checkSoftwareForAdor from '@core/helpers/check-software';
 import getIsWeb from '@core/helpers/is-web';
+import communicator from '@core/implementations/communicator';
 import storage from '@core/implementations/storage';
 
 import AutoFocusButton from './AutoFocusButton';
@@ -37,19 +38,23 @@ const UnmemorizedTopBar = (): React.JSX.Element => {
   const [hasDiscoveredMachine, setHasDiscoveredMachine] = useState(false);
   const defaultDeviceUUID = useRef<null | string>(storage.get('selected-device'));
   const [isTabFocused, setIsTabFocused] = useState(false);
+  const [isFullScreen, setIsFullScreen] = useState(false);
 
   useEffect(() => registerWindowUpdateTitle(), []);
 
   useEffect(() => {
     const onTabFocused = () => setIsTabFocused(true);
     const onTabBlurred = () => setIsTabFocused(false);
+    const onFullScreenChange = (_: unknown, isFullScreen: boolean) => setIsFullScreen(isFullScreen);
 
     tabController.onFocused(onTabFocused);
     tabController.onBlurred(onTabBlurred);
+    communicator.on('window-fullscreen', onFullScreenChange);
 
     return () => {
       tabController.offFocused(onTabFocused);
       tabController.offBlurred(onTabBlurred);
+      communicator.off('window-fullscreen', onFullScreenChange);
     };
   }, []);
 
@@ -82,7 +87,11 @@ const UnmemorizedTopBar = (): React.JSX.Element => {
         })}
         onClick={() => ObjectPanelController.updateActiveKey(null)}
       >
-        <div className={classNames(styles.controls, styles.left, { [styles.space]: isDragRegion || isWeb })}>
+        <div
+          className={classNames(styles.controls, styles.left, {
+            [styles.space]: (isDragRegion && !isFullScreen) || isWeb,
+          })}
+        >
           {isWeb ? (
             <>
               <WelcomePageButton />

--- a/packages/core/src/web/app/components/beambox/top-bar/tabs/Tabs.module.scss
+++ b/packages/core/src/web/app/components/beambox/top-bar/tabs/Tabs.module.scss
@@ -49,6 +49,12 @@
     &.small {
       min-width: 40px;
       max-width: 40px;
+      padding: 0;
+      justify-content: center;
+
+      .icon {
+        font-size: 20px;
+      }
     }
 
     &.focused {

--- a/packages/core/src/web/app/components/boxgen/Controller.module.scss
+++ b/packages/core/src/web/app/components/boxgen/Controller.module.scss
@@ -1,7 +1,7 @@
 .controller {
   flex: 1;
   padding: 20px 20px 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   @media screen and (max-width: 600px) {
     padding: 12px 12px 0;
   }

--- a/packages/core/src/web/app/components/dialogs/PresetsManagementPanel/PresetsManagementPanel.module.scss
+++ b/packages/core/src/web/app/components/dialogs/PresetsManagementPanel/PresetsManagementPanel.module.scss
@@ -149,7 +149,7 @@ div.modal-wrap {
       display: flex;
       gap: 12%;
       max-height: 200px;
-      overflow-y: scroll;
+      overflow-y: auto;
 
       > div {
         flex-grow: 1;

--- a/packages/core/src/web/app/components/dialogs/camera/common/Instruction.module.scss
+++ b/packages/core/src/web/app/components/dialogs/camera/common/Instruction.module.scss
@@ -13,5 +13,6 @@
     width: 100%;
     min-height: 225px;
     max-height: 400px;
+    margin: -1px;
   }
 }

--- a/packages/core/src/web/app/components/dialogs/myCloud/MyCloud.module.scss
+++ b/packages/core/src/web/app/components/dialogs/myCloud/MyCloud.module.scss
@@ -41,7 +41,7 @@ $content-height: 60vh;
 .grids {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(variables.$grid-width, 1fr));
-  overflow-y: scroll;
+  overflow-y: auto;
   gap: 20px 10px;
   height: $content-height;
 }

--- a/packages/core/src/web/app/components/pass-through/PassThrough.module.scss
+++ b/packages/core/src/web/app/components/pass-through/PassThrough.module.scss
@@ -3,7 +3,7 @@
 .controls {
   flex: 1;
   padding: 20px 40px 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   font-size: 14px;
   color: #1e1e1e;
 

--- a/packages/core/src/web/app/components/welcome/TabMyCloud.module.scss
+++ b/packages/core/src/web/app/components/welcome/TabMyCloud.module.scss
@@ -30,7 +30,7 @@
     auto-fill,
     minmax(myCloudVariables.$grid-width, 1fr)
   );
-  overflow-y: scroll;
+  overflow-y: auto;
   gap: 20px 10px;
 }
 

--- a/packages/core/src/web/app/components/welcome/TabRecentFiles.module.scss
+++ b/packages/core/src/web/app/components/welcome/TabRecentFiles.module.scss
@@ -11,7 +11,7 @@
     auto-fill,
     minmax(myCloudVariables.$grid-width, 1fr)
   );
-  overflow-y: scroll;
+  overflow-y: auto;
   gap: 20px 10px;
   @include mixins.content;
 }

--- a/packages/core/src/web/app/pages/Beambox.tsx
+++ b/packages/core/src/web/app/pages/Beambox.tsx
@@ -35,8 +35,6 @@ const beamboxInit = new BeamboxInit();
 const Beambox = (): React.JSX.Element => {
   React.useEffect(() => {
     window.homePage = hashMap.editor;
-    BeamboxGlobalInteraction.attach();
-
     communicator.send('FRONTEND_READY');
     // Init view
     workareaManager.resetView();

--- a/packages/core/src/web/app/pages/Welcome.module.scss
+++ b/packages/core/src/web/app/pages/Welcome.module.scss
@@ -11,14 +11,24 @@ $header-height: 60px;
     display: flex;
     background-color: #333333;
     height: variables.$topBarHeight;
-    padding-left: 80px;
+
+    ~ .content {
+      height: calc(
+        100% - $header-height - variables.$topBarHeight -
+          variables.$menuBarHeight
+      );
+    }
+
+    &.mac {
+      padding-left: variables.$windowControlsWidth;
+
+      ~ .content {
+        height: calc(100% - $header-height - variables.$topBarHeight);
+      }
+    }
 
     &.draggable {
       -webkit-app-region: drag;
-    }
-
-    ~ .content {
-      height: calc(100% - $header-height - variables.$topBarHeight);
     }
   }
 

--- a/packages/core/src/web/app/pages/Welcome.module.scss
+++ b/packages/core/src/web/app/pages/Welcome.module.scss
@@ -20,8 +20,6 @@ $header-height: 60px;
     }
 
     &.mac {
-      padding-left: variables.$windowControlsWidth;
-
       ~ .content {
         height: calc(100% - $header-height - variables.$topBarHeight);
       }
@@ -29,6 +27,10 @@ $header-height: 60px;
 
     &.draggable {
       -webkit-app-region: drag;
+    }
+
+    &.space {
+      padding-left: variables.$windowControlsWidth;
     }
   }
 

--- a/packages/core/src/web/app/pages/Welcome.module.scss
+++ b/packages/core/src/web/app/pages/Welcome.module.scss
@@ -71,7 +71,7 @@ $header-height: 60px;
         flex-direction: column;
         gap: 8px;
         font-size: 16px;
-        overflow-y: scroll;
+        overflow-y: auto;
         border-top: 1px solid $border-color;
 
         .menu-item {
@@ -121,7 +121,7 @@ $header-height: 60px;
       display: flex;
       flex-direction: column;
       gap: 32px;
-      overflow-y: scroll;
+      overflow-y: auto;
       @media screen and (min-width: 601px) {
         padding: 24px 60px 60px;
       }

--- a/packages/core/src/web/app/pages/Welcome.spec.tsx
+++ b/packages/core/src/web/app/pages/Welcome.spec.tsx
@@ -11,6 +11,11 @@ jest.mock('@core/app/components/welcome/TabMyCloud', () => 'mock-tab-my-cloud');
 jest.mock('@core/app/components/welcome/TabRecentFiles', () => 'mock-tab-recent-files');
 jest.mock('@core/app/components/welcome/UserInfo', () => 'mock-user-info');
 
+jest.mock('@core/app/actions/beambox/beambox-global-interaction', () => ({
+  attach: jest.fn(),
+  detach: jest.fn(),
+}));
+
 const mockClearScene = jest.fn();
 const mockImportImage = jest.fn();
 

--- a/packages/core/src/web/app/pages/Welcome.tsx
+++ b/packages/core/src/web/app/pages/Welcome.tsx
@@ -11,6 +11,7 @@ import {
 import { CapsuleTabs } from 'antd-mobile';
 import classNames from 'classnames';
 
+import beamboxGlobalInteraction from '@core/app/actions/beambox/beambox-global-interaction';
 import funcs from '@core/app/actions/beambox/svgeditor-function-wrapper';
 import tabController from '@core/app/actions/tabController';
 import Chat from '@core/app/components/beambox/svg-editor/Chat';
@@ -34,6 +35,7 @@ import isWeb from '@core/helpers/is-web';
 import { isMac, useIsMobile } from '@core/helpers/system-helper';
 import useI18n from '@core/helpers/useI18n';
 import browser from '@core/implementations/browser';
+import communicator from '@core/implementations/communicator';
 import type { IUser } from '@core/interfaces/IUser';
 
 import styles from './Welcome.module.scss';
@@ -104,8 +106,15 @@ const Welcome = (): ReactNode => {
       // Fix tab content after reset
       window.location.hash = hashMap.editor;
     } else {
+      communicator.on('NEW_APP_MENU', beamboxGlobalInteraction.attach);
+      beamboxGlobalInteraction.attach();
       window.homePage = hashMap.welcome;
       setIsLoading(false);
+
+      return () => {
+        beamboxGlobalInteraction.detach();
+        communicator.off('NEW_APP_MENU', beamboxGlobalInteraction.attach);
+      };
     }
   }, []);
 

--- a/packages/core/src/web/app/pages/Welcome.tsx
+++ b/packages/core/src/web/app/pages/Welcome.tsx
@@ -81,6 +81,7 @@ const Welcome = (): ReactNode => {
   const [isTabFocused, setIsTabFocused] = useState(true);
   const isDesktopMac = useMemo(() => !isWeb() && isMac(), []);
   const socialMedia = useMemo(() => getSocialMedia(), []);
+  const [isFullScreen, setIsFullScreen] = useState(false);
 
   const fetchBanners = useCallback(async () => {
     try {
@@ -106,14 +107,19 @@ const Welcome = (): ReactNode => {
       // Fix tab content after reset
       window.location.hash = hashMap.editor;
     } else {
+      const onFullScreenChange = (_: unknown, isFullScreen: boolean) => setIsFullScreen(isFullScreen);
+
+      communicator.on('window-fullscreen', onFullScreenChange);
       communicator.on('NEW_APP_MENU', beamboxGlobalInteraction.attach);
       beamboxGlobalInteraction.attach();
       window.homePage = hashMap.welcome;
       setIsLoading(false);
+      communicator.send('FRONTEND_READY');
 
       return () => {
         beamboxGlobalInteraction.detach();
         communicator.off('NEW_APP_MENU', beamboxGlobalInteraction.attach);
+        communicator.off('window-fullscreen', onFullScreenChange);
       };
     }
   }, []);
@@ -206,6 +212,7 @@ const Welcome = (): ReactNode => {
           className={classNames(styles['top-bar'], {
             [styles.draggable]: isDesktopMac && isTabFocused,
             [styles.mac]: isDesktopMac,
+            [styles.space]: isDesktopMac && !isFullScreen,
           })}
         >
           <Tabs inverse />

--- a/packages/core/src/web/app/pages/Welcome.tsx
+++ b/packages/core/src/web/app/pages/Welcome.tsx
@@ -79,7 +79,7 @@ const Welcome = (): ReactNode => {
   const [isLoading, setIsLoading] = useState(true);
   const setUser = useCallback((user: IUser | null) => setCurrentUser(user ? { ...user } : user), []);
   const [isTabFocused, setIsTabFocused] = useState(true);
-  const draggable = useMemo(() => !isWeb() && isMac(), []);
+  const isDesktopMac = useMemo(() => !isWeb() && isMac(), []);
   const socialMedia = useMemo(() => getSocialMedia(), []);
 
   const fetchBanners = useCallback(async () => {
@@ -119,7 +119,7 @@ const Welcome = (): ReactNode => {
   }, []);
 
   useEffect(() => {
-    if (draggable) {
+    if (isDesktopMac) {
       const onTabFocused = () => setIsTabFocused(true);
       const onTabBlurred = () => setIsTabFocused(false);
 
@@ -131,7 +131,7 @@ const Welcome = (): ReactNode => {
         tabController.offBlurred(onTabBlurred);
       };
     }
-  }, [draggable]);
+  }, [isDesktopMac]);
 
   useEffect(() => {
     fluxIDEvents.on('update-user', setUser);
@@ -202,7 +202,12 @@ const Welcome = (): ReactNode => {
   ) : (
     <div className={styles.container}>
       {!isWeb() && (
-        <div className={classNames(styles['top-bar'], { [styles.draggable]: draggable && isTabFocused })}>
+        <div
+          className={classNames(styles['top-bar'], {
+            [styles.draggable]: isDesktopMac && isTabFocused,
+            [styles.mac]: isDesktopMac,
+          })}
+        >
           <Tabs inverse />
         </div>
       )}

--- a/packages/core/src/web/app/pages/__snapshots__/Welcome.spec.tsx.snap
+++ b/packages/core/src/web/app/pages/__snapshots__/Welcome.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`test Welcome should render correctly 1`] = `
     class="container"
   >
     <div
-      class="top-bar draggable"
+      class="top-bar draggable mac space"
     >
       <mock-tabs
         inverse="true"
@@ -308,7 +308,7 @@ exports[`test Welcome should render correctly 2`] = `
     class="container"
   >
     <div
-      class="top-bar draggable"
+      class="top-bar draggable mac space"
     >
       <mock-tabs
         inverse="true"
@@ -607,7 +607,7 @@ exports[`test Welcome should render correctly in mobile 1`] = `
     class="container"
   >
     <div
-      class="top-bar draggable"
+      class="top-bar draggable mac space"
     >
       <mock-tabs
         inverse="true"
@@ -965,7 +965,7 @@ exports[`test Welcome should render correctly in mobile 2`] = `
     class="container"
   >
     <div
-      class="top-bar draggable"
+      class="top-bar draggable mac space"
     >
       <mock-tabs
         inverse="true"

--- a/packages/core/src/web/app/views/monitor/MonitorFilelist.module.scss
+++ b/packages/core/src/web/app/views/monitor/MonitorFilelist.module.scss
@@ -3,5 +3,5 @@
   flex-wrap: wrap;
   width: 100%;
   height: 400px;
-  overflow: scroll;
+  overflow: auto;
 }

--- a/packages/core/src/web/app/widgets/DraggableModal.module.scss
+++ b/packages/core/src/web/app/widgets/DraggableModal.module.scss
@@ -13,7 +13,7 @@
   }
 
   :global(.ant-modal-body) {
-    overflow: scroll;
+    overflow: auto;
   }
 
   :global(.ant-modal-footer) {

--- a/packages/core/src/web/helpers/menubar/AbstractMenu.ts
+++ b/packages/core/src/web/helpers/menubar/AbstractMenu.ts
@@ -13,23 +13,27 @@ import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
 type MenuActions = { [key: string]: (device?: IDeviceInfo) => void };
 
+/**
+ * Special menu items that should be disabled in certain pages
+ * Set `enabled: false` in electron menu and update them by attach/detach
+ */
 const MENU_ITEMS = [
-  'IMPORT',
-  'EXPORT_FLUX_TASK',
-  'SAVE_SCENE',
-  'UNDO',
-  'DUPLICATE',
-  'PHOTO_EDIT',
-  'DOCUMENT_SETTING',
-  'CLEAR_SCENE',
-  'ZOOM_IN',
-  'ZOOM_OUT',
-  'FITS_TO_WINDOW',
-  'ZOOM_WITH_WINDOW',
-  'SHOW_GRIDS',
-  'SHOW_LAYER_COLOR',
+  '_edit',
+  '_view',
+  '_tools',
   'NETWORK_TESTING',
-  'ABOUT_BEAM_STUDIO',
+  // _file
+  'CLEAR_SCENE',
+  'OPEN',
+  'RECENT',
+  'SAVE_AS',
+  'SAVE_SCENE',
+  'SAVE_TO_CLOUD',
+  'SAMPLES',
+  'EXPORT_TO',
+  // _help
+  'START_TUTORIAL',
+  'START_UI_INTRO',
 ];
 
 export default abstract class AbstractMenu {
@@ -110,14 +114,22 @@ export default abstract class AbstractMenu {
     }
   }
 
-  attach(enabledItems: string[]): void {
-    const disabledItems = [];
+  attach(enabledItems?: string[]): void {
+    let disabledItems: string[] = [];
 
-    for (const item of MENU_ITEMS) {
-      if (!enabledItems.includes(item)) {
-        disabledItems.push(item);
+    if (!enabledItems) {
+      enabledItems = MENU_ITEMS;
+    } else if (enabledItems.length === 0) {
+      enabledItems = [];
+      disabledItems = MENU_ITEMS;
+    } else {
+      for (const item of MENU_ITEMS) {
+        if (!enabledItems.includes(item)) {
+          disabledItems.push(item);
+        }
       }
     }
+
     this.enable(enabledItems);
     this.disable(disabledItems);
   }

--- a/packages/core/src/web/styles/_variables.scss
+++ b/packages/core/src/web/styles/_variables.scss
@@ -7,6 +7,8 @@ $welcomePageSidePanelWidth: 280px;
 $winSidePanelWidth: 258px;
 $panelBorderColor: #e0e0e0;
 $topBarHeight: 40px;
+$menuBarHeight: 30px; // for Windows
+$windowControlsWidth: 80px; // for Mac
 
 $primary-blue: #1890ff;
 $primary-gray: #1e1e1e;


### PR DESCRIPTION
1. Disable some menu items if not in editor page
2. No margin left in top bar when Mac Desktop is in full screen mode
3. Fix content height and top bar padding in Windows welcome page
4. Skip setup in editor tab (after reset)
5. Change some `overflow: scroll` to `overflow: auto` to hide scrollbar in Windows if not needed

Temporarily ignore Ador print offset when drawing boundary
