### PR TITLE
feat(clipboard): use counter and signature to record past shift

### DIFF
--- a/apps/web/cypress/e2e/right-panel/ador-layer.spec.ts
+++ b/apps/web/cypress/e2e/right-panel/ador-layer.spec.ts
@@ -56,7 +56,7 @@ describe('ador layer', () => {
     mergeLayer('Layer 2', 'Do you want to merge these layers into one Laser layer?');
   });
 
-  it('move to printing or laser layers', () => {
+  it.only('move to printing or laser layers', () => {
     cy.changeWorkarea('Ador');
     cy.get(`button[class*="${addLayerBtnPrefix}btn"]`).click({ force: true });
     change2PrintingModule();
@@ -67,6 +67,7 @@ describe('ador layer', () => {
     cy.get(`div[class*="${moduleBlockPrefix}select"] > .ant-select-selector`).should('have.text', 'Printing');
 
     const moveElement = (layer: string, expectedText: string) => {
+      cy.get('#svg_1').click({ force: true });
       cy.get('#svg_1').click({ force: true });
       cy.get('select[title="Move selected elements to a different layer"]').select(layer);
       cy.get('.ant-modal-title').should('have.text', expectedText);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
     "three": "^0.159.0",
     "ts-pattern": "^5.6.2",
     "use-image": "^1.1.1",
+    "uuid": "^11.1.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/copy.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/copy.ts
@@ -2,7 +2,6 @@ import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
 import { clipboardCore } from '../singleton';
-import { useClipboardStore } from '../useClipboardStore';
 
 let svgCanvas: ISVGCanvas;
 
@@ -12,10 +11,6 @@ getSVGAsync(({ Canvas }) => {
 
 export const copyElements = async (elems: Element[]): Promise<void> => {
   await clipboardCore.copyElements(elems);
-
-  const initialSignature = elems.map((el) => el.outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
-
-  useClipboardStore.getState().reset(initialSignature);
 };
 
 export const copySelectedElements = async (): Promise<void> => {

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/copy.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/copy.ts
@@ -13,8 +13,7 @@ getSVGAsync(({ Canvas }) => {
 export const copyElements = async (elems: Element[]): Promise<void> => {
   await clipboardCore.copyElements(elems);
 
-  const elements = await clipboardCore.getData();
-  const initialSignature = elements.map((el) => el.outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
+  const initialSignature = elems.map((el) => el.outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
 
   useClipboardStore.getState().reset(initialSignature);
 };

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/copy.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/copy.ts
@@ -2,6 +2,7 @@ import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
 import { clipboardCore } from '../singleton';
+import { useClipboardStore } from '../useClipboardStore';
 
 let svgCanvas: ISVGCanvas;
 
@@ -9,11 +10,19 @@ getSVGAsync(({ Canvas }) => {
   svgCanvas = Canvas;
 });
 
-export const copyElements = async (elems: Element[]): Promise<void> => clipboardCore.copyElements(elems);
+export const copyElements = async (elems: Element[]): Promise<void> => {
+  await clipboardCore.copyElements(elems);
+
+  const elements = await clipboardCore.getData();
+  const initialSignature = elements.map((el) => el.outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
+
+  useClipboardStore.getState().reset(initialSignature);
+};
 
 export const copySelectedElements = async (): Promise<void> => {
   const selectedElems = svgCanvas.getSelectedWithoutTempGroup();
 
   await copyElements(selectedElems);
+
   svgCanvas.tempGroupSelectedElements();
 };

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
@@ -146,21 +146,19 @@ export const pasteWithDefaultPosition = async (
     return null;
   }
 
-  const outerHTMLs = rawData.outerHTMLs;
+  const dataId = rawData.id;
 
-  if (outerHTMLs.length === 0) {
+  if (!dataId) {
     return null;
   }
 
-  const newSignature = outerHTMLs.map((outerHTML) => outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
-  const updateSignatureCommand = new updateSignatureClipboardCommand(newSignature);
+  const updateSignatureCommand = new updateSignatureClipboardCommand(dataId);
 
-  useClipboardStore.getState().updateSignature(newSignature);
+  useClipboardStore.getState().updateSignature(dataId);
 
   const consecutivePasteCounter = useClipboardStore.getState().counter;
   const offsetX = x * consecutivePasteCounter;
   const offsetY = y * consecutivePasteCounter;
-
   const pasteCommand = await pasteElements({ isSubCmd: true, type: 'inPlace', x: offsetX, y: offsetY });
 
   batchCommand.addSubCommand(updateSignatureCommand);

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
@@ -140,13 +140,19 @@ export const pasteWithDefaultPosition = async (
   y = 100,
 ): Promise<null | { cmd: IBatchCommand; elems: Element[] }> => {
   const batchCommand = new history.BatchCommand('Paste elements with default position');
-  const elements = await clipboardCore.getData();
+  const rawData = await clipboardCore.getRawData();
 
-  if (elements.length === 0) {
+  if (!rawData) {
     return null;
   }
 
-  const newSignature = elements.map((el) => el.outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
+  const outerHTMLs = rawData.outerHTMLs;
+
+  if (outerHTMLs.length === 0) {
+    return null;
+  }
+
+  const newSignature = outerHTMLs.map((outerHTML) => outerHTML.replace(/\s*id="[^"]*"/g, '')).join('');
   const updateSignatureCommand = new updateSignatureClipboardCommand(newSignature);
 
   useClipboardStore.getState().updateSignature(newSignature);

--- a/packages/core/src/web/app/svgedit/operations/clipboard/class/MemoryClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/class/MemoryClipboard.ts
@@ -1,4 +1,4 @@
-import type { ClipboardCore } from '@core/interfaces/Clipboard';
+import type { ClipboardCore, ClipboardData } from '@core/interfaces/Clipboard';
 
 import { Clipboard } from './Clipboard';
 
@@ -9,7 +9,12 @@ export class MemoryClipboard extends Clipboard implements ClipboardCore {
     this.clipboardData = [...elems];
   };
 
-  getRawData = async (): Promise<null> => null; // MemoryClipboard does not support raw data
+  getRawData = async (): Promise<ClipboardData> =>
+    // only provide outerHTMLs and source for paste signature check
+    ({
+      outerHTMLs: this.clipboardData.map((elem) => elem.outerHTML),
+      source: 'web',
+    }) as ClipboardData;
 
   getData = async (): Promise<Element[]> => this.clipboardData;
 

--- a/packages/core/src/web/app/svgedit/operations/clipboard/class/MemoryClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/class/MemoryClipboard.ts
@@ -13,9 +13,9 @@ export class MemoryClipboard extends Clipboard implements ClipboardCore {
     this.clipboardData = [...elems];
   };
 
-  getRawData = async (): Promise<ClipboardData> =>
+  getRawData = async (): Promise<ClipboardData | null> =>
     // only provide id and source for paste check
-    ({ id: this.id, source: 'web' }) as ClipboardData;
+    this.clipboardData.length ? ({ id: this.id, source: 'web' } as ClipboardData) : null;
 
   getData = async (): Promise<Element[]> => this.clipboardData;
 

--- a/packages/core/src/web/app/svgedit/operations/clipboard/class/MemoryClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/class/MemoryClipboard.ts
@@ -1,20 +1,21 @@
+import { v4 as uuid } from 'uuid';
+
 import type { ClipboardCore, ClipboardData } from '@core/interfaces/Clipboard';
 
 import { Clipboard } from './Clipboard';
 
 export class MemoryClipboard extends Clipboard implements ClipboardCore {
   private clipboardData: Element[] = [];
+  private id: string = '';
 
   protected writeDataToClipboard = async (elems: Element[]): Promise<void> => {
+    this.id = uuid();
     this.clipboardData = [...elems];
   };
 
   getRawData = async (): Promise<ClipboardData> =>
-    // only provide outerHTMLs and source for paste signature check
-    ({
-      outerHTMLs: this.clipboardData.map((elem) => elem.outerHTML),
-      source: 'web',
-    }) as ClipboardData;
+    // only provide id and source for paste check
+    ({ id: this.id, source: 'web' }) as ClipboardData;
 
   getData = async (): Promise<Element[]> => this.clipboardData;
 

--- a/packages/core/src/web/app/svgedit/operations/clipboard/class/NativeClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/class/NativeClipboard.ts
@@ -1,4 +1,5 @@
 import { match } from 'ts-pattern';
+import { v4 as uuid } from 'uuid';
 
 import tabController from '@core/app/actions/tabController';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
@@ -6,6 +7,7 @@ import type { ClipboardCore, ClipboardData, ClipboardElement } from '@core/inter
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
 import { updateSymbolStyle } from '../helpers/updateSymbolStyle';
+import { useClipboardStore } from '../useClipboardStore';
 
 import { Clipboard } from './Clipboard';
 
@@ -51,15 +53,16 @@ export class NativeClipboard extends Clipboard implements ClipboardCore {
   protected writeDataToClipboard = async (elems: Element[]): Promise<void> => {
     const serializedData: ClipboardData = {
       elements: [],
+      id: uuid(),
       imageData: {},
-      outerHTMLs: [],
       refs: {},
       source: String(tabController.currentId),
     };
 
+    useClipboardStore.getState().reset(serializedData.id);
+
     elems.forEach((elem) => {
       serializedData.elements.push(serializeElement(elem));
-      serializedData.outerHTMLs.push(elem.outerHTML);
     });
 
     const keys = Object.keys(this.refClipboard);

--- a/packages/core/src/web/app/svgedit/operations/clipboard/class/NativeClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/class/NativeClipboard.ts
@@ -52,11 +52,15 @@ export class NativeClipboard extends Clipboard implements ClipboardCore {
     const serializedData: ClipboardData = {
       elements: [],
       imageData: {},
+      outerHTMLs: [],
       refs: {},
       source: String(tabController.currentId),
     };
 
-    elems.forEach((elem) => serializedData.elements.push(serializeElement(elem)));
+    elems.forEach((elem) => {
+      serializedData.elements.push(serializeElement(elem));
+      serializedData.outerHTMLs.push(elem.outerHTML);
+    });
 
     const keys = Object.keys(this.refClipboard);
 

--- a/packages/core/src/web/app/svgedit/operations/clipboard/useClipboardStore.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/useClipboardStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+import type { ICommand } from '@core/interfaces/IHistory';
+
+import { BaseHistoryCommand } from '../../history/history';
+
+type State = {
+  counter: number;
+  signature: null | string;
+};
+
+type Action = {
+  reset: (initialSignature?: null | string) => void;
+  set: <K extends keyof State>(key: K, value: State[K]) => void;
+  updateSignature: (newSignature: string) => void;
+};
+
+export const useClipboardStore = create<Action & State>((set, get) => ({
+  counter: 0,
+  reset: (initialSignature = null) => set({ counter: 0, signature: initialSignature }),
+  set: (key, value) => set({ [key]: value }),
+  signature: null,
+  updateSignature: (newSignature) => {
+    const { counter, signature } = get();
+
+    set({ counter: newSignature === signature ? counter + 1 : 0, signature: newSignature });
+  },
+}));
+
+export class updateSignatureClipboardCommand extends BaseHistoryCommand implements ICommand {
+  type = () => 'updateSignatureClipboardCommand';
+  elements = () => [];
+  oldState: State = { counter: 0, signature: null };
+
+  constructor(private newSignature: string = '') {
+    super();
+    this.oldState = {
+      counter: useClipboardStore.getState().counter,
+      signature: useClipboardStore.getState().signature,
+    };
+  }
+
+  doApply = (): void => {
+    useClipboardStore.getState().updateSignature(this.newSignature);
+  };
+
+  doUnapply = (): void => {
+    useClipboardStore.getState().set('counter', this.oldState.counter);
+    useClipboardStore.getState().set('signature', this.oldState.signature);
+  };
+}

--- a/packages/core/src/web/interfaces/Clipboard.ts
+++ b/packages/core/src/web/interfaces/Clipboard.ts
@@ -13,6 +13,7 @@ export interface ClipboardElement {
 export interface ClipboardData {
   elements: ClipboardElement[];
   imageData: Record<string, string>;
+  outerHTMLs: string[];
   refs: Record<string, ClipboardElement>;
   // The source of the clipboard data, e.g., the current tab ID.
   // This can be used to identify where the clipboard data originated from.

--- a/packages/core/src/web/interfaces/Clipboard.ts
+++ b/packages/core/src/web/interfaces/Clipboard.ts
@@ -12,8 +12,8 @@ export interface ClipboardElement {
 
 export interface ClipboardData {
   elements: ClipboardElement[];
+  id: string;
   imageData: Record<string, string>;
-  outerHTMLs: string[];
   refs: Record<string, ClipboardElement>;
   // The source of the clipboard data, e.g., the current tab ID.
   // This can be used to identify where the clipboard data originated from.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,7 +412,7 @@ importers:
         version: 3.1.1(webpack@5.99.9)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.16.9)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(typescript@5.8.3))
+        version: 29.7.0(@types/node@22.15.31)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.15.31)(typescript@5.8.3))
       mini-css-extract-plugin:
         specifier: ^2.9.2
         version: 2.9.2(webpack@5.99.9)
@@ -430,7 +430,7 @@ importers:
         version: 3.3.4(webpack@5.99.9)
       ts-jest:
         specifier: 29.2.6
-        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.16.9)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.15.31)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.15.31)(typescript@5.8.3)))(typescript@5.8.3)
       ts-loader:
         specifier: ^9.1.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.99.9)
@@ -608,6 +608,9 @@ importers:
       use-image:
         specifier: ^1.1.1
         version: 1.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       zustand:
         specifier: ^5.0.3
         version: 5.0.5(@types/react@18.3.23)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
@@ -10500,6 +10503,10 @@ packages:
 
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -23330,6 +23337,8 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
     optional: true
+
+  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## Overview

1. [feat(clipboard): use counter and signature to record past shift](https://github.com/flux3dp/beam-studio/commit/4ec65f7dd6f7f6b3ba44dcf3cfe3da34f9322baa)