### PR TITLE
Handle font-scanner import error

### DIFF
--- a/apps/app/src/implementations/localFontHelper.ts
+++ b/apps/app/src/implementations/localFontHelper.ts
@@ -3,17 +3,17 @@ import { openSync } from 'fontkit';
 
 import { FontEvents } from '@core/app/constants/ipcEvents';
 import communicator from '@core/implementations/communicator';
-import type { FontDescriptor, LocalFontHelper } from '@core/interfaces/IFont';
+import type { FontDescriptor, FontDescriptorQuery, LocalFontHelper } from '@core/interfaces/IFont';
 
 interface Font extends FontkitFont {
   name?: { records: { fontFamily: Record<string, string> } };
 }
 
 export default {
-  findFont(fontDescriptor: FontDescriptor): FontDescriptor {
+  findFont(fontDescriptor: FontDescriptorQuery): FontDescriptor {
     return communicator.sendSync(FontEvents.FindFont, fontDescriptor);
   },
-  findFonts(fontDescriptor: FontDescriptor): FontDescriptor[] {
+  findFonts(fontDescriptor: FontDescriptorQuery): FontDescriptor[] {
     return communicator.sendSync(FontEvents.FindFonts, fontDescriptor);
   },
   getAvailableFonts(): FontDescriptor[] {
@@ -88,7 +88,7 @@ export default {
       return getFontFromPath;
     }
   },
-  substituteFont(postscriptName: string, text: string): FontDescriptor[] {
+  substituteFont(postscriptName: string, text: string): FontDescriptor {
     return communicator.sendSync(FontEvents.SubstituteFont, postscriptName, text);
   },
 } as LocalFontHelper;

--- a/apps/app/src/node/font-helper.ts
+++ b/apps/app/src/node/font-helper.ts
@@ -1,14 +1,27 @@
 import { ipcMain } from 'electron';
-import fontScanner from 'font-scanner';
 
 import { FontEvents } from '@core/app/constants/ipcEvents';
 
 import type Font from './interfaces/Fonts';
 
+// `font-scanner` is a native module that can fail to load on some devices
+// (e.g. missing system libraries). Loading it with a guarded require prevents
+// the import error from crashing the main process and blocking the renderer.
+// eslint-disable-next-line ts/consistent-type-imports
+let fontScanner: null | typeof import('font-scanner') = null;
+
+try {
+  fontScanner = require('font-scanner');
+} catch (error) {
+  console.error('Failed to load font-scanner, font features will be unavailable:', error);
+}
+
 let fontsListCache: Font[] = [];
 
+const getAvailableFontsSync = (): Font[] => fontScanner?.getAvailableFontsSync() ?? [];
+
 const findFontsSync = (arg: Font) => {
-  const availableFonts = fontsListCache || fontScanner.getAvailableFontsSync();
+  const availableFonts = fontsListCache || getAvailableFontsSync();
   const matchFamily = availableFonts.filter((font) => font.family === arg.family);
   const match = matchFamily.filter((font) => {
     let result = true;
@@ -25,14 +38,14 @@ const findFontsSync = (arg: Font) => {
   return match;
 };
 
-const findFontSync = (arg: Font) => {
+const findFontSync = (arg: Font): Font | undefined => {
   if (arg.postscriptName) {
-    return fontScanner.findFontSync(arg);
+    return fontScanner?.findFontSync(arg);
   }
 
   arg.style = arg.style || 'Regular';
 
-  const availableFonts = fontsListCache || fontScanner.getAvailableFontsSync();
+  const availableFonts = fontsListCache || getAvailableFontsSync();
   let font = availableFonts[0];
   let match = availableFonts.filter((f) => f.family === arg.family);
 
@@ -57,7 +70,7 @@ const findFontSync = (arg: Font) => {
 
 const registerEvents = (): void => {
   ipcMain.on(FontEvents.GetAvailableFonts, (event) => {
-    const fonts = fontScanner.getAvailableFontsSync();
+    const fonts = getAvailableFontsSync();
 
     fontsListCache = fonts;
     event.returnValue = fonts;
@@ -76,7 +89,7 @@ const registerEvents = (): void => {
   });
 
   ipcMain.on(FontEvents.SubstituteFont, (event, postscriptName, text) => {
-    const font = fontScanner.substituteFontSync(postscriptName, text);
+    const font = fontScanner?.substituteFontSync(postscriptName, text) ?? null;
 
     event.returnValue = font;
   });

--- a/packages/core/src/web/app/actions/beambox/font-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/font-funcs.ts
@@ -27,7 +27,7 @@ import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import weldPath from '@core/helpers/weldPath';
 import localFontHelper from '@core/implementations/localFontHelper';
 import storage from '@core/implementations/storage';
-import type { FontDescriptor, GeneralFont, GoogleFont, IFontQuery } from '@core/interfaces/IFont';
+import type { GeneralFont, GoogleFont, IFontQuery } from '@core/interfaces/IFont';
 import type { IBatchCommand } from '@core/interfaces/IHistory';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
@@ -498,7 +498,11 @@ const substitutedFont = async (font: GeneralFont, textElement: Element) => {
   if (!isWeb()) {
     unsupportedChar = [];
     textContent.forEach((char) => {
-      const sub = localFontHelper.substituteFont(originPostscriptName!, char) as FontDescriptor;
+      const sub = localFontHelper.substituteFont(originPostscriptName!, char);
+
+      if (!sub) {
+        return;
+      }
 
       if (sub.postscriptName !== originPostscriptName) {
         unsupportedChar.push(char);
@@ -521,7 +525,7 @@ const substitutedFont = async (font: GeneralFont, textElement: Element) => {
       for (const char of text ?? '') {
         const foundFont = localFontHelper.substituteFont(font.postscriptName!, char);
 
-        if (font.postscriptName !== foundFont!.postscriptName) {
+        if (!foundFont || font.postscriptName !== foundFont.postscriptName) {
           allFit = false;
           break;
         }


### PR DESCRIPTION
as title, some computer may throw `There is no built binary for font-manager` when importing `font-scanner`
And cause the main process to exit.

Add try-catch with `require` to replace the import