### PR TITLE
Feature/autocad direct SVG copy-paste

### DIFF
--- a/DIRECT_PASTE_FROM_AUTOCAD.md
+++ b/DIRECT_PASTE_FROM_AUTOCAD.md
@@ -33,18 +33,42 @@ can parse into real vector cut paths.
 
 ---
 
+## Installing the AutoCAD command (`BEAMCOPY`)
+
+The AutoLISP file is in [`autocad/BeamCopy.lsp`](autocad/BeamCopy.lsp). To install it:
+
+1. Copy `BeamCopy.lsp` somewhere permanent, e.g. `C:\BeamStudio\BeamCopy.lsp`
+   (avoid spaces/OneDrive paths).
+2. In AutoCAD, type **`APPLOAD`** and press Enter.
+3. Browse to `BeamCopy.lsp`, select it, click **Load**, then **Close**.
+   - You'll see `BeamCopy loaded.` on the command line.
+4. **Load it automatically on every start (recommended):** in the same `APPLOAD`
+   dialog, click the **Startup Suite** "Contents…" button (briefcase icon, bottom-right),
+   click **Add…**, pick `BeamCopy.lsp`, **Close**. It will now load in every drawing.
+5. *(Optional)* give it a hotkey: **Manage tab → CUI → Customize**, create a command
+   that runs the macro `BEAMCOPY ` and drag it onto a toolbar or assign a shortcut key.
+
+**Use it:** type `BEAMCOPY`, select objects, press Enter → switch to Beam Studio → `Ctrl+V`.
+
+Full details and troubleshooting: [`autocad/README.md`](autocad/README.md).
+
+---
+
 ## Building & running this repo
 
-Prerequisites: **Node.js ≥ 24.11.1** and **pnpm** (`npm install -g pnpm`).
+Prerequisites: **Node.js ≥ 24.11.1** and **pnpm**.
 
 ```bash
-# from the beam-studio/ folder
+git clone https://github.com/hftsai/beam-studio.git
+cd beam-studio
+git checkout feature/autocad-direct-paste
+
 pnpm install            # install dependencies (first time only)
 
 # Web app (fastest way to try the paste change) -> http://localhost:8080
 pnpm nx run web:start
 
-# Electron desktop app
+# Electron desktop app (see Windows notes below for native build tools)
 pnpm nx run app:dev     # build for development
 pnpm nx run app:start   # launch
 
@@ -56,6 +80,40 @@ pnpm lint               # lint all projects
 The clipboard paste change lives in `packages/core` (shared), so it applies to both the
 web and Electron apps. Some machine-communication features need external services
 (FLUXGhost, Swiftray) but the editor/import works without them.
+
+### Windows first-time setup (tested on Windows 10)
+
+If you don't have Node/pnpm yet:
+
+```powershell
+winget install OpenJS.NodeJS.LTS      # installs Node 24.x (LTS)
+npm install -g pnpm                    # installs pnpm into %AppData%\npm
+# open a NEW terminal so PATH picks up node + pnpm
+```
+
+Two Windows gotchas this fork already accounts for:
+
+1. **Native module needs a C++ compiler.** `font-scanner` (used only by the Electron
+   app for font discovery) compiles with node-gyp. For just the **web app**, install with
+   `pnpm install --ignore-scripts` to skip it. For the **Electron** app, install the
+   compiler first: `winget install Microsoft.VisualStudio.2022.BuildTools` with the
+   *"Desktop development with C++"* workload, then run a plain `pnpm install`.
+
+2. **Git symlinks don't materialize on Windows.** `apps/web/public/js/lib` and
+   `apps/app/public/js/lib` are symlinks to `packages/core/public/js/lib`; Git checks
+   them out as text files, so the DXF parser can't be found. Recreate them as directory
+   junctions (no admin needed):
+
+   ```powershell
+   $core = "$PWD\packages\core\public\js\lib"
+   foreach ($p in "apps\web\public\js\lib","apps\app\public\js\lib") {
+     Remove-Item $p -Force -ErrorAction SilentlyContinue
+     New-Item -ItemType Junction -Path $p -Target $core | Out-Null
+   }
+   ```
+
+> **Tip:** avoid putting this repo inside Dropbox/OneDrive — they lock files during
+> sync and cause `EPERM` errors mid-install. A path like `C:\dev\beam-studio` is best.
 
 ## Testing the paste change without AutoCAD
 

--- a/DIRECT_PASTE_FROM_AUTOCAD.md
+++ b/DIRECT_PASTE_FROM_AUTOCAD.md
@@ -1,0 +1,73 @@
+# Beam Studio — Direct Paste from AutoCAD (fork)
+
+This is a fork of [flux3dp/beam-studio](https://github.com/flux3dp/beam-studio) that
+adds a **copy-in-AutoCAD → paste-in-Beam-Studio** workflow, so you no longer have
+to *Save As DXF → import file* every time.
+
+## What was added
+
+1. **Beam Studio paste handler** now recognizes **DXF text** on the clipboard and
+   imports it through the normal DXF pipeline (unit/DPI dialog, undo history, layers,
+   unsaved-changes tracking all preserved).
+   - File: `packages/core/src/web/app/actions/beambox/svg-editor.ts`
+     (the global `paste` event handler, ~line 525).
+2. **`autocad/BeamCopy.lsp`** — an AutoCAD command (`BEAMCOPY`) that exports the
+   current selection to a temp DXF and puts the DXF **text** on the Windows clipboard
+   via `clip.exe`.
+   - Setup + usage details: `autocad/README.md`.
+
+## Why not "real" AutoCAD Ctrl+C?
+
+When you press Ctrl+C in AutoCAD, the clipboard gets a **binary DWG** (a temp file) and
+a **Windows metafile (EMF)** — neither of which a web/Electron app can read as vectors.
+The most a normal paste could recover is a raster image, which is useless for cutting.
+`BeamCopy.lsp` sidesteps this by putting **DXF text** on the clipboard, which Beam Studio
+can parse into real vector cut paths.
+
+## The workflow
+
+1. **AutoCAD:** type `BEAMCOPY`, select objects, press Enter.
+2. **Beam Studio:** click the canvas, press **Ctrl+V**, choose units in the dialog.
+
+> Requires full AutoCAD (AutoLISP). AutoCAD **LT** is not supported.
+
+---
+
+## Building & running this repo
+
+Prerequisites: **Node.js ≥ 24.11.1** and **pnpm** (`npm install -g pnpm`).
+
+```bash
+# from the beam-studio/ folder
+pnpm install            # install dependencies (first time only)
+
+# Web app (fastest way to try the paste change) -> http://localhost:8080
+pnpm nx run web:start
+
+# Electron desktop app
+pnpm nx run app:dev     # build for development
+pnpm nx run app:start   # launch
+
+# Quality checks
+pnpm nx run core:test   # unit tests for the core package
+pnpm lint               # lint all projects
+```
+
+The clipboard paste change lives in `packages/core` (shared), so it applies to both the
+web and Electron apps. Some machine-communication features need external services
+(FLUXGhost, Swiftray) but the editor/import works without them.
+
+## Testing the paste change without AutoCAD
+
+You can verify the Beam Studio side using any plain DXF file:
+
+```bash
+# macOS/Linux: put a DXF's text on the clipboard, then Ctrl+V in the running app
+cat some.dxf | pbcopy           # macOS
+xclip -sel clip < some.dxf      # Linux
+```
+```powershell
+# Windows PowerShell
+Get-Content some.dxf -Raw | clip
+```
+Then focus the Beam Studio canvas and press **Ctrl+V** — the geometry should import.

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -205,8 +205,8 @@ module.exports = {
           to: path.resolve(__dirname, 'dist/js/lib/svg-nest'),
         },
         {
-          from: path.resolve(__dirname, 'public/js/lib/dxf2svg.js'),
-          to: path.resolve(__dirname, 'dist'),
+          from: path.resolve(core, 'public/js/lib/dxf2svg.js'),
+          to: path.resolve(__dirname, 'dist/dxf2svg.js'),
         },
         { from: path.resolve(__dirname, 'src/vendor'), to: path.resolve(__dirname, 'dist/vendor') },
         { from: path.resolve(__dirname, 'src/manifest.json'), to: path.resolve(__dirname, 'dist') },

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -244,6 +244,7 @@ module.exports = {
       buffer: false,
       events: false,
       fs: false,
+      path: false,
       stream: false,
       util: false,
     },

--- a/autocad/BeamCopy.lsp
+++ b/autocad/BeamCopy.lsp
@@ -1,0 +1,38 @@
+;;; ------------------------------------------------------------------
+;;; BeamCopy.lsp  -  "Copy to Beam Studio"
+;;;
+;;; Exports the selected objects to a temporary DXF and places the DXF
+;;; *text* on the Windows clipboard. Switch to Beam Studio and press
+;;; Ctrl+V to paste the geometry directly onto the canvas.
+;;;
+;;; Usage in AutoCAD:
+;;;   Command: BEAMCOPY   ->  select objects  ->  Enter
+;;;   (then paste in Beam Studio with Ctrl+V)
+;;;
+;;; Requires full AutoCAD (AutoLISP). NOT supported on AutoCAD LT.
+;;; ------------------------------------------------------------------
+
+(defun c:BEAMCOPY (/ f ss od)
+  (vl-load-com)
+  (princ "\nSelect objects to send to Beam Studio: ")
+  (setq ss (ssget))                       ; prompt user for a selection
+  (if ss
+    (progn
+      (setq f (strcat (getenv "TEMP") "\\beam_clip.dxf"))
+      (if (findfile f) (vl-file-delete f)); avoid the "overwrite?" prompt
+      (setq od (getvar "FILEDIA"))
+      (setvar "FILEDIA" 0)                ; suppress the file dialog
+      ;; "_O" = export Objects (the selection); trailing 16 = decimal accuracy
+      (command "_.DXFOUT" f "_O" ss "" "16")
+      (setvar "FILEDIA" od)
+      ;; pipe the DXF text onto the Windows clipboard
+      (startapp "cmd.exe" (strcat "/c clip < \"" f "\""))
+      (princ "\nDXF copied to clipboard. Switch to Beam Studio and press Ctrl+V.")
+    )
+    (princ "\nNothing selected - cancelled.")
+  )
+  (princ)
+)
+
+(princ "\nBeamCopy loaded. Type BEAMCOPY to copy a selection to Beam Studio.")
+(princ)

--- a/autocad/README.md
+++ b/autocad/README.md
@@ -1,0 +1,47 @@
+# Copy from AutoCAD → Paste into Beam Studio
+
+This adds a "copy in AutoCAD, paste in Beam Studio" workflow so you no longer
+have to *Save As → pick a filename → import*. It has two parts:
+
+1. **`BeamCopy.lsp`** — an AutoCAD command that puts your selection on the
+   clipboard as DXF text.
+2. **A Beam Studio change** — the paste handler now recognizes DXF text on the
+   clipboard and imports it through the normal DXF pipeline.
+
+## Why DXF text (and not "real" AutoCAD copy)?
+
+When you press Ctrl+C in AutoCAD, it puts a *binary DWG* (a temp file) and a
+Windows metafile on the clipboard — neither of which a web/Electron app can read
+as vector geometry. The best a normal paste could ever recover is a raster
+image, which is useless for cutting. `BeamCopy.lsp` works around this by writing
+**DXF text** to the clipboard, which Beam Studio can parse into real vectors.
+
+## Setup (AutoCAD side)
+
+> Requires full AutoCAD. **AutoCAD LT does not support AutoLISP** — use the
+> watched-folder approach instead (ask the maintainer for "Option B").
+
+1. Copy `BeamCopy.lsp` somewhere permanent (e.g. `C:\BeamStudio\BeamCopy.lsp`).
+2. Load it for the current session: type `APPLOAD`, browse to the file, **Load**.
+   - To load it automatically on every start, click the **Startup Suite**
+     (briefcase) button in the APPLOAD dialog and add the file.
+3. (Optional) Bind it to a shortcut: in **Manage → Customize User Interface (CUI)**,
+   create a command that runs `BEAMCOPY` and assign a hotkey, or just type it.
+
+## Daily use
+
+1. In AutoCAD: type **`BEAMCOPY`**, select the objects, press **Enter**.
+   - You'll see: *"DXF copied to clipboard..."*
+2. Switch to Beam Studio, click on the canvas, press **Ctrl+V**.
+3. Choose the unit/DPI in the dialog that appears (same dialog as file import).
+
+## Notes / limitations
+
+- A console window may flash briefly when the clipboard is written — that's
+  `clip.exe` doing its job.
+- The DXF unit dialog appears on every paste because DXF has no reliable unit;
+  pick the unit your AutoCAD drawing uses.
+- Supported geometry matches Beam Studio's normal DXF import (lines, polylines,
+  arcs, circles, splines, ellipses, etc.). Exotic AutoCAD objects (3D solids,
+  proxy/AEC objects) won't survive — flatten/explode them first.
+- The temp file is `%TEMP%\beam_clip.dxf` and is overwritten each time.

--- a/packages/core/src/web/app/actions/beambox/svg-editor.ts
+++ b/packages/core/src/web/app/actions/beambox/svg-editor.ts
@@ -37,6 +37,7 @@ import { deleteSelectedElements } from '@core/app/svgedit/operations/delete';
 import importBitmap from '@core/app/svgedit/operations/import/importBitmap';
 import importBvg from '@core/app/svgedit/operations/import/importBvg';
 import importDxf from '@core/app/svgedit/operations/import/importDxf';
+import { importDxfFromText } from '@core/app/svgedit/operations/import/importDxfFromClipboard';
 import importSvg from '@core/app/svgedit/operations/import/importSvg';
 import { moveSelectedElements } from '@core/app/svgedit/operations/move';
 import svgCanvasClass from '@core/app/svgedit/svgcanvas';
@@ -559,13 +560,9 @@ const svgEditor = (window['svgEditor'] = (function () {
             importedFromClipboard = true;
           }
         } else if (isDxfText) {
-          // Reuse the normal file-import pipeline by wrapping the text in a .dxf File.
           console.log('handle clip board dxf text');
           importedFromClipboard = true;
-
-          const dxfFile = new File([plainText], 'clipboard.dxf', { type: 'application/dxf' });
-
-          svgEditor.handleFile(dxfFile);
+          await importDxfFromText(plainText);
         } else if (clipboardData.types.includes('text/html')) {
           const htmlData = clipboardData.getData('text/html');
           const matchImgs = htmlData.match(/<img[^>]+>/);

--- a/packages/core/src/web/app/actions/beambox/svg-editor.ts
+++ b/packages/core/src/web/app/actions/beambox/svg-editor.ts
@@ -542,6 +542,14 @@ const svgEditor = (window['svgEditor'] = (function () {
       let importedFromClipboard = false;
 
       if (clipboardData) {
+        // Detect DXF text placed on the clipboard by a CAD app (e.g. AutoCAD via clip.exe / BeamCopy.lsp).
+        const plainText = clipboardData.types.includes('text/plain') ? clipboardData.getData('text/plain') : '';
+        const dxfHead = plainText.slice(0, 1024);
+        const isDxfText =
+          plainText.length > 0 &&
+          (/(^|\r?\n)\s*0\r?\n\s*SECTION\r?\n/.test(dxfHead) ||
+            (dxfHead.includes('SECTION') && plainText.includes('ENTITIES') && plainText.includes('EOF')));
+
         if (clipboardData.types.includes('Files')) {
           console.log('handle clip board file');
           for (let i = 0; i < clipboardData.files.length; i++) {
@@ -550,6 +558,14 @@ const svgEditor = (window['svgEditor'] = (function () {
             svgEditor.handleFile(file);
             importedFromClipboard = true;
           }
+        } else if (isDxfText) {
+          // Reuse the normal file-import pipeline by wrapping the text in a .dxf File.
+          console.log('handle clip board dxf text');
+          importedFromClipboard = true;
+
+          const dxfFile = new File([plainText], 'clipboard.dxf', { type: 'application/dxf' });
+
+          svgEditor.handleFile(dxfFile);
         } else if (clipboardData.types.includes('text/html')) {
           const htmlData = clipboardData.getData('text/html');
           const matchImgs = htmlData.match(/<img[^>]+>/);

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
@@ -51,7 +51,6 @@ export const pasteElements = async ({
 
   if (!clipboard?.length) {
     // No Beam Studio clipboard data - it may be external DXF text (e.g. AutoCAD via BEAMCOPY).
-    console.log('[DXF paste] pasteElements: no Beam Studio clipboard data, checking for DXF text');
     await importDxfFromClipboard();
 
     return null;

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
@@ -51,6 +51,7 @@ export const pasteElements = async ({
 
   if (!clipboard?.length) {
     // No Beam Studio clipboard data - it may be external DXF text (e.g. AutoCAD via BEAMCOPY).
+    console.log('[DXF paste] pasteElements: no Beam Studio clipboard data, checking for DXF text');
     await importDxfFromClipboard();
 
     return null;

--- a/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
+++ b/packages/core/src/web/app/svgedit/operations/clipboard/actions/paste.ts
@@ -9,6 +9,7 @@ import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import type { IBatchCommand } from '@core/interfaces/IHistory';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
+import { importDxfFromClipboard } from '../../../operations/import/importDxfFromClipboard';
 import undoManager from '../../../history/undoManager';
 import { handlePastedRef } from '../helpers/paste';
 import { clipboardCore } from '../singleton';
@@ -49,6 +50,9 @@ export const pasteElements = async ({
   const clipboard = useCache && dataCache ? dataCache : await clipboardCore.getData();
 
   if (!clipboard?.length) {
+    // No Beam Studio clipboard data - it may be external DXF text (e.g. AutoCAD via BEAMCOPY).
+    await importDxfFromClipboard();
+
     return null;
   }
 

--- a/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
@@ -28,24 +28,18 @@ export const looksLikeDxfText = (text: string): boolean => {
  * If the given text is DXF, import it. Returns true if an import was handled.
  */
 export const importDxfFromText = async (text: string): Promise<boolean> => {
-  const isDxf = looksLikeDxfText(text);
-
-  console.log('[DXF paste] looksLikeDxfText:', isDxf, '| already importing:', importing, '| length:', text?.length);
-
-  if (importing || !isDxf) {
+  if (importing || !looksLikeDxfText(text)) {
     return false;
   }
 
   importing = true;
 
   try {
-    console.log('[DXF paste] calling importDxf...');
     await importDxf(new Blob([text], { type: 'application/dxf' }));
-    console.log('[DXF paste] importDxf finished');
 
     return true;
-  } catch (e) {
-    console.error('[DXF paste] importDxf threw:', e);
+  } catch (error) {
+    console.error('Failed to import DXF from clipboard:', error);
 
     return false;
   } finally {
@@ -64,12 +58,9 @@ export const importDxfFromClipboard = async (): Promise<boolean> => {
   try {
     const text = await navigator.clipboard.readText();
 
-    console.log('[DXF paste] clipboard read ok | length:', text?.length, '| head:', JSON.stringify(text?.slice(0, 40)));
-
     return await importDxfFromText(text);
-  } catch (e) {
-    console.error('[DXF paste] clipboard read FAILED:', e);
-
+  } catch {
+    // Clipboard unreadable (permission / focus) - nothing to import.
     return false;
   }
 };

--- a/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
@@ -26,16 +26,26 @@ export const looksLikeDxfText = (text: string): boolean => {
  * If the given text is DXF, import it. Returns true if an import was handled.
  */
 export const importDxfFromText = async (text: string): Promise<boolean> => {
-  if (importing || !looksLikeDxfText(text)) {
+  const isDxf = looksLikeDxfText(text);
+
+  console.log('[DXF paste] looksLikeDxfText:', isDxf, '| already importing:', importing, '| length:', text?.length);
+
+  if (importing || !isDxf) {
     return false;
   }
 
   importing = true;
 
   try {
+    console.log('[DXF paste] calling importDxf...');
     await importDxf(new Blob([text], { type: 'application/dxf' }));
+    console.log('[DXF paste] importDxf finished');
 
     return true;
+  } catch (e) {
+    console.error('[DXF paste] importDxf threw:', e);
+
+    return false;
   } finally {
     importing = false;
   }
@@ -49,9 +59,12 @@ export const importDxfFromClipboard = async (): Promise<boolean> => {
   try {
     const text = await navigator.clipboard.readText();
 
+    console.log('[DXF paste] clipboard read ok | length:', text?.length, '| head:', JSON.stringify(text?.slice(0, 40)));
+
     return await importDxfFromText(text);
-  } catch {
-    // Clipboard unreadable (permission / focus) - nothing to import.
+  } catch (e) {
+    console.error('[DXF paste] clipboard read FAILED:', e);
+
     return false;
   }
 };

--- a/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
@@ -1,3 +1,5 @@
+import progressCaller from '@core/app/actions/progress-caller';
+
 import importDxf from './importDxf';
 
 // Guard against importing the same paste twice when more than one paste entry
@@ -48,6 +50,9 @@ export const importDxfFromText = async (text: string): Promise<boolean> => {
     return false;
   } finally {
     importing = false;
+    // importDxf opens the "Loading image" progress but relies on its caller to
+    // close it (handleFile does). We call importDxf directly, so close it here.
+    progressCaller.popById('loading_image');
   }
 };
 

--- a/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/importDxfFromClipboard.ts
@@ -1,0 +1,57 @@
+import importDxf from './importDxf';
+
+// Guard against importing the same paste twice when more than one paste entry
+// point fires for a single Ctrl+V (native clipboard path + document paste event).
+let importing = false;
+
+/**
+ * Heuristic check for DXF text on the clipboard (e.g. produced by AutoCAD's
+ * BEAMCOPY / clip.exe). DXF group codes are right-justified, so the file starts
+ * with something like "  0\r\nSECTION\r\n".
+ */
+export const looksLikeDxfText = (text: string): boolean => {
+  if (!text) {
+    return false;
+  }
+
+  const head = text.slice(0, 1024);
+
+  return (
+    /(^|\r?\n)\s*0\r?\n\s*SECTION\r?\n/.test(head) ||
+    (head.includes('SECTION') && text.includes('ENTITIES') && text.includes('EOF'))
+  );
+};
+
+/**
+ * If the given text is DXF, import it. Returns true if an import was handled.
+ */
+export const importDxfFromText = async (text: string): Promise<boolean> => {
+  if (importing || !looksLikeDxfText(text)) {
+    return false;
+  }
+
+  importing = true;
+
+  try {
+    await importDxf(new Blob([text], { type: 'application/dxf' }));
+
+    return true;
+  } finally {
+    importing = false;
+  }
+};
+
+/**
+ * Read the system clipboard and import it if it contains DXF text.
+ * Returns true if an import was handled.
+ */
+export const importDxfFromClipboard = async (): Promise<boolean> => {
+  try {
+    const text = await navigator.clipboard.readText();
+
+    return await importDxfFromText(text);
+  } catch {
+    // Clipboard unreadable (permission / focus) - nothing to import.
+    return false;
+  }
+};

--- a/prompt-history.html
+++ b/prompt-history.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Beam Studio — Direct AutoCAD Paste · Prompt History</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --panel2: #1e222b; --border: #2a2f3a;
+    --text: #e6e9ef; --muted: #9aa3b2; --accent: #4f9cff; --user: #2d6cdf;
+    --code-bg: #0b0d12; --green: #43c59e; --amber: #e0b341;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 16px/1.6 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 40px 20px 80px; }
+  header h1 { font-size: 26px; margin: 0 0 6px; }
+  header p { color: var(--muted); margin: 0 0 28px; }
+  .meta { font-size: 13px; color: var(--muted); border-top: 1px solid var(--border);
+          border-bottom: 1px solid var(--border); padding: 10px 0; margin-bottom: 32px; }
+  .turn { margin: 0 0 26px; }
+  .role { display: inline-block; font-size: 12px; font-weight: 700; letter-spacing: .06em;
+          text-transform: uppercase; padding: 3px 10px; border-radius: 999px; margin-bottom: 8px; }
+  .role.user { background: var(--user); color: #fff; }
+  .role.assistant { background: var(--panel2); color: var(--accent); border: 1px solid var(--border); }
+  .bubble { background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+            padding: 16px 18px; }
+  .bubble.user { background: var(--panel2); }
+  .bubble h3 { margin: 14px 0 6px; font-size: 15px; color: var(--accent); }
+  .bubble ul { margin: 8px 0; padding-left: 20px; }
+  .bubble li { margin: 4px 0; }
+  code { background: var(--code-bg); border: 1px solid var(--border); border-radius: 5px;
+         padding: 1px 6px; font: 13px/1.5 "SFMono-Regular", Consolas, monospace; }
+  pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px;
+        padding: 12px 14px; overflow-x: auto; }
+  pre code { border: 0; padding: 0; }
+  .tag { font-size: 12px; color: var(--green); font-weight: 600; }
+  .files { font-size: 13px; color: var(--muted); margin-top: 10px; }
+  .files code { color: var(--text); }
+  footer { color: var(--muted); font-size: 13px; margin-top: 40px; border-top: 1px solid var(--border); padding-top: 16px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Beam Studio — Direct Paste from AutoCAD</h1>
+    <p>Development prompt history &amp; decision log</p>
+  </header>
+  <div class="meta">
+    Project: fork of <code>flux3dp/beam-studio</code> &nbsp;·&nbsp;
+    Goal: copy in AutoCAD → paste vectors into Beam Studio (no DXF file save) &nbsp;·&nbsp;
+    Generated with Claude Code
+  </div>
+
+  <!-- Turn 1 -->
+  <div class="turn">
+    <div class="role user">User</div>
+    <div class="bubble user">
+      Shared <code>https://github.com/flux3dp/beam-studio</code> (laser cutter workspace).
+      Currently it requires saving DXF files from AutoCAD to import.
+      Asked: can the API be modified to let users <strong>directly copy a design from AutoCAD
+      and paste it into Beam Studio</strong> to print?
+    </div>
+  </div>
+
+  <!-- Turn 2 -->
+  <div class="turn">
+    <div class="role assistant">Assistant</div>
+    <div class="bubble">
+      Analyzed both sides of the problem.
+      <h3>How import works today</h3>
+      <ul>
+        <li><code>importDxf(file: Blob)</code> reads text → parses with <code>dxf2svg</code> → SVG → canvas.</li>
+        <li>A global <code>paste</code> handler already exists (handles clipboard Files and HTML <code>&lt;img&gt;</code>).</li>
+      </ul>
+      <h3>Why direct vector paste fails</h3>
+      <ul>
+        <li>AutoCAD Ctrl+C puts a binary <strong>DWG</strong> (temp file) + <strong>EMF metafile</strong> on the clipboard — not DXF text.</li>
+        <li>The browser/Electron paste event only exposes <code>text/plain</code>, <code>text/html</code>, <code>image/*</code>, <code>Files</code> — never <code>AutoCAD.r17</code> or <code>CF_ENHMETAFILE</code>.</li>
+        <li>Best case a naive paste recovers a <strong>raster image</strong> — useless for cutting.</li>
+      </ul>
+      <h3>Options proposed</h3>
+      <ul>
+        <li><strong>A (recommended):</strong> AutoCAD-side helper puts DXF <em>text</em> on the clipboard; small Beam Studio change to import it.</li>
+        <li><strong>B:</strong> Watched-folder / "Import latest" auto-import.</li>
+        <li><strong>C:</strong> Accept raster paste only (loses vectors).</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Turn 3 -->
+  <div class="turn">
+    <div class="role user">User</div>
+    <div class="bubble user">option A</div>
+  </div>
+
+  <!-- Turn 4 -->
+  <div class="turn">
+    <div class="role assistant">Assistant <span class="tag">implemented</span></div>
+    <div class="bubble">
+      Built both halves of Option A.
+      <h3>1. Beam Studio paste handler</h3>
+      Added a DXF-text branch to the global <code>paste</code> handler: detects DXF in
+      <code>text/plain</code>, wraps it in a <code>clipboard.dxf</code> <code>File</code>, and reuses the
+      existing <code>handleFile → importDxf</code> pipeline (unit dialog, undo, layers all preserved).
+      Computed the DXF check up front so non-DXF text no longer pre-empts the image-paste branch.
+      <h3>2. AutoCAD <code>BEAMCOPY</code> command (AutoLISP)</h3>
+      Select objects → <code>DXFOUT</code> the selection to <code>%TEMP%\beam_clip.dxf</code> →
+      pipe to clipboard with <code>clip.exe</code>.
+      <div class="files">
+        Files touched:
+        <code>packages/core/src/web/app/actions/beambox/svg-editor.ts</code>,
+        <code>autocad/BeamCopy.lsp</code>, <code>autocad/README.md</code>.
+      </div>
+    </div>
+  </div>
+
+  <!-- Turn 5 -->
+  <div class="turn">
+    <div class="role user">User</div>
+    <div class="bubble user">
+      Write a README and prompt-history HTML. How do I execute this repository?
+      How do I upload my fork to my GitHub?
+    </div>
+  </div>
+
+  <!-- Turn 6 -->
+  <div class="turn">
+    <div class="role assistant">Assistant <span class="tag">docs + git</span></div>
+    <div class="bubble">
+      Added <code>DIRECT_PASTE_FROM_AUTOCAD.md</code> (feature + build/run guide) and this
+      <code>prompt-history.html</code>; moved the <code>autocad/</code> helper into the repo; staged a
+      commit on a feature branch and provided fork &amp; push instructions.
+      <h3>Run it</h3>
+<pre><code>pnpm install
+pnpm nx run web:start      # http://localhost:8080
+# or Electron:
+pnpm nx run app:dev &amp;&amp; pnpm nx run app:start</code></pre>
+    </div>
+  </div>
+
+  <footer>
+    See <code>DIRECT_PASTE_FROM_AUTOCAD.md</code> for full build instructions and
+    <code>autocad/README.md</code> for AutoCAD setup.
+  </footer>
+</div>
+</body>
+</html>

--- a/run-web.bat
+++ b/run-web.bat
@@ -1,10 +1,7 @@
 @echo off
-cd /d "%~dp0"
+set "ROOT=%~dp0"
 
-REM Beam Studio web launcher. Double-click to start; close window to stop.
-REM Make node + pnpm reachable regardless of the system PATH.
-
-set "PATH=%PATH%;%ProgramFiles%\nodejs;%APPDATA%\npm;%LOCALAPPDATA%\pnpm"
+REM Beam Studio web launcher - runs webpack directly via node (no pnpm/nx).
 
 set "NODE="
 for /f "delims=" %%i in ('where node 2^>nul') do if not defined NODE set "NODE=%%i"
@@ -13,19 +10,20 @@ if not defined NODE if exist "%LOCALAPPDATA%\Programs\nodejs\node.exe" set "NODE
 
 if not defined NODE (
   echo.
-  echo [ERROR] Node.js was not found.
-  echo   Install it with:  winget install OpenJS.NodeJS.LTS
-  echo   then reopen this window and try again.
+  echo [ERROR] Node.js was not found. Install with: winget install OpenJS.NodeJS.LTS
   echo.
   pause
   exit /b 1
 )
 
-set "NX=%~dp0node_modules\nx\bin\nx.js"
-if not exist "%NX%" (
+REM put node's own folder on PATH so the webpack shim can find node
+for %%D in ("%NODE%") do set "PATH=%%~dpD;%PATH%"
+
+cd /d "%ROOT%apps\web"
+
+if not exist "node_modules\.bin\webpack.cmd" (
   echo.
-  echo [ERROR] Dependencies are not installed - node_modules\nx is missing.
-  echo   Open a terminal in this folder and run:  pnpm install
+  echo [ERROR] Dependencies are not installed. Run  pnpm install  in the beam-studio folder.
   echo.
   pause
   exit /b 1
@@ -40,7 +38,7 @@ echo.
 
 start "" /min powershell -NoProfile -WindowStyle Hidden -Command "while($true){ try { (New-Object Net.Sockets.TcpClient).Connect('localhost',8080); break } catch { Start-Sleep -Seconds 2 } }; Start-Process 'http://localhost:8080'"
 
-"%NODE%" "%NX%" run web:start
+call "node_modules\.bin\webpack.cmd" serve --config webpack.dev.js
 
 echo.
 echo Server stopped.

--- a/run-web.bat
+++ b/run-web.bat
@@ -1,17 +1,15 @@
 @echo off
-REM ============================================================
-REM  Beam Studio (web) launcher - double-click to start the app
-REM  Runs the dev server and opens http://localhost:8080 when ready.
-REM  Close this window to stop the server.
-REM ============================================================
-
 cd /d "%~dp0"
 
-REM Make sure Node + pnpm are on PATH (in case this runs in a bare shell)
+REM Beam Studio (web) launcher - double-click to start. Close window to stop.
+
 set "PATH=%PATH%;C:\Program Files\nodejs;%APPDATA%\npm"
 
-where pnpm >nul 2>nul
-if errorlevel 1 (
+set "PNPM="
+where pnpm >nul 2>nul && set "PNPM=pnpm"
+if not defined PNPM if exist "%APPDATA%\npm\pnpm.cmd" set "PNPM=%APPDATA%\npm\pnpm.cmd"
+
+if not defined PNPM (
   echo.
   echo [ERROR] pnpm was not found.
   echo   Install Node first:  winget install OpenJS.NodeJS.LTS
@@ -22,17 +20,14 @@ if errorlevel 1 (
 )
 
 echo.
-echo Starting Beam Studio (web) ...
-echo The browser will open automatically once it has compiled (first run ~1-2 min).
+echo Starting Beam Studio web app...
+echo The browser opens automatically once it compiles. First run takes ~1-2 min.
 echo Close this window to stop the server.
 echo.
 
-REM In the background: wait for port 8080, then open the browser once.
-start "" /min powershell -NoProfile -WindowStyle Hidden -Command ^
-  "while($true){ try { (New-Object Net.Sockets.TcpClient).Connect('localhost',8080); break } catch { Start-Sleep -Seconds 2 } }; Start-Process 'http://localhost:8080'"
+start "" /min powershell -NoProfile -WindowStyle Hidden -Command "while($true){ try { (New-Object Net.Sockets.TcpClient).Connect('localhost',8080); break } catch { Start-Sleep -Seconds 2 } }; Start-Process 'http://localhost:8080'"
 
-REM Run the dev server in this window (foreground).
-call pnpm nx run web:start
+call "%PNPM%" nx run web:start
 
 echo.
 echo Server stopped.

--- a/run-web.bat
+++ b/run-web.bat
@@ -1,19 +1,31 @@
 @echo off
 cd /d "%~dp0"
 
-REM Beam Studio (web) launcher - double-click to start. Close window to stop.
+REM Beam Studio web launcher. Double-click to start; close window to stop.
+REM Make node + pnpm reachable regardless of the system PATH.
 
-set "PATH=%PATH%;C:\Program Files\nodejs;%APPDATA%\npm"
+set "PATH=%PATH%;%ProgramFiles%\nodejs;%APPDATA%\npm;%LOCALAPPDATA%\pnpm"
 
-set "PNPM="
-where pnpm >nul 2>nul && set "PNPM=pnpm"
-if not defined PNPM if exist "%APPDATA%\npm\pnpm.cmd" set "PNPM=%APPDATA%\npm\pnpm.cmd"
+set "NODE="
+for /f "delims=" %%i in ('where node 2^>nul') do if not defined NODE set "NODE=%%i"
+if not defined NODE if exist "%ProgramFiles%\nodejs\node.exe" set "NODE=%ProgramFiles%\nodejs\node.exe"
+if not defined NODE if exist "%LOCALAPPDATA%\Programs\nodejs\node.exe" set "NODE=%LOCALAPPDATA%\Programs\nodejs\node.exe"
 
-if not defined PNPM (
+if not defined NODE (
   echo.
-  echo [ERROR] pnpm was not found.
-  echo   Install Node first:  winget install OpenJS.NodeJS.LTS
-  echo   Then install pnpm:   npm install -g pnpm
+  echo [ERROR] Node.js was not found.
+  echo   Install it with:  winget install OpenJS.NodeJS.LTS
+  echo   then reopen this window and try again.
+  echo.
+  pause
+  exit /b 1
+)
+
+set "NX=%~dp0node_modules\nx\bin\nx.js"
+if not exist "%NX%" (
+  echo.
+  echo [ERROR] Dependencies are not installed - node_modules\nx is missing.
+  echo   Open a terminal in this folder and run:  pnpm install
   echo.
   pause
   exit /b 1
@@ -21,13 +33,14 @@ if not defined PNPM (
 
 echo.
 echo Starting Beam Studio web app...
-echo The browser opens automatically once it compiles. First run takes ~1-2 min.
+echo Using Node: %NODE%
+echo The browser opens automatically once it compiles. First run takes 1-2 min.
 echo Close this window to stop the server.
 echo.
 
 start "" /min powershell -NoProfile -WindowStyle Hidden -Command "while($true){ try { (New-Object Net.Sockets.TcpClient).Connect('localhost',8080); break } catch { Start-Sleep -Seconds 2 } }; Start-Process 'http://localhost:8080'"
 
-call "%PNPM%" nx run web:start
+"%NODE%" "%NX%" run web:start
 
 echo.
 echo Server stopped.

--- a/run-web.bat
+++ b/run-web.bat
@@ -1,0 +1,39 @@
+@echo off
+REM ============================================================
+REM  Beam Studio (web) launcher - double-click to start the app
+REM  Runs the dev server and opens http://localhost:8080 when ready.
+REM  Close this window to stop the server.
+REM ============================================================
+
+cd /d "%~dp0"
+
+REM Make sure Node + pnpm are on PATH (in case this runs in a bare shell)
+set "PATH=%PATH%;C:\Program Files\nodejs;%APPDATA%\npm"
+
+where pnpm >nul 2>nul
+if errorlevel 1 (
+  echo.
+  echo [ERROR] pnpm was not found.
+  echo   Install Node first:  winget install OpenJS.NodeJS.LTS
+  echo   Then install pnpm:   npm install -g pnpm
+  echo.
+  pause
+  exit /b 1
+)
+
+echo.
+echo Starting Beam Studio (web) ...
+echo The browser will open automatically once it has compiled (first run ~1-2 min).
+echo Close this window to stop the server.
+echo.
+
+REM In the background: wait for port 8080, then open the browser once.
+start "" /min powershell -NoProfile -WindowStyle Hidden -Command ^
+  "while($true){ try { (New-Object Net.Sockets.TcpClient).Connect('localhost',8080); break } catch { Start-Sleep -Seconds 2 } }; Start-Process 'http://localhost:8080'"
+
+REM Run the dev server in this window (foreground).
+call pnpm nx run web:start
+
+echo.
+echo Server stopped.
+pause


### PR DESCRIPTION
Agentic coding with Claude opus 4.8

過去beam studio需要在autocad另存dxf後再import.
這一個功能透過安裝lisp macro在autocad中，可藉beamcopy複製要印的結構，在beamstudio paste in place 中可以直接輸入SVG

please test, verify and consider incorporate the function
