### PR TITLE
Update path simplify

### DIFF
--- a/packages/core/src/web/app/views/beambox/Right-Panels/ActionsPanel.tsx
+++ b/packages/core/src/web/app/views/beambox/Right-Panels/ActionsPanel.tsx
@@ -506,6 +506,7 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
 
   const renderMultiSelectActions = (): React.JSX.Element[] => {
     const children = Array.from(elem.childNodes) as SVGElement[];
+    const onlyPaths = children.every((child) => child.nodeName === 'path');
     let content: React.JSX.Element[] = [];
 
     const appendOptionalButtons = (buttons: React.JSX.Element[]) => {
@@ -548,7 +549,7 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
 
     appendOptionalButtons(content);
 
-    return [
+    const buttons = [
       renderAutoFitButton(),
       ...content,
       renderSmartNestButton(),
@@ -556,6 +557,21 @@ const ActionsPanel = ({ elem }: Props): React.JSX.Element => {
       renderOffsetButton(),
       renderArrayButton(),
     ];
+
+    if (onlyPaths) {
+      buttons.push(
+        renderButtons(
+          'simplify',
+          lang.simplify,
+          () => svgCanvas.simplifyPath(),
+          <ActionPanelIcons.Simplify />,
+          <ActionPanelIcons.SimplifyMobile />,
+          { isFullLine: true },
+        ),
+      );
+    }
+
+    return buttons;
   };
 
   const content = match(elem?.tagName.toLowerCase())

--- a/packages/core/src/web/helpers/bezier-fit-curve.ts
+++ b/packages/core/src/web/helpers/bezier-fit-curve.ts
@@ -15,23 +15,23 @@ interface Segment2D {
 
 let output = [] as Segment2D[];
 
-export const fitPath = (points: vector2D[]) => {
+export const fitPath = (points: vector2D[], totalDist?: number) => {
   output = [];
 
   let start = 0;
   let currentVector = v2Sub(points[0], points[points.length - 1]);
   let accumulatedDist = 0;
 
-  for (let i = 1; i < points.length; i += 1) {
-    const point = points[i];
-    const dist = Math.hypot(point.x - points[i - 1].x, point.y - points[i - 1].y);
+  if (!totalDist) {
+    for (let i = 1; i < points.length; i += 1) {
+      const point = points[i];
+      const dist = Math.hypot(point.x - points[i - 1].x, point.y - points[i - 1].y);
 
-    accumulatedDist += dist;
+      accumulatedDist += dist;
+    }
+    totalDist = accumulatedDist;
+    accumulatedDist = 0;
   }
-
-  const totalDist = accumulatedDist;
-
-  accumulatedDist = 0;
 
   const allowedDist = Math.min(totalDist / allowedDistFactor, minAllowedDist);
 
@@ -82,7 +82,7 @@ const fitSegment = (
   const allowedIterationError = allowedError > 1 ? allowedError * allowedError : Math.sqrt(allowedError);
   const numPoints = end - start + 1;
 
-  if (numPoints === 1) {
+  if (numPoints === 1 || allowedError === 0) {
     return;
   }
 


### PR DESCRIPTION
1. Allow to call simplify when selecting multiple path elements
2. Fix simplified results may be longer
   a. Ignore curve commands (Temp fix)
   b. Remove redundant points
3. Fix `fill-opacity` changed to '0' on second call by updating d instead of creating a new element
fill-opacity 1 was removed in addSvgElementFromJson and regarded as 0 on next time
4. Fix infinite stack in fitSegment when all points are same (i.e. allowedError === 0)
