### PR TITLE
Add filter in app.cd scripts

### DIFF
--- a/.github/workflows/app.cd.linux.yml
+++ b/.github/workflows/app.cd.linux.yml
@@ -81,8 +81,8 @@ jobs:
 
       - name: Build Beam Studio
         run: |
-          pnpm -r install
-          pnpm dlx nx run app:build
+          pnpm -r install --filter="." --filter="app" --filter="core"
+          pnpm nx run app:build
 
       - name: Sign and Publish
         run: |
@@ -109,7 +109,7 @@ jobs:
           fi
           echo $PUBLISH_PATH
 
-          pnpm dlx nx run app:dist --publish always
+          pnpm nx run app:dist --publish always
         env:
           PUBLISH_BUCKET: beamstudio
           PUBLISH_SUFFIX: ${{ github.event.inputs.publish_suffix || '' }}

--- a/.github/workflows/app.cd.mac.yml
+++ b/.github/workflows/app.cd.mac.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build Beam Studio
         run: |
           pnpm -r install --filter="app" --filter="core"
-          pnpm nx reset
+          pnpm dlx nx reset
           pnpm dlx nx run app:build
 
       # It is said codesign --deep is not a good practice, but it is the only way to sign Swiftray successfully

--- a/.github/workflows/app.cd.mac.yml
+++ b/.github/workflows/app.cd.mac.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Build Beam Studio
         run: |
           pnpm -r install --filter="app" --filter="core"
+          pnpm nx reset
           pnpm dlx nx run app:build
 
       # It is said codesign --deep is not a good practice, but it is the only way to sign Swiftray successfully

--- a/.github/workflows/app.cd.mac.yml
+++ b/.github/workflows/app.cd.mac.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Beamify
         run: |
           cd ./apps/app/.github/actions/beamify/python
-          python3 setup.py install --verbose || echo "Failed to install beamify"
+          python3 setup.py install --verbose
 
       - name: Install Fluxsvg
         uses: flux3dp/fluxsvg@2.7.7
@@ -79,7 +79,7 @@ jobs:
       - name: Install FluxClient
         run: |
           cd ./apps/app/.github/actions/fluxclient
-          python3 setup.py install --verbose || echo "Failed to install fluxclient"
+          python3 setup.py install --verbose
 
       - name: Build Flux Ghost
         uses: flux3dp/fluxghost@2.5.0

--- a/.github/workflows/app.cd.mac.yml
+++ b/.github/workflows/app.cd.mac.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build Beam Studio
         run: |
-          pnpm -r install
+          pnpm -r install --filter="app" --filter="core"
           pnpm dlx nx run app:build
 
       # It is said codesign --deep is not a good practice, but it is the only way to sign Swiftray successfully

--- a/.github/workflows/app.cd.mac.yml
+++ b/.github/workflows/app.cd.mac.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build Beam Studio
         run: |
-          pnpm -r install --filter="app" --filter="core"
+          pnpm -r install --filter="." --filter="app" --filter="core"
           pnpm dlx nx reset
           pnpm dlx nx run app:build
 

--- a/.github/workflows/app.cd.mac.yml
+++ b/.github/workflows/app.cd.mac.yml
@@ -96,8 +96,7 @@ jobs:
       - name: Build Beam Studio
         run: |
           pnpm -r install --filter="." --filter="app" --filter="core"
-          pnpm dlx nx reset
-          pnpm dlx nx run app:build
+          pnpm nx run app:build
 
       # It is said codesign --deep is not a good practice, but it is the only way to sign Swiftray successfully
       # https://developer.apple.com/forums/thread/129980
@@ -138,9 +137,9 @@ jobs:
           echo "Building for macOS ${BUILD_ARCH}..."
           if [ "$BUILD_ARCH" = "arm64" ]; then
             export PUBLISH_PATH="-arm64"
-            pnpm dlx nx run app:dist --arm64 --publish always
+            pnpm nx run app:dist --arm64 --publish always
           else
-            pnpm dlx nx run app:dist --x64 --publish always
+            pnpm nx run app:dist --x64 --publish always
           fi
 
 

--- a/.github/workflows/app.cd.x64.yml
+++ b/.github/workflows/app.cd.x64.yml
@@ -94,8 +94,8 @@ jobs:
 
       - name: Build Beam Studio
         run: |
-          pnpm -r install
-          pnpm dlx nx run app:build
+          pnpm -r install --filter="." --filter="app" --filter="core"
+          pnpm nx run app:build
 
       - name: Sign and Publish
         shell: bash
@@ -120,7 +120,7 @@ jobs:
 
           bash ./build/clearup-develop-files.sh
 
-          pnpm dlx nx run app:dist --win --x64 --publish always
+          pnpm nx run app:dist --win --x64 --publish always
         env:
           PUBLISH_BUCKET: beamstudio
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.13.0",
+    "@nx/cypress": "20.0.10",
     "@svgr/webpack": "^8.1.0",
     "@testing-library/cypress": "^10.0.1",
     "@types/file-saver": "^2.0.7",

--- a/nx.json
+++ b/nx.json
@@ -33,15 +33,6 @@
       "options": {
         "targetName": "test"
       }
-    },
-    {
-      "plugin": "@nx/cypress/plugin",
-      "options": {
-        "targetName": "e2e",
-        "ciTargetName": "e2e-ci",
-        "componentTestingTargetName": "component-test",
-        "openTargetName": "open-cypress"
-      }
     }
   ],
   "targetDefaults": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@babel/core": "^7.26.9",
     "@babel/preset-react": "^7.14.5",
     "@eslint/js": "^9.8.0",
-    "@nx/cypress": "20.0.10",
     "@nx/devkit": "20.0.10",
     "@nx/eslint": "20.0.10",
     "@nx/eslint-plugin": "20.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.28.0
-      '@nx/cypress':
-        specifier: 20.0.10
-        version: 20.0.10(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.22)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(cypress@13.6.2)(eslint@9.28.0)(nx@20.0.10(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.22)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.8.3)
       '@nx/devkit':
         specifier: 20.0.10
         version: 20.0.10(nx@20.0.10(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.22)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -356,6 +353,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.13.0
         version: 7.27.1(@babel/core@7.26.9)
+      '@nx/cypress':
+        specifier: 20.0.10
+        version: 20.0.10(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.22)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(cypress@13.6.2)(eslint@9.28.0)(nx@20.0.10(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.22)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.8.3)
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.8.3)
@@ -412,7 +412,7 @@ importers:
         version: 3.1.1(webpack@5.99.9)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.31)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.15.31)(typescript@5.8.3))
+        version: 29.7.0(@types/node@18.16.9)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(typescript@5.8.3))
       mini-css-extract-plugin:
         specifier: ^2.9.2
         version: 2.9.2(webpack@5.99.9)
@@ -430,7 +430,7 @@ importers:
         version: 3.3.4(webpack@5.99.9)
       ts-jest:
         specifier: 29.2.6
-        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.15.31)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.15.31)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@18.16.9)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(typescript@5.8.3)))(typescript@5.8.3)
       ts-loader:
         specifier: ^9.1.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.99.9)


### PR DESCRIPTION
when building, pnpm install now still download web dependencies like cypress.
However, downloading cypress  may occur unknown error sometimes.
(e.g. https://github.com/flux3dp/beam-studio/actions/runs/16954974942/job/48061329792)
Add `--filter` to avoid this.
Also remove cypress from root `package.json` and `nx.json`
As a result, to run cypress use `pnpm nx run web:cy:dev` now