### PR TITLE
Fix beamo2 preview when auto exposure is on

### DIFF
--- a/packages/core/src/web/app/actions/camera/preview-helper/Beamo2PreviewManager.ts
+++ b/packages/core/src/web/app/actions/camera/preview-helper/Beamo2PreviewManager.ts
@@ -273,19 +273,21 @@ class Beamo2PreviewManager extends RegionPreviewMixin(BasePreviewManager) implem
         if (darkImageUrl) setMaskImage(darkImageUrl, 'fbm2Camera');
       };
 
-      await takePictures(true);
-      this.showMessage({ content: i18n.lang.message.preview.capturing_image });
-      await takePictures(false);
-
-      if (originalAutoExposure !== null) {
-        try {
-          await deviceMaster.setCameraExposureAuto(originalAutoExposure);
-        } catch (error) {
-          console.error('Failed to reset auto exposure setting', error);
+      try {
+        await takePictures(true);
+        this.showMessage({ content: i18n.lang.message.preview.capturing_image });
+        await takePictures(false);
+      } finally {
+        if (originalAutoExposure !== null) {
+          try {
+            await deviceMaster.setCameraExposureAuto(originalAutoExposure);
+          } catch (error) {
+            console.error('Failed to reset auto exposure setting', error);
+          }
         }
-      }
 
-      this.originalExposure = null;
+        this.originalExposure = null;
+      }
 
       this.showMessage({ content: i18n.lang.message.preview.succeeded, duration: 3, level: MessageLevel.SUCCESS });
 

--- a/packages/core/src/web/app/actions/camera/preview-helper/Beamo2PreviewManager.ts
+++ b/packages/core/src/web/app/actions/camera/preview-helper/Beamo2PreviewManager.ts
@@ -230,6 +230,14 @@ class Beamo2PreviewManager extends RegionPreviewMixin(BasePreviewManager) implem
         console.error('Failed to get camera exposure auto', error);
       }
 
+      if (originalAutoExposure) {
+        try {
+          await deviceMaster.setCameraExposureAuto(false);
+        } catch (error) {
+          console.error('Failed to set camera exposure auto to false', error);
+        }
+      }
+
       try {
         const getExposureRes = await deviceMaster.getCameraExposure();
 
@@ -260,14 +268,6 @@ class Beamo2PreviewManager extends RegionPreviewMixin(BasePreviewManager) implem
           darkImageUrl = await this.getPhotoFromMachine({ useLowResolution });
         }
 
-        if (originalAutoExposure !== null) {
-          try {
-            await deviceMaster.setCameraExposureAuto(originalAutoExposure);
-          } catch (error) {
-            console.error('Failed to reset auto exposure setting', error);
-          }
-        }
-
         await new Promise<void>((resolve) => previewModeBackgroundDrawer.drawFullWorkarea(lightImageUrl, resolve));
 
         if (darkImageUrl) setMaskImage(darkImageUrl, 'fbm2Camera');
@@ -276,6 +276,15 @@ class Beamo2PreviewManager extends RegionPreviewMixin(BasePreviewManager) implem
       await takePictures(true);
       this.showMessage({ content: i18n.lang.message.preview.capturing_image });
       await takePictures(false);
+
+      if (originalAutoExposure !== null) {
+        try {
+          await deviceMaster.setCameraExposureAuto(originalAutoExposure);
+        } catch (error) {
+          console.error('Failed to reset auto exposure setting', error);
+        }
+      }
+
       this.originalExposure = null;
 
       this.showMessage({ content: i18n.lang.message.preview.succeeded, duration: 3, level: MessageLevel.SUCCESS });

--- a/packages/core/src/web/app/components/beambox/SvgEditor/PreviewSlider.tsx
+++ b/packages/core/src/web/app/components/beambox/SvgEditor/PreviewSlider.tsx
@@ -97,7 +97,7 @@ const PreviewSlider = (): React.ReactNode => {
     return true;
   }, [autoExposure, previewMode]);
 
-  if (!exposureSetting || (Boolean(autoExposure) && !showAutoExposure)) {
+  if (!exposureSetting) {
     return <div className={styles.notSupported}>{lang.not_supported}</div>;
   }
 
@@ -107,7 +107,7 @@ const PreviewSlider = (): React.ReactNode => {
     >
       <Slider
         className={styles.slider}
-        disabled={(isRawMode && isDrawing) || Boolean(autoExposure)}
+        disabled={(isRawMode && isDrawing) || (Boolean(autoExposure) && showAutoExposure)}
         max={Math.min(exposureSetting.max, 2000)}
         min={Math.max(exposureSetting.min, 50)}
         onChange={(value: number) => setExposureSetting({ ...exposureSetting, value })}


### PR DESCRIPTION
1. Still show preview slider for full area preview in fbm2
2. Turn off auto exposure before preview_full_area in fbm2
3. Fix set back auto exposure timing