### PR TITLE
Update bm2 calibration file length

### DIFF
--- a/packages/core/src/web/assets/assets/bm2-4c-scene-args.txt
+++ b/packages/core/src/web/assets/assets/bm2-4c-scene-args.txt
@@ -1,1 +1,1 @@
-svgeditor_upload bm2-4c-calibration 5069 998 -workarea [360,280] -model fbm2 -mdpi
+svgeditor_upload bm2-4c-calibration 5044 998 -workarea [360,280] -model fbm2 -mdpi


### PR DESCRIPTION
Removed attribute ` data-ceZSpeedLimit="140"` length = 25