### PR TITLE
fix: convert to image pop progress too early

### DIFF
--- a/packages/core/src/web/helpers/convertToImage/index.ts
+++ b/packages/core/src/web/helpers/convertToImage/index.ts
@@ -59,6 +59,7 @@ export const convertSvgToImage: MainConverterFunc = async ({
       id: 'convert-svg-to-image',
       message: i18n.lang.beambox.photo_edit_panel.processing,
     });
+    requestAnimationFrame(() => {});
   }
 
   const layer = pipe(svgElement, getLayerTitles, sortLayerNamesByPosition, (titles) => titles.at(-1));
@@ -116,7 +117,10 @@ export const convertSvgToImage: MainConverterFunc = async ({
       await waitForHrefTransformation(result.imageElements);
     } catch (error) {
       console.error('Error waiting for image loads:', error);
-      progressCaller.popById('convert-svg-to-image');
+
+      if (isToSelect) {
+        progressCaller.popById('convert-svg-to-image');
+      }
 
       return undefined;
     }
@@ -137,7 +141,9 @@ export const convertSvgToImage: MainConverterFunc = async ({
     undoManager.addCommandToHistory(parentCmd);
   }
 
-  progressCaller.popById('convert-svg-to-image');
+  if (isToSelect) {
+    progressCaller.popById('convert-svg-to-image');
+  }
 
   return result;
 };

--- a/packages/core/src/web/helpers/convertToImage/index.ts
+++ b/packages/core/src/web/helpers/convertToImage/index.ts
@@ -74,14 +74,11 @@ export const convertSvgToImage: MainConverterFunc = async ({
         return await convertSvgToImage({ isToSelect: false, parentCmd, svgElement: group });
       },
     )
-    .with(
-      { tagName: 'g' },
-      async (el) => await convertGroupToImage({ isToSelect, parentCmd, svgElement: el }, convertSvgToImage),
-    )
+    .with({ tagName: 'g' }, async (el) => await convertGroupToImage({ parentCmd, svgElement: el }, convertSvgToImage))
     .with({ tagName: 'text' }, async (el) => {
       const { path } = await convertTextToPath({ element: el, isToSelect: false, parentCommand: parentCmd });
 
-      return await convertSvgToImage({ isToSelect, parentCmd, svgElement: path! });
+      return await convertSvgToImage({ isToSelect: false, parentCmd, svgElement: path! });
     })
     .with(
       { tagName: P.union(...convertibleSvgTags) },


### PR DESCRIPTION
## Overview

1. [fix: pop progress too early](https://github.com/flux3dp/beam-studio/commit/93f8afbff0663ebf750524d96edd31078fed1af1)
2. [fix: single text element convert to image might duplicate](https://github.com/flux3dp/beam-studio/commit/4dcdfd5b3aa39edf9c1b3c5d340370bf95726962)