### PR TITLE
Restructure .claude skills into SKILL.md directories

### DIFF
--- a/.claude/skills/camera-calibration/SKILL.md
+++ b/.claude/skills/camera-calibration/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: camera-calibration
+description: Camera calibration flows and camera data structures — fisheye parameter versions (V2/V3/V4), storage files, per-model dialog steps, SolvePnP and CheckPnP. Use when working on calibration dialogs under components/dialogs/camera/ or on cameraCalibrationApi.
+---
+
 # Camera Calibration & Camera Data
 
 Location: `packages/core/src/web/app/components/dialogs/camera/`

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,9 +1,14 @@
+---
+name: e2e-test
+description: Cypress E2E conventions for Beam Studio release-test automation under apps/web/cypress/ — spec layout, custom commands, and path-based gcode verification. Use when adding, updating, or debugging an E2E spec.
+---
+
 # E2E Test Skill (Cypress)
 
 Guide for writing Cypress E2E specs in Beam Studio. The release-test spreadsheet
 ("Beam Studio Test") is automated almost entirely through these specs, so **every new
 release-test automation lands here** unless it is pure logic (then prefer a Jest unit test —
-see `.claude/skills/unit-test.md`). Coverage roadmap: `docs/testing/test-coverage-plan.md`.
+see `.claude/skills/unit-test/SKILL.md`). Coverage roadmap: `docs/testing/test-coverage-plan.md`.
 
 ## Layout & Commands
 

--- a/.claude/skills/keychain-generator/SKILL.md
+++ b/.claude/skills/keychain-generator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: keychain-generator
+description: Keychain generator dialog — shape categories, Paper.js geometry operations, hole positioning by ray intersection, and the shape build pipeline. Use when working on components/dialogs/KeyChainGenerator/.
+---
+
 # Keychain Generator
 
 Location: `packages/core/src/web/app/components/dialogs/KeyChainGenerator/`

--- a/.claude/skills/svgedit-recalculate/SKILL.md
+++ b/.claude/skills/svgedit-recalculate/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: svgedit-recalculate
+description: SVG transform recalculation — how recalculateDimensions() absorbs translate, scale, and rotate into element attributes. Use when changing element transforms, implementing resize or rotate, or debugging transform and undo/redo bugs on the canvas.
+---
+
 # SVG Transform Recalculation System
 
 ## Purpose

--- a/.claude/skills/svgedit-text/SKILL.md
+++ b/.claude/skills/svgedit-text/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: svgedit-text
+description: SVG text editing system — multi-line text, tspans, fitText, and text-on-path. Use when creating or modifying text elements under app/svgedit/text/, textedit/, textactions.ts, or the TextContentBlock panel.
+---
+
 # SVG Text Editing System
 
 Location: `packages/core/src/web/app/svgedit/text/`

--- a/.claude/skills/unit-test/SKILL.md
+++ b/.claude/skills/unit-test/SKILL.md
@@ -1,10 +1,15 @@
+---
+name: unit-test
+description: Jest unit-test conventions for Beam Studio — spec layout, mocking patterns, and the shared __mocks__ inventory. Use when writing, updating, or debugging any *.spec.ts or *.spec.tsx file.
+---
+
 # Unit Test Skill
 
 Guide for writing Jest unit tests in the Beam Studio codebase. Follow it literally — every
 rule here was derived from the 400+ existing spec files; do not invent alternative patterns.
 
 For Cypress E2E specs (release-test automation under `apps/web/cypress/`), see
-`.claude/skills/e2e-test.md`. For the coverage roadmap, see `docs/testing/test-coverage-plan.md`.
+`.claude/skills/e2e-test/SKILL.md`. For the coverage roadmap, see `docs/testing/test-coverage-plan.md`.
 
 ## Framework & Config
 

--- a/apps/web/cypress/e2e/top-bar/auto-shrink.spec.ts
+++ b/apps/web/cypress/e2e/top-bar/auto-shrink.spec.ts
@@ -2,7 +2,7 @@
  * Auto Shrink / 自動內縮 (release-test sheet 文件設定 row:
  *   「測試自動內縮功能是否有正確作用（用 HEXA 測試複合填充路徑）」)
  *
- * Path-based verification (see .claude/skills/e2e-test.md → "Path-based verification"): Auto Shrink
+ * Path-based verification (see .claude/skills/e2e-test/SKILL.md → "Path-based verification"): Auto Shrink
  * changes the GENERATED TOOLPATH, not any UI state, so we assert against the FLUXGhost gcode via
  * cypress/support/taskPath.ts rather than the canvas.
  *

--- a/apps/web/cypress/e2e/top-bar/dpi-resolution.spec.ts
+++ b/apps/web/cypress/e2e/top-bar/dpi-resolution.spec.ts
@@ -2,7 +2,7 @@
  * Engrave DPI / resolution (release-test sheet 文件設定 row:
  *   「以不同 DPI 雕刻點陣圖確認解析度功能是否正常（點陣圖需開啟漸層）」)
  *
- * Path-based verification (see .claude/skills/e2e-test.md → "Path-based verification"): the DPI
+ * Path-based verification (see .claude/skills/e2e-test/SKILL.md → "Path-based verification"): the DPI
  * setting changes the GENERATED TOOLPATH, not any UI state, so we assert against the FLUXGhost
  * gcode via cypress/support/taskPath.ts rather than the canvas.
  *

--- a/docs/testing/test-coverage-plan.md
+++ b/docs/testing/test-coverage-plan.md
@@ -3,7 +3,7 @@
 Source: "Beam Studio Test 2026JUL.xlsx" (331 test cases) cross-referenced against the repo
 on branch 2.6.9, 2026-07-04. Row numbers below are the xlsx row numbers.
 
-Companion guides: `.claude/skills/unit-test.md` (Jest), `.claude/skills/e2e-test.md` (Cypress).
+Companion guides: `.claude/skills/unit-test/SKILL.md` (Jest), `.claude/skills/e2e-test/SKILL.md` (Cypress).
 
 ## 1. Current State
 

--- a/docs/tests/Overall-Analysis.md
+++ b/docs/tests/Overall-Analysis.md
@@ -48,7 +48,7 @@
 
 **已建立的資產**：
 - 測試表 CSV 的 Agent Status 欄（進度單一事實來源）＋ 22 個分類 `Summary.md`（人可讀索引）＋ 39 份逐 spec 審查筆記 ＋ 8 份 bug 報告。
-- 本地 rig 一鍵執行器與 `.claude/skills/e2e-test.md` 中的接線規範（未來新增受限 spec 只需在清單加一行）。
+- 本地 rig 一鍵執行器與 `.claude/skills/e2e-test/SKILL.md` 中的接線規範（未來新增受限 spec 只需在清單加一行）。
 - Google Fonts 的「攔截層＋真實 API 契約層」雙層模式——適合推廣到其他外部依賴（雲端 API 契約、FLUXGhost 版本升級煙霧測試）。
 
 **優先次序建議（成本效益由高至低）**：

--- a/docs/tests/document-settings/Summary.md
+++ b/docs/tests/document-settings/Summary.md
@@ -13,7 +13,7 @@
 | `apps/web/cypress/e2e/top-bar/dpi-resolution.spec.ts` | Cypress E2E（路徑驗證） | DPI 解析度對產生 gcode 的作用：掃描線數隨 DPI 倍增、間距減半、bbox 不變 + golden gcode 快照（需 FLUXGhost，本機批次執行） | Claude 自動產生 (2026-07) |
 | `apps/web/cypress/e2e/top-bar/auto-shrink.spec.ts` | Cypress E2E（路徑驗證） | 自動內縮：HEXA 複合填充路徑外框內縮 0.05mm、內孔外擴、<250 DPI 引擎閘門驗證 + OFF/ON golden gcode（需 FLUXGhost） | Claude 自動產生 (2026-07) |
 
-共用基礎：`apps/web/cypress/support/taskPath.ts`（gcode 擷取／解析／度量／golden 快照模組）與 `.claude/skills/e2e-test.md` 的「Path-based verification」準則。其餘項目（當前位置雕刻、實機雕刻品質）維持實機人工。
+共用基礎：`apps/web/cypress/support/taskPath.ts`（gcode 擷取／解析／度量／golden 快照模組）與 `.claude/skills/e2e-test/SKILL.md` 的「Path-based verification」準則。其餘項目（當前位置雕刻、實機雕刻品質）維持實機人工。
 
 ## 尚未自動化項目
 


### PR DESCRIPTION
## Why

Claude Code only discovers a skill when it lives in its own directory as `SKILL.md` with YAML frontmatter. Our guides were flat `.md` files with no frontmatter, so they were never registered — `/skills` listed nothing, and the guides only got read when someone already knew the path to point at.

## What changed

Each guide moves to `<name>/SKILL.md` and gains `name`/`description` frontmatter. Git tracked all six as renames, so history is preserved.

| Before | After |
|---|---|
| `.claude/skills/unit-test.md` | `.claude/skills/unit-test/SKILL.md` |
| `.claude/skills/e2e-test.md` | `.claude/skills/e2e-test/SKILL.md` |
| `.claude/skills/camera-calibration.md` | `.claude/skills/camera-calibration/SKILL.md` |
| `.claude/skills/keychain-generator.md` | `.claude/skills/keychain-generator/SKILL.md` |
| `.claude/skills/svgedit/text.md` | `.claude/skills/svgedit-text/SKILL.md` |
| `.claude/skills/svgedit/recalculate.md` | `.claude/skills/svgedit-recalculate/SKILL.md` |

The two svgedit docs become separate skills rather than one combined skill, so each gets a precise trigger — text-element work and transform work rarely come up together.

Descriptions name concrete files and symptoms (e.g. `*.spec.ts`, `textactions.ts`, "debugging transform and undo/redo bugs") rather than topic labels, since the description is the only thing visible before the skill loads and it's what decides whether the right guide fires.

Guide content is otherwise unchanged. The 7 references to the old paths — in `docs/testing/test-coverage-plan.md`, `docs/tests/`, and two cypress specs — are updated.

## Verification

All six skills now register and list correctly with their descriptions. No references to the old paths remain.