### PR TITLE
chore: preserve BeamCopy.lsp for help-center distribution

### DIFF
--- a/resources/autocad/BeamCopy.lsp
+++ b/resources/autocad/BeamCopy.lsp
@@ -1,0 +1,61 @@
+;;; ------------------------------------------------------------------
+;;; BeamCopy.lsp  -  "Copy to Beam Studio"
+;;;
+;;; Exports the selected objects to a temporary DXF and places the DXF
+;;; *text* on the Windows clipboard. Switch to Beam Studio and press
+;;; Ctrl+V to paste the geometry directly onto the canvas.
+;;;
+;;; Usage in AutoCAD:
+;;;   Command: BEAMCOPY   ->  select objects  ->  Enter
+;;;   (then paste in Beam Studio with Ctrl+V)
+;;;
+;;; Requires full AutoCAD (AutoLISP). NOT supported on AutoCAD LT.
+;;; ------------------------------------------------------------------
+;;;
+;;; Copyright (c) 2026 Paul Hsieh-Fu Tsai (蔡協孚)
+;;; Contributed to FLUX Inc. and distributed under the MIT License.
+;;;
+;;; Permission is hereby granted, free of charge, to any person obtaining
+;;; a copy of this software and associated documentation files (the
+;;; "Software"), to deal in the Software without restriction, including
+;;; without limitation the rights to use, copy, modify, merge, publish,
+;;; distribute, sublicense, and/or sell copies of the Software, and to
+;;; permit persons to whom the Software is furnished to do so, subject to
+;;; the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+;;; IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+;;; CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;;; ------------------------------------------------------------------
+
+(defun c:BEAMCOPY (/ f ss od)
+  (vl-load-com)
+  (princ "\nSelect objects to send to Beam Studio: ")
+  (setq ss (ssget))                       ; prompt user for a selection
+  (if ss
+    (progn
+      (setq f (strcat (getenv "TEMP") "\\beam_clip.dxf"))
+      (if (findfile f) (vl-file-delete f)); avoid the "overwrite?" prompt
+      (setq od (getvar "FILEDIA"))
+      (setvar "FILEDIA" 0)                ; suppress the file dialog
+      ;; "_O" = export Objects (the selection); trailing 16 = decimal accuracy
+      (command "_.DXFOUT" f "_O" ss "" "16")
+      (setvar "FILEDIA" od)
+      ;; pipe the DXF text onto the Windows clipboard
+      (startapp "cmd.exe" (strcat "/c clip < \"" f "\""))
+      (princ "\nDXF copied to clipboard. Switch to Beam Studio and press Ctrl+V.")
+    )
+    (princ "\nNothing selected - cancelled.")
+  )
+  (princ)
+)
+
+(princ "\nBeamCopy loaded. Type BEAMCOPY to copy a selection to Beam Studio.")
+(princ)

--- a/resources/autocad/README.md
+++ b/resources/autocad/README.md
@@ -1,0 +1,54 @@
+# BeamCopy — Copy from AutoCAD → Paste into Beam Studio
+
+`BeamCopy.lsp` adds a "copy in AutoCAD, paste in Beam Studio" workflow so you no
+longer have to *Save As → pick a filename → import*. It puts the selected
+objects on the Windows clipboard as **DXF text**; Beam Studio's paste handler
+recognizes DXF text and imports it through the normal DXF pipeline.
+
+> This file is kept here as the version-controlled source of truth. It is **not**
+> bundled into the application build by default — it is distributed to users via
+> the FLUX help center. Edit here when the script needs a fix or revision.
+
+## Attribution & license
+
+Authored by **Paul Hsieh-Fu Tsai (蔡協孚)**, Assistant Professor, Dept. of
+Biomedical Engineering, Chang Gung University, Taiwan. Contributed to FLUX in
+[PR #904](https://github.com/flux3dp/beam-studio/pull/904) and distributed under
+the **MIT License** (see the header in `BeamCopy.lsp`).
+
+## Why DXF text (and not a "real" AutoCAD copy)?
+
+When you press Ctrl+C in AutoCAD it puts a *binary DWG* (a temp file) and a
+Windows metafile on the clipboard — neither of which a web/Electron app can read
+as vector geometry. The best a normal paste could recover is a raster image,
+which is useless for cutting. `BeamCopy.lsp` works around this by writing **DXF
+text** to the clipboard, which Beam Studio can parse into real vectors.
+
+## Setup (AutoCAD side)
+
+> Requires full AutoCAD. **AutoCAD LT does not support AutoLISP.**
+
+1. Copy `BeamCopy.lsp` somewhere permanent (e.g. `C:\BeamStudio\BeamCopy.lsp`).
+2. Load it for the current session: type `APPLOAD`, browse to the file, **Load**.
+   - To load it automatically on every start, click the **Startup Suite**
+     (briefcase) button in the APPLOAD dialog and add the file.
+3. (Optional) Bind it to a shortcut via **Manage → Customize User Interface
+   (CUI)**, or just type the command.
+
+## Daily use
+
+1. In AutoCAD: type **`BEAMCOPY`**, select the objects, press **Enter**.
+   - You'll see: *"DXF copied to clipboard..."*
+2. Switch to Beam Studio, click on the canvas, press **Ctrl+V**.
+3. Choose the unit/DPI in the dialog that appears (same dialog as file import).
+
+## Notes / limitations
+
+- A console window may flash briefly when the clipboard is written — that's
+  `clip.exe` doing its job.
+- The DXF unit dialog appears on every paste because DXF has no reliable unit;
+  pick the unit your AutoCAD drawing uses.
+- Supported geometry matches Beam Studio's normal DXF import (lines, polylines,
+  arcs, circles, splines, ellipses, etc.). Exotic AutoCAD objects (3D solids,
+  proxy/AEC objects) won't survive — flatten/explode them first.
+- The temp file is `%TEMP%\beam_clip.dxf` and is overwritten each time.


### PR DESCRIPTION
## Summary

Keeps the AutoCAD `BeamCopy.lsp` script (from #904) under version control as the
source of truth for **help-center distribution** and future fixes/revisions.

- `resources/autocad/BeamCopy.lsp` — the AutoLISP command, with an MIT license header crediting the author
- `resources/autocad/README.md` — setup/usage, attribution, and rationale

This file is **not bundled into the app build**; it is distributed to users via
the FLUX help center. Versioning it here means we don't lose it when #904 closes,
and have a canonical copy to edit.

## Attribution

Authored by **Paul Hsieh-Fu Tsai (蔡協孚)**, contributed in #904, distributed
under the MIT License with his explicit consent.

## Related
- Core paste feature: #907
- Original contribution: #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)