### PR TITLE
Fix promark button handler stopped with wrong status

### DIFF
--- a/packages/core/src/web/helpers/device/promark/promark-button-handler.ts
+++ b/packages/core/src/web/helpers/device/promark/promark-button-handler.ts
@@ -182,6 +182,7 @@ class PromarkButtonHandler {
         await closeFrame();
         dialogCaller.popDialogById(modalId.monitor);
         useCanvasStore.getState().setMode(CanvasMode.Draw);
+        await new Promise((resolve) => setTimeout(resolve, 50)); // Wait for dialog to close, not really needed here but just in case
         showFramingModal();
 
         return;
@@ -198,9 +199,10 @@ class PromarkButtonHandler {
       return;
     }
 
-    this.status = 'uploading';
+    this.status = 'preparing';
     await closeFrame();
     dialogCaller.popDialogById(modalId.monitor);
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for dialog to close
     await this.exportFn(true);
   };
 }


### PR DESCRIPTION
https://app.clickup.com/t/5719332/86ey98ub8
1. Fix status `uploading` -> `preparing` when triggered, so `handleTaskFinish` in `handleExportClick` works correctly when early return (return before `promarkButtonHandler.setStatus('preparing');`)
2. Wait `monitor` modal closed so  `handleExportClick` is not prevented by `isRelatedModalsExist`