### PR TITLE
Support ssl-ip based websocket secure protocol

### DIFF
--- a/packages/core/src/web/helpers/api/discover.ts
+++ b/packages/core/src/web/helpers/api/discover.ts
@@ -15,6 +15,7 @@ import communicator from '@core/implementations/communicator';
 import network from '@core/implementations/network';
 import storage from '@core/implementations/storage';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
+import type { WrappedWebSocket } from '@core/interfaces/WebSocket';
 
 import { swiftrayClient } from './swiftray-client';
 
@@ -41,7 +42,7 @@ export class DiscoverManager {
   protected swiftrayDevices: Record<string, IDeviceInfo> = {};
   protected initialized = false;
   private isMaster = false;
-  private ws: any;
+  private ws: null | WrappedWebSocket = null;
   private pokeIPs: string[] = [];
   private intervals: NodeJS.Timeout[] = [];
 

--- a/packages/core/src/web/helpers/handleAutoConnect.ts
+++ b/packages/core/src/web/helpers/handleAutoConnect.ts
@@ -8,6 +8,7 @@ import checkIPFormat from '@core/helpers/check-ip-format';
 import i18n from '@core/helpers/i18n';
 import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
 import isJson from '@core/helpers/is-json';
+import { raceWebSockets, toSslIpHostname } from '@core/helpers/sslIpHelper';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
 const MESSAGE_KEY = 'qr-auto-connect';
@@ -57,25 +58,20 @@ function parseAndValidateIPs(param: string): string[] {
 
 /**
  * Probe a machine via WebSocket to verify it's a valid FLUX device.
+ * Races WSS and WS in parallel, preferring WSS within its probe window.
  * Returns device info if successful, null otherwise.
  */
 function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promise<IDeviceInfo | null> {
   return new Promise((resolve) => {
-    const url = `ws://${ip}:${port}/ws/discover`;
-    let ws: InsecureWebsocket | null | WebSocket = null;
     let resolved = false;
+    let cleanupSockets: (() => void) | null = null;
 
     const cleanup = (result: IDeviceInfo | null) => {
       if (resolved) return;
 
       resolved = true;
       clearTimeout(timeoutId);
-
-      try {
-        ws?.close();
-      } catch {
-        // Ignore close errors
-      }
+      cleanupSockets?.();
 
       resolve(result);
     };
@@ -85,18 +81,13 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
       cleanup(null);
     }, PROBE_TIMEOUT_MS);
 
-    try {
-      const useInsecure = window.location.protocol === 'https:' && checkFluxTunnel();
-      const WebSocketClass = useInsecure ? InsecureWebsocket : WebSocket;
+    const sendPoke = (socket: InsecureWebsocket | WebSocket) => {
+      console.log(`QR Auto-Connect: WebSocket opened to ${ip}`);
+      socket.send(JSON.stringify({ cmd: 'poke', ipaddr: ip }));
+    };
 
-      ws = new WebSocketClass(url);
-
-      ws.onopen = () => {
-        console.log(`QR Auto-Connect: WebSocket opened to ${ip}`);
-        ws?.send(JSON.stringify({ cmd: 'poke', ipaddr: ip }));
-      };
-
-      ws.onmessage = (event: MessageEvent) => {
+    const attachMessageHandler = (socket: InsecureWebsocket | WebSocket) => {
+      socket.onmessage = (event: MessageEvent) => {
         try {
           const data = isJson(event.data) ? JSON.parse(event.data) : event.data;
 
@@ -109,16 +100,35 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
         }
       };
 
-      ws.onerror = () => {
+      socket.onerror = () => {
         console.log(`QR Auto-Connect: WebSocket error for ${ip}`);
         cleanup(null);
       };
 
-      ws.onclose = () => cleanup(null);
-    } catch (e) {
-      console.warn(`QR Auto-Connect: Failed to create WebSocket for ${ip}:`, e);
-      cleanup(null);
-    }
+      socket.onclose = () => cleanup(null);
+    };
+
+    // Race WSS and WS in parallel, preferring WSS within its probe window
+    const wssUrl = `wss://${toSslIpHostname(ip)}:${port}/ws/discover`;
+    const wsUrl = `ws://${ip}:${port}/ws/discover`;
+    const useInsecure = window.location.protocol === 'https:' && checkFluxTunnel();
+    const WebSocketClass = useInsecure ? InsecureWebsocket : WebSocket;
+
+    const result = raceWebSockets({
+      createFallback: () => new WebSocketClass(wsUrl),
+      createPreferred: () => new WebSocket(wssUrl),
+      onAllFailed: () => cleanup(null),
+      onSettled: (winner) => {
+        attachMessageHandler(winner);
+        sendPoke(winner);
+      },
+    });
+
+    cleanupSockets = () => {
+      result.cancel();
+      result.preferredSocket?.close();
+      result.fallbackSocket?.close();
+    };
   });
 }
 

--- a/packages/core/src/web/helpers/handleAutoConnect.ts
+++ b/packages/core/src/web/helpers/handleAutoConnect.ts
@@ -6,9 +6,8 @@ import TopBarController from '@core/app/components/beambox/TopBar/contexts/TopBa
 import { finishWithDevice } from '@core/app/pages/InitializeMachine/ConnectMachineIp/utils/finishWithDevice';
 import checkIPFormat from '@core/helpers/check-ip-format';
 import i18n from '@core/helpers/i18n';
-import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
 import isJson from '@core/helpers/is-json';
-import { raceWebSockets, toSslIpHostname } from '@core/helpers/sslIpHelper';
+import { connectWebSocket } from '@core/helpers/sslIpHelper';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
 const MESSAGE_KEY = 'qr-auto-connect';
@@ -81,12 +80,12 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
       cleanup(null);
     }, PROBE_TIMEOUT_MS);
 
-    const sendPoke = (socket: InsecureWebsocket | WebSocket) => {
+    const sendPoke = (socket: WebSocket) => {
       console.log(`QR Auto-Connect: WebSocket opened to ${ip}`);
       socket.send(JSON.stringify({ cmd: 'poke', ipaddr: ip }));
     };
 
-    const attachMessageHandler = (socket: InsecureWebsocket | WebSocket) => {
+    const attachMessageHandler = (socket: WebSocket) => {
       socket.onmessage = (event: MessageEvent) => {
         try {
           const data = isJson(event.data) ? JSON.parse(event.data) : event.data;
@@ -109,25 +108,21 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
     };
 
     // Race WSS and WS in parallel, preferring WSS within its probe window
-    const wssUrl = `wss://${toSslIpHostname(ip)}:${port}/ws/discover`;
-    const wsUrl = `ws://${ip}:${port}/ws/discover`;
-    const useInsecure = window.location.protocol === 'https:' && checkFluxTunnel();
-    const WebSocketClass = useInsecure ? InsecureWebsocket : WebSocket;
-
-    const result = raceWebSockets({
-      createFallback: () => new WebSocketClass(wsUrl),
-      createPreferred: () => new WebSocket(wssUrl),
-      onAllFailed: () => cleanup(null),
-      onSettled: (winner) => {
-        attachMessageHandler(winner);
-        sendPoke(winner);
+    const result = connectWebSocket({
+      hostname: ip,
+      method: 'discover',
+      onFailed: () => cleanup(null),
+      onSettled: (socket) => {
+        attachMessageHandler(socket as WebSocket);
+        sendPoke(socket as WebSocket);
       },
+      port,
     });
 
     cleanupSockets = () => {
       result.cancel();
-      result.preferredSocket?.close();
-      result.fallbackSocket?.close();
+      result.wssSocket?.close();
+      result.wsSocket?.close();
     };
   });
 }

--- a/packages/core/src/web/helpers/handleAutoConnect.ts
+++ b/packages/core/src/web/helpers/handleAutoConnect.ts
@@ -64,6 +64,7 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
   return new Promise((resolve) => {
     let resolved = false;
     let cleanupSockets: (() => void) | null = null;
+    let ws: null | WebSocket = null;
 
     const cleanup = (result: IDeviceInfo | null) => {
       if (resolved) return;
@@ -113,6 +114,7 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
       method: 'discover',
       onFailed: () => cleanup(null),
       onSettled: (socket) => {
+        ws = socket as WebSocket;
         attachMessageHandler(socket as WebSocket);
         sendPoke(socket as WebSocket);
       },
@@ -121,8 +123,7 @@ function probeDeviceDirectly(ip: string, port: string = DEFAULT_WEB_PORT): Promi
 
     cleanupSockets = () => {
       result.cancel();
-      result.wssSocket?.close();
-      result.wsSocket?.close();
+      ws?.close();
     };
   });
 }

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -1,28 +1,30 @@
-import type InsecureWebsocket from '@core/helpers/InsecureWebsocket';
+import checkIPFormat from '@core/helpers/check-ip-format';
+import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
+import isWeb from '@core/helpers/is-web';
 
 export const toSslIpHostname = (ip: string): string => `${ip.replaceAll('.', '-')}.sslip.flux3dp.com`;
 
+const WSS_PORT = 8443;
 const DEFAULT_TIMEOUT_MS = 10000;
 
 type Socket = InsecureWebsocket | WebSocket;
 
-export interface RaceWebSocketsOptions {
-  /** Factory for the fallback socket (e.g. WS). Null if construction fails. */
-  createFallback: () => null | Socket;
-  /** Factory for the preferred socket (e.g. WSS). Null if construction fails. */
-  createPreferred: () => null | Socket;
+export interface ConnectWebSocketOptions {
+  hostname: string;
+  method: string;
   /** Called when both sockets fail */
-  onAllFailed: () => void;
+  onFailed: () => void;
   /** Called when a winner connects */
-  onSettled: (winner: Socket, isPreferred: boolean, openEvent: Event | null) => void;
-  /** Timeout — preferred gets this window to connect; when expired, settle with fallback if ready, otherwise fail. Omit if caller manages timeout externally. */
+  onSettled: (winner: Socket, openEvent: Event | null) => void;
+  port: number | string;
+  /** Timeout — WSS gets this window to connect; when expired, settle with WS if ready, otherwise fail. */
   timeoutMs?: number;
 }
 
-export interface RaceWebSocketsResult {
+export interface ConnectWebSocketResult {
   cancel: () => void;
-  fallbackSocket: null | Socket;
-  preferredSocket: null | Socket;
+  wsSocket: null | Socket;
+  wssSocket: null | Socket;
 }
 
 const noop = () => {};
@@ -43,43 +45,55 @@ const cleanupSocket = (socket: null | Socket) => {
 };
 
 /**
- * Race two WebSocket connections (e.g. WS vs WSS), returning the winner and cleaning up the loser. Handles various edge cases around connection failures and timeouts.
+ * Connect via WebSocket, racing WSS (via sslip) against plain WS.
+ * WSS is preferred and gets a timeout window; if it doesn't connect in time,
+ * falls back to WS if already open, otherwise reports failure.
  */
-export const raceWebSockets = (options: RaceWebSocketsOptions): RaceWebSocketsResult => {
-  const { createFallback, createPreferred, onAllFailed, onSettled, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSocketResult => {
+  const { hostname, method, onFailed, onSettled, port, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
 
-  let preferredSocket: null | Socket = null;
-  let fallbackSocket: null | Socket = null;
+  const useWss = checkIPFormat(hostname);
+  const wsUrl = `ws://${hostname}:${port}/ws/${method}`;
+  const WebSocketClass =
+    isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;
+
+  let wssSocket: null | Socket = null;
+  let wsSocket: null | Socket = null;
+
+  if (useWss) {
+    const wssUrl = `wss://${toSslIpHostname(hostname)}:${WSS_PORT}/ws/${method}`;
+
+    try {
+      wssSocket = new WebSocket(wssUrl);
+    } catch {
+      // Construction failed
+    }
+  }
 
   try {
-    preferredSocket = createPreferred();
+    wsSocket = new WebSocketClass(wsUrl);
   } catch {
     // Construction failed
   }
 
-  try {
-    fallbackSocket = createFallback();
-  } catch {
-    // Construction failed
-  }
+  if (!wssSocket && !wsSocket) {
+    onFailed();
 
-  if (!preferredSocket && !fallbackSocket) {
-    onAllFailed();
-
-    return { cancel: noop, fallbackSocket: null, preferredSocket: null };
+    return { cancel: noop, wsSocket: null, wssSocket: null };
   }
 
   let settled = false;
-  let fallbackOpenEvent: Event | null = null;
+  let wsOpenEvent: Event | null = null;
   let timeoutId: NodeJS.Timeout | undefined;
 
-  const settleWith = (winner: Socket, isPreferred: boolean, openEvent: Event | null) => {
+  const settleWith = (winner: Socket, isWss: boolean, openEvent: Event | null) => {
     if (settled) return;
 
     settled = true;
     clearTimeout(timeoutId);
-    cleanupSocket(isPreferred ? fallbackSocket : preferredSocket);
-    onSettled(winner, isPreferred, openEvent);
+    console.log(`WebSocket ${method} connected via ${isWss ? 'WSS' : 'WS'}`);
+    cleanupSocket(isWss ? wsSocket : wssSocket);
+    onSettled(winner, openEvent);
   };
 
   const handleAllFailed = () => {
@@ -87,9 +101,9 @@ export const raceWebSockets = (options: RaceWebSocketsOptions): RaceWebSocketsRe
 
     settled = true;
     clearTimeout(timeoutId);
-    cleanupSocket(preferredSocket);
-    cleanupSocket(fallbackSocket);
-    onAllFailed();
+    cleanupSocket(wssSocket);
+    cleanupSocket(wsSocket);
+    onFailed();
   };
 
   const cancel = () => {
@@ -97,80 +111,74 @@ export const raceWebSockets = (options: RaceWebSocketsOptions): RaceWebSocketsRe
 
     settled = true;
     clearTimeout(timeoutId);
-    cleanupSocket(preferredSocket);
-    cleanupSocket(fallbackSocket);
+    cleanupSocket(wssSocket);
+    cleanupSocket(wsSocket);
   };
 
-  // Single timeout — preferred gets this window; when expired, settle with fallback if ready, otherwise fail
+  // Single timeout — WSS gets this window; when expired, settle with WS if ready, otherwise fail
   if (timeoutMs != null) {
     timeoutId = setTimeout(() => {
-      if (fallbackOpenEvent && fallbackSocket) {
-        settleWith(fallbackSocket, false, fallbackOpenEvent);
+      if (wsOpenEvent && wsSocket) {
+        settleWith(wsSocket, false, wsOpenEvent);
       } else {
         handleAllFailed();
       }
     }, timeoutMs);
   }
 
-  // Preferred handlers — can win at any time before settlement
-  if (preferredSocket) {
-    preferredSocket.onopen = (e) => {
-      settleWith(preferredSocket!, true, e);
+  // WSS handlers — can win at any time before settlement
+  if (wssSocket) {
+    wssSocket.onopen = (e) => {
+      settleWith(wssSocket!, true, e);
     };
 
-    preferredSocket.onerror = () => {
-      preferredSocket = null;
+    wssSocket.onerror = () => {
+      wssSocket = null;
 
-      if (fallbackOpenEvent && fallbackSocket) {
-        // Early settle if preferred fails after fallback is already open
-        settleWith(fallbackSocket, false, fallbackOpenEvent);
-      } else if (!fallbackSocket) {
-        // Otherwise, if no fallback to wait for, fail immediately
+      if (wsOpenEvent && wsSocket) {
+        settleWith(wsSocket, false, wsOpenEvent);
+      } else if (!wsSocket) {
         handleAllFailed();
       }
     };
 
-    preferredSocket.onclose = () => {
-      if (!preferredSocket) return;
+    wssSocket.onclose = () => {
+      if (!wssSocket) return;
 
-      preferredSocket = null;
+      wssSocket = null;
 
-      if (fallbackOpenEvent && fallbackSocket) {
-        // Early settle if preferred fails after fallback is already open
-        settleWith(fallbackSocket, false, fallbackOpenEvent);
-      } else if (!fallbackSocket) {
-        // Otherwise, if no fallback to wait for, fail immediately
+      if (wsOpenEvent && wsSocket) {
+        settleWith(wsSocket, false, wsOpenEvent);
+      } else if (!wsSocket) {
         handleAllFailed();
       }
     };
   }
 
-  // Fallback handlers — can only settle after preferred fails (or timeout expires)
-  if (fallbackSocket) {
-    fallbackSocket.onopen = (e) => {
-      fallbackOpenEvent = e;
+  // WS handlers — can only settle after WSS fails (or timeout expires)
+  if (wsSocket) {
+    wsSocket.onopen = (e) => {
+      wsOpenEvent = e;
 
-      if (!preferredSocket) {
-        // Settle immediately if preferred already failed, otherwise wait for preferred to fail or timeout
-        settleWith(fallbackSocket!, false, e);
+      if (!wssSocket) {
+        settleWith(wsSocket!, false, e);
       }
-      // else: preferred still trying, wait for timeout or preferred result
     };
 
-    fallbackSocket.onerror = () => {
-      fallbackSocket = null;
+    wsSocket.onerror = () => {
+      wsSocket = null;
 
-      if (!preferredSocket) handleAllFailed();
+      if (!wssSocket) handleAllFailed();
     };
 
-    fallbackSocket.onclose = () => {
-      if (!fallbackSocket) return;
+    wsSocket.onclose = () => {
+      if (!wsSocket) return;
 
-      fallbackSocket = null;
+      wsSocket = null;
 
-      if (!preferredSocket) handleAllFailed();
+      if (!wssSocket) handleAllFailed();
     };
   }
 
-  return { cancel, fallbackSocket, preferredSocket };
+  return { cancel, wsSocket, wssSocket };
 };

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -86,8 +86,10 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
   let wsOpenEvent: Event | null = null;
   let timeoutId: NodeJS.Timeout | undefined;
 
-  const settleWith = (winner: Socket, isWss: boolean, openEvent: Event | null) => {
+  const settleWith = (winner: Socket, openEvent: Event | null) => {
     if (settled) return;
+
+    const isWss = winner === wssSocket;
 
     settled = true;
     clearTimeout(timeoutId);
@@ -119,7 +121,7 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
   if (timeoutMs != null) {
     timeoutId = setTimeout(() => {
       if (wsOpenEvent && wsSocket) {
-        settleWith(wsSocket, false, wsOpenEvent);
+        settleWith(wsSocket, wsOpenEvent);
       } else {
         handleAllFailed();
       }
@@ -129,14 +131,14 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
   // WSS handlers — can win at any time before settlement
   if (wssSocket) {
     wssSocket.onopen = (e) => {
-      settleWith(wssSocket!, true, e);
+      settleWith(wssSocket!, e);
     };
 
     wssSocket.onerror = () => {
       wssSocket = null;
 
       if (wsOpenEvent && wsSocket) {
-        settleWith(wsSocket, false, wsOpenEvent);
+        settleWith(wsSocket, wsOpenEvent);
       } else if (!wsSocket) {
         handleAllFailed();
       }
@@ -148,7 +150,7 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
       wssSocket = null;
 
       if (wsOpenEvent && wsSocket) {
-        settleWith(wsSocket, false, wsOpenEvent);
+        settleWith(wsSocket, wsOpenEvent);
       } else if (!wsSocket) {
         handleAllFailed();
       }
@@ -161,7 +163,7 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
       wsOpenEvent = e;
 
       if (!wssSocket) {
-        settleWith(wsSocket!, false, e);
+        settleWith(wsSocket!, e);
       }
     };
 

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -5,7 +5,7 @@ import isWeb from '@core/helpers/is-web';
 export const toSslIpHostname = (ip: string): string => `${ip.replaceAll('.', '-')}.sslip.flux3dp.com`;
 
 const WSS_PORT = 8443;
-const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_TIMEOUT_MS = 5000;
 
 type Socket = InsecureWebsocket | WebSocket;
 
@@ -23,8 +23,6 @@ export interface ConnectWebSocketOptions {
 
 export interface ConnectWebSocketResult {
   cancel: () => void;
-  wsSocket: null | Socket;
-  wssSocket: null | Socket;
 }
 
 const noop = () => {};
@@ -79,7 +77,7 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
   if (!wssSocket && !wsSocket) {
     onFailed();
 
-    return { cancel: noop, wsSocket: null, wssSocket: null };
+    return { cancel: noop };
   }
 
   let settled = false;
@@ -182,5 +180,5 @@ export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSo
     };
   }
 
-  return { cancel, wsSocket, wssSocket };
+  return { cancel };
 };

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -2,6 +2,8 @@ import checkIPFormat from '@core/helpers/check-ip-format';
 import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
 import isWeb from '@core/helpers/is-web';
 
+import isDev from './is-dev';
+
 export const toSslIpHostname = (ip: string): string => `${ip.replaceAll('.', '-')}.sslip.flux3dp.com`;
 
 const WSS_PORT = 8443;
@@ -50,7 +52,7 @@ const cleanupSocket = (socket: null | Socket) => {
 export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSocketResult => {
   const { hostname, method, onFailed, onSettled, port, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
 
-  const useWss = checkIPFormat(hostname);
+  const useWss = (isWeb() || isDev()) && checkIPFormat(hostname);
   const wsUrl = `ws://${hostname}:${port}/ws/${method}`;
   const WebSocketClass =
     isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -1,0 +1,176 @@
+import type InsecureWebsocket from '@core/helpers/InsecureWebsocket';
+
+export const toSslIpHostname = (ip: string): string => `${ip.replaceAll('.', '-')}.sslip.flux3dp.com`;
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+type Socket = InsecureWebsocket | WebSocket;
+
+export interface RaceWebSocketsOptions {
+  /** Factory for the fallback socket (e.g. WS). Null if construction fails. */
+  createFallback: () => null | Socket;
+  /** Factory for the preferred socket (e.g. WSS). Null if construction fails. */
+  createPreferred: () => null | Socket;
+  /** Called when both sockets fail */
+  onAllFailed: () => void;
+  /** Called when a winner connects */
+  onSettled: (winner: Socket, isPreferred: boolean, openEvent: Event | null) => void;
+  /** Timeout — preferred gets this window to connect; when expired, settle with fallback if ready, otherwise fail. Omit if caller manages timeout externally. */
+  timeoutMs?: number;
+}
+
+export interface RaceWebSocketsResult {
+  cancel: () => void;
+  fallbackSocket: null | Socket;
+  preferredSocket: null | Socket;
+}
+
+const noop = () => {};
+
+const cleanupSocket = (socket: null | Socket) => {
+  if (!socket) return;
+
+  socket.onopen = null;
+  socket.onerror = null;
+  socket.onclose = null;
+  socket.onmessage = null;
+
+  try {
+    socket.close();
+  } catch {
+    // Ignore close errors
+  }
+};
+
+/**
+ * Race two WebSocket connections (e.g. WS vs WSS), returning the winner and cleaning up the loser. Handles various edge cases around connection failures and timeouts.
+ */
+export const raceWebSockets = (options: RaceWebSocketsOptions): RaceWebSocketsResult => {
+  const { createFallback, createPreferred, onAllFailed, onSettled, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+
+  let preferredSocket: null | Socket = null;
+  let fallbackSocket: null | Socket = null;
+
+  try {
+    preferredSocket = createPreferred();
+  } catch {
+    // Construction failed
+  }
+
+  try {
+    fallbackSocket = createFallback();
+  } catch {
+    // Construction failed
+  }
+
+  if (!preferredSocket && !fallbackSocket) {
+    onAllFailed();
+
+    return { cancel: noop, fallbackSocket: null, preferredSocket: null };
+  }
+
+  let settled = false;
+  let fallbackOpenEvent: Event | null = null;
+  let timeoutId: NodeJS.Timeout | undefined;
+
+  const settleWith = (winner: Socket, isPreferred: boolean, openEvent: Event | null) => {
+    if (settled) return;
+
+    settled = true;
+    clearTimeout(timeoutId);
+    cleanupSocket(isPreferred ? fallbackSocket : preferredSocket);
+    onSettled(winner, isPreferred, openEvent);
+  };
+
+  const handleAllFailed = () => {
+    if (settled) return;
+
+    settled = true;
+    clearTimeout(timeoutId);
+    cleanupSocket(preferredSocket);
+    cleanupSocket(fallbackSocket);
+    onAllFailed();
+  };
+
+  const cancel = () => {
+    if (settled) return;
+
+    settled = true;
+    clearTimeout(timeoutId);
+    cleanupSocket(preferredSocket);
+    cleanupSocket(fallbackSocket);
+  };
+
+  // Single timeout — preferred gets this window; when expired, settle with fallback if ready, otherwise fail
+  if (timeoutMs != null) {
+    timeoutId = setTimeout(() => {
+      if (fallbackOpenEvent && fallbackSocket) {
+        settleWith(fallbackSocket, false, fallbackOpenEvent);
+      } else {
+        handleAllFailed();
+      }
+    }, timeoutMs);
+  }
+
+  // Preferred handlers — can win at any time before settlement
+  if (preferredSocket) {
+    preferredSocket.onopen = (e) => {
+      settleWith(preferredSocket!, true, e);
+    };
+
+    preferredSocket.onerror = () => {
+      preferredSocket = null;
+
+      if (fallbackOpenEvent && fallbackSocket) {
+        // Early settle if preferred fails after fallback is already open
+        settleWith(fallbackSocket, false, fallbackOpenEvent);
+      } else if (!fallbackSocket) {
+        // Otherwise, if no fallback to wait for, fail immediately
+        handleAllFailed();
+      }
+    };
+
+    preferredSocket.onclose = () => {
+      if (!preferredSocket) return;
+
+      preferredSocket = null;
+
+      if (fallbackOpenEvent && fallbackSocket) {
+        // Early settle if preferred fails after fallback is already open
+        settleWith(fallbackSocket, false, fallbackOpenEvent);
+      } else if (!fallbackSocket) {
+        // Otherwise, if no fallback to wait for, fail immediately
+        handleAllFailed();
+      }
+    };
+  }
+
+  // Fallback handlers — can only settle after preferred fails (or timeout expires)
+  if (fallbackSocket) {
+    fallbackSocket.onopen = (e) => {
+      fallbackOpenEvent = e;
+
+      if (!preferredSocket) {
+        // Settle immediately if preferred already failed, otherwise wait for preferred to fail or timeout
+        settleWith(fallbackSocket!, false, e);
+      }
+      // else: preferred still trying, wait for timeout or preferred result
+    };
+
+    fallbackSocket.onerror = () => {
+      fallbackSocket = null;
+
+      if (!preferredSocket) handleAllFailed();
+    };
+
+    fallbackSocket.onclose = () => {
+      if (!fallbackSocket) return;
+
+      fallbackSocket = null;
+
+      if (!preferredSocket) handleAllFailed();
+    };
+  }
+
+  return { cancel, fallbackSocket, preferredSocket };
+};

--- a/packages/core/src/web/helpers/websocket.ts
+++ b/packages/core/src/web/helpers/websocket.ts
@@ -3,16 +3,14 @@ import MessageCaller, { MessageLevel } from '@core/app/actions/message-caller';
 import alertConstants from '@core/app/constants/alert-constants';
 import blobSegments from '@core/helpers/blob-segments';
 import i18n from '@core/helpers/i18n';
-import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
+import type InsecureWebsocket from '@core/helpers/InsecureWebsocket';
 import isJson from '@core/helpers/is-json';
 import isWeb from '@core/helpers/is-web';
 import Logger from '@core/helpers/logger';
 import outputError from '@core/helpers/output-error';
-import { raceWebSockets, toSslIpHostname } from '@core/helpers/sslIpHelper';
+import { connectWebSocket } from '@core/helpers/sslIpHelper';
 import storage from '@core/implementations/storage';
 import type { Option, WrappedWebSocket } from '@core/interfaces/WebSocket';
-
-import checkIPFormat from './check-ip-format';
 
 const WsLogger = Logger('websocket');
 const logLimit = 100;
@@ -272,15 +270,10 @@ export default (options: Option): WrappedWebSocket => {
       return null;
     }
 
-    const wssUrl = checkIPFormat(hostName) ? `wss://${toSslIpHostname(hostName)}:8443/ws/${createWsOpts.method}` : null;
-    const wsUrl = `ws://${hostName}:${port}/ws/${createWsOpts.method}`;
-    const WebSocketClass =
-      isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;
-
-    const result = raceWebSockets({
-      createFallback: () => new WebSocketClass(wsUrl),
-      createPreferred: () => (wssUrl ? new WebSocket(wssUrl) : null),
-      onAllFailed: () => {
+    const result = connectWebSocket({
+      hostname: hostName,
+      method: createWsOpts.method!,
+      onFailed: () => {
         ws = null;
         handleCreateWebSocketFailed();
 
@@ -290,20 +283,19 @@ export default (options: Option): WrappedWebSocket => {
           }, 300);
         }
       },
-      onSettled: (winner, isPreferred, openEvent) => {
-        console.log(`WebSocket ${createWsOpts.method} connected ${isPreferred ? 'WSS' : 'WS'}`);
-
-        ws = winner;
+      onSettled: (socket, openEvent) => {
+        ws = socket;
         wsCreateFailedCount = 0;
         wsErrorCount = 0;
         alertCaller.popById('backend-error');
         MessageCaller.closeMessage('backend-error-hint');
-        attachHandlers(winner, createWsOpts);
+        attachHandlers(socket, createWsOpts);
         socketOptions.onOpen?.(openEvent);
       },
+      port: port!,
     });
 
-    return result.preferredSocket ?? result.fallbackSocket;
+    return result.wssSocket ?? result.wsSocket;
   };
 
   let timer: NodeJS.Timeout;

--- a/packages/core/src/web/helpers/websocket.ts
+++ b/packages/core/src/web/helpers/websocket.ts
@@ -38,6 +38,7 @@ export const setCurrentVersion = (version: string): void => {
 //      onClose       - fired on connection closed
 //      onOpen        - fired on connection connecting
 export default (options: Option): WrappedWebSocket => {
+  const scheduledMessages: string[] = [];
   const defaultCallback = () => {};
   const defaultOptions = {
     autoReconnect: true,
@@ -139,13 +140,6 @@ export default (options: Option): WrappedWebSocket => {
           onClick: () => MessageCaller.closeMessage('backend-error-hint'),
         });
       }
-    };
-
-    nodeWs.onopen = (e) => {
-      socketOptions.onOpen?.(e);
-      wsErrorCount = 0;
-      alertCaller.popById('backend-error');
-      MessageCaller.closeMessage('backend-error-hint');
     };
 
     nodeWs.onmessage = (result: MessageEvent) => {
@@ -291,6 +285,8 @@ export default (options: Option): WrappedWebSocket => {
         MessageCaller.closeMessage('backend-error-hint');
         attachHandlers(socket, createWsOpts);
         socketOptions.onOpen?.(openEvent);
+        scheduledMessages.forEach((msg) => sender(msg));
+        scheduledMessages.length = 0;
       },
       port: port!,
     });
@@ -359,14 +355,8 @@ export default (options: Option): WrappedWebSocket => {
         ws = createWebSocket(socketOptions);
       }
 
-      if (ws?.readyState === WebSocket.CONNECTING) {
-        const prevOnOpen = ws.onopen;
-
-        ws.onopen = (e) => {
-          if (typeof prevOnOpen === 'function') prevOnOpen.call(ws as any, e);
-
-          sender(data);
-        };
+      if (!ws || ws?.readyState === WebSocket.CONNECTING) {
+        scheduledMessages.push(data);
       } else {
         sender(data);
       }

--- a/packages/core/src/web/helpers/websocket.ts
+++ b/packages/core/src/web/helpers/websocket.ts
@@ -8,8 +8,11 @@ import isJson from '@core/helpers/is-json';
 import isWeb from '@core/helpers/is-web';
 import Logger from '@core/helpers/logger';
 import outputError from '@core/helpers/output-error';
+import { raceWebSockets, toSslIpHostname } from '@core/helpers/sslIpHelper';
 import storage from '@core/implementations/storage';
 import type { Option, WrappedWebSocket } from '@core/interfaces/WebSocket';
+
+import checkIPFormat from './check-ip-format';
 
 const WsLogger = Logger('websocket');
 const logLimit = 100;
@@ -112,41 +115,7 @@ export default (options: Option): WrappedWebSocket => {
     }
   };
 
-  const createWebSocket = (createWsOpts: Option) => {
-    if (ws) {
-      if (ws.readyState === WebSocket.CONNECTING) {
-        return ws;
-      }
-
-      if (ws.readyState !== WebSocket.CLOSED) {
-        ws.close();
-      }
-    }
-
-    const hostName = createWsOpts.hostname || defaultOptions.hostname;
-    const port = createWsOpts.port || defaultOptions.port;
-    const url = `ws://${hostName}:${port}/ws/${createWsOpts.method}`;
-
-    if (port === undefined) {
-      handleCreateWebSocketFailed();
-
-      return null;
-    }
-
-    const WebSocketClass =
-      isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;
-    let nodeWs: InsecureWebsocket | WebSocket;
-
-    try {
-      nodeWs = new WebSocketClass(url);
-    } catch (error) {
-      console.error('Failed to create websocket', error);
-      handleCreateWebSocketFailed();
-
-      return null;
-    }
-    wsCreateFailedCount = 0;
-
+  const attachHandlers = (nodeWs: InsecureWebsocket | WebSocket, createWsOpts: Option) => {
     nodeWs.onerror = () => {
       wsErrorCount += 1;
 
@@ -281,8 +250,60 @@ export default (options: Option): WrappedWebSocket => {
         ws = null; // release
       }
     };
+  };
 
-    return nodeWs;
+  const createWebSocket = (createWsOpts: Option): InsecureWebsocket | null | WebSocket => {
+    if (ws) {
+      if (ws.readyState === WebSocket.CONNECTING) {
+        return ws;
+      }
+
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.close();
+      }
+    }
+
+    const hostName = createWsOpts.hostname || defaultOptions.hostname;
+    const port = createWsOpts.port || defaultOptions.port;
+
+    if (port === undefined) {
+      handleCreateWebSocketFailed();
+
+      return null;
+    }
+
+    const wssUrl = checkIPFormat(hostName) ? `wss://${toSslIpHostname(hostName)}:8443/ws/${createWsOpts.method}` : null;
+    const wsUrl = `ws://${hostName}:${port}/ws/${createWsOpts.method}`;
+    const WebSocketClass =
+      isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;
+
+    const result = raceWebSockets({
+      createFallback: () => new WebSocketClass(wsUrl),
+      createPreferred: () => (wssUrl ? new WebSocket(wssUrl) : null),
+      onAllFailed: () => {
+        ws = null;
+        handleCreateWebSocketFailed();
+
+        if (socketOptions.autoReconnect === true) {
+          setTimeout(() => {
+            createWebSocket(createWsOpts);
+          }, 300);
+        }
+      },
+      onSettled: (winner, isPreferred, openEvent) => {
+        console.log(`WebSocket ${createWsOpts.method} connected ${isPreferred ? 'WSS' : 'WS'}`);
+
+        ws = winner;
+        wsCreateFailedCount = 0;
+        wsErrorCount = 0;
+        alertCaller.popById('backend-error');
+        MessageCaller.closeMessage('backend-error-hint');
+        attachHandlers(winner, createWsOpts);
+        socketOptions.onOpen?.(openEvent);
+      },
+    });
+
+    return result.preferredSocket ?? result.fallbackSocket;
   };
 
   let timer: NodeJS.Timeout;
@@ -347,8 +368,11 @@ export default (options: Option): WrappedWebSocket => {
       }
 
       if (ws?.readyState === WebSocket.CONNECTING) {
+        const prevOnOpen = ws.onopen;
+
         ws.onopen = (e) => {
-          socketOptions.onOpen?.(e);
+          if (typeof prevOnOpen === 'function') prevOnOpen.call(ws as any, e);
+
           sender(data);
         };
       } else {

--- a/packages/core/src/web/helpers/websocket.ts
+++ b/packages/core/src/web/helpers/websocket.ts
@@ -38,7 +38,7 @@ export const setCurrentVersion = (version: string): void => {
 //      onClose       - fired on connection closed
 //      onOpen        - fired on connection connecting
 export default (options: Option): WrappedWebSocket => {
-  const scheduledMessages: string[] = [];
+  let pendingSends: string[] = [];
   const defaultCallback = () => {};
   const defaultOptions = {
     autoReconnect: true,
@@ -204,7 +204,7 @@ export default (options: Option): WrappedWebSocket => {
           // if identify error, reconnect again
           if (errorStr === 'REMOTE_IDENTIFY_ERROR') {
             setTimeout(() => {
-              ws = createWebSocket(createWsOpts);
+              createWebSocket(createWsOpts);
             }, 1000);
 
             return;
@@ -237,22 +237,27 @@ export default (options: Option): WrappedWebSocket => {
       }
 
       if (socketOptions.autoReconnect === true) {
-        ws = createWebSocket(createWsOpts);
+        createWebSocket(createWsOpts);
       } else {
         ws = null; // release
       }
     };
   };
 
-  const createWebSocket = (createWsOpts: Option): InsecureWebsocket | null | WebSocket => {
-    if (ws) {
-      if (ws.readyState === WebSocket.CONNECTING) {
-        return ws;
-      }
+  let isCreatingWebsocket = false;
 
+  const createWebSocket = (createWsOpts: Option): void => {
+    if (isCreatingWebsocket) {
+      // A race is already in progress, don't start another
+      return;
+    }
+
+    if (ws) {
       if (ws.readyState !== WebSocket.CLOSED) {
         ws.close();
       }
+
+      ws = null;
     }
 
     const hostName = createWsOpts.hostname || defaultOptions.hostname;
@@ -261,14 +266,16 @@ export default (options: Option): WrappedWebSocket => {
     if (port === undefined) {
       handleCreateWebSocketFailed();
 
-      return null;
+      return;
     }
 
-    const result = connectWebSocket({
+    isCreatingWebsocket = true;
+    connectWebSocket({
       hostname: hostName,
       method: createWsOpts.method!,
       onFailed: () => {
         ws = null;
+        isCreatingWebsocket = false;
         handleCreateWebSocketFailed();
 
         if (socketOptions.autoReconnect === true) {
@@ -279,19 +286,19 @@ export default (options: Option): WrappedWebSocket => {
       },
       onSettled: (socket, openEvent) => {
         ws = socket;
+        isCreatingWebsocket = false;
         wsCreateFailedCount = 0;
         wsErrorCount = 0;
         alertCaller.popById('backend-error');
         MessageCaller.closeMessage('backend-error-hint');
         attachHandlers(socket, createWsOpts);
         socketOptions.onOpen?.(openEvent);
-        scheduledMessages.forEach((msg) => sender(msg));
-        scheduledMessages.length = 0;
+
+        pendingSends.forEach((msg) => sender(msg));
+        pendingSends = [];
       },
       port: port!,
     });
-
-    return result.wssSocket ?? result.wsSocket;
   };
 
   let timer: NodeJS.Timeout;
@@ -324,13 +331,7 @@ export default (options: Option): WrappedWebSocket => {
   };
 
   const initWebSocket = () => {
-    ws = createWebSocket(socketOptions);
-
-    if (!ws && socketOptions.autoReconnect) {
-      setTimeout(() => {
-        initWebSocket();
-      }, 300);
-    }
+    createWebSocket(socketOptions);
   };
 
   initWebSocket();
@@ -351,12 +352,8 @@ export default (options: Option): WrappedWebSocket => {
     log: wsLog.log,
     options: socketOptions,
     send(data: string) {
-      if (!ws || ws === null || ws?.readyState === WebSocket.CLOSING || ws?.readyState === WebSocket.CLOSED) {
-        ws = createWebSocket(socketOptions);
-      }
-
-      if (!ws || ws?.readyState === WebSocket.CONNECTING) {
-        scheduledMessages.push(data);
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        pendingSends.push(data);
       } else {
         sender(data);
       }


### PR DESCRIPTION
use connectWebSocket to connect to web sockets. Race between ws and wss in 5 sec. If wss connected in 5 sec, use wss. Otherwise, if ws is connected, use ws. If both failed, trigger onFailed.

Update websocket, `createWebSocket` does not set the `ws` variable directly, `ws` is set when connection race `onSettled`. Adjust `send` method accordingly