### PR TITLE
Kill orphaned Swiftray daemons holding port 6611

### DIFF
--- a/apps/app/src/node/backend-manager.ts
+++ b/apps/app/src/node/backend-manager.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'child_process';
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import os from 'os';
@@ -8,6 +8,8 @@ import path from 'path';
 import { app, ipcMain } from 'electron';
 
 import { BackendEvents } from '@core/app/constants/ipcEvents';
+
+import { getSwiftrayPaths, killStaleSwiftray, killSwiftrayPid } from './helpers/swiftrayProcess';
 
 function uglyJsonParser(data: string): any {
   try {
@@ -35,6 +37,9 @@ class BackendManager extends EventEmitter {
   private ghostLocation: string;
 
   private isRunning: boolean;
+
+  /** Whether start() was ever called, i.e. whether any process is ours to clean up. */
+  private hasStarted = false;
 
   private port?: number;
 
@@ -194,101 +199,99 @@ class BackendManager extends EventEmitter {
   }
 
   checkSwiftrayExists = (): boolean => {
-    if (!process.env.BACKEND_ROOT) {
-      return false;
-    }
+    const paths = getSwiftrayPaths();
 
-    let swiftrayDir: string;
-    let swiftrayExec: string;
-
-    if (os.platform() === 'win32') {
-      swiftrayDir = path.join(process.env.BACKEND_ROOT, 'swiftray');
-      swiftrayExec = 'Swiftray.exe';
-    } else if (os.platform() === 'darwin') {
-      swiftrayDir = path.join(process.env.BACKEND_ROOT, 'Swiftray.app', 'Contents', 'MacOS');
-      swiftrayExec = 'Swiftray';
-    } else {
-      console.error('checkSwiftrayExists: Unsupported platform');
+    if (!paths) {
+      console.error('checkSwiftrayExists: BACKEND_ROOT not set or unsupported platform');
 
       return false;
     }
 
-    return fs.existsSync(path.join(swiftrayDir, swiftrayExec));
+    return fs.existsSync(path.join(paths.dir, paths.exec));
   };
 
   spawnSwiftray(): void {
-    if (!process.env.BACKEND_ROOT) {
-      console.error('spawnSwiftray: BACKEND_ROOT not set');
+    const paths = getSwiftrayPaths();
+
+    if (!paths) {
+      console.error('spawnSwiftray: BACKEND_ROOT not set or unsupported platform');
 
       return;
     }
 
-    let swiftrayDir: string;
-    let swiftrayExec: string;
+    // A daemon orphaned by a crash or a force quit still owns the port, which would make the
+    // instance we are about to spawn unreachable. Clear the way before every spawn.
+    killStaleSwiftray();
 
-    if (os.platform() === 'win32') {
-      swiftrayDir = path.join(process.env.BACKEND_ROOT, 'swiftray');
-      swiftrayExec = 'Swiftray.exe';
-      this.swiftrayProc = spawn(`"${swiftrayExec}"`, ['--daemon'], {
-        cwd: swiftrayDir,
-        shell: true,
-      });
-    } else if (os.platform() === 'darwin') {
-      swiftrayDir = path.join(process.env.BACKEND_ROOT, 'Swiftray.app', 'Contents', 'MacOS');
-      swiftrayExec = 'Swiftray';
-      this.swiftrayProc = spawn(`./"${swiftrayExec}"`, ['--daemon'], {
-        cwd: swiftrayDir,
-        shell: true,
-      });
-    } else {
-      console.error('spawnSwiftray: Unsupported platform');
-    }
+    const command = os.platform() === 'win32' ? `"${paths.exec}"` : `./"${paths.exec}"`;
 
-    if (this.swiftrayProc) {
-      this.swiftrayProc.stdout?.on('data', (data) => {
-        console.log(`Swiftray: ${data}`);
-      });
-      this.swiftrayProc.stderr?.on('data', (data) => {
-        console.error(`Swiftray: ${data}`);
-      });
-      this.swiftrayProc.on('exit', () => {
-        console.error('Swiftray terminated unexpectedly!');
-        this.swiftrayProc = undefined;
+    this.swiftrayProc = spawn(command, ['--daemon'], { cwd: paths.dir, shell: true });
 
-        if (this.isRunning) {
-          this.setRecoverSwiftray();
-        }
-      });
-    }
+    this.swiftrayProc.stdout?.on('data', (data) => {
+      console.log(`Swiftray: ${data}`);
+    });
+    this.swiftrayProc.stderr?.on('data', (data) => {
+      console.error(`Swiftray: ${data}`);
+    });
+    this.swiftrayProc.on('exit', () => {
+      console.error('Swiftray terminated unexpectedly!');
+      // The handle is gone, but the daemon behind the shell wrapper may well have survived. It is
+      // no longer killable by pid, so hand it over to the name/port sweep.
+      this.swiftrayProc = undefined;
+
+      if (this.isRunning) {
+        this.setRecoverSwiftray();
+      } else {
+        killStaleSwiftray();
+      }
+    });
   }
 
   killSwiftray(): void {
-    if (this.swiftrayProc) {
-      if (os.platform() === 'win32' && this.swiftrayProc.pid) {
-        console.log(this.swiftrayProc.pid);
+    const { pid } = this.swiftrayProc ?? {};
 
-        const res = execSync(`taskkill /PID ${this.swiftrayProc.pid} /T /F`);
+    this.swiftrayProc = undefined;
 
-        console.log(res.toString());
-      } else {
-        this.swiftrayProc.kill();
-      }
-    }
+    if (pid) killSwiftrayPid(pid);
+
+    // `pid` is the shell wrapper, and on Windows a tree kill can miss a re-parented daemon, so
+    // always follow up with the name/port sweep.
+    killStaleSwiftray();
   }
 
   start(): void {
     if (!this.isRunning) {
       this.isRunning = true;
+      this.hasStarted = true;
       this.spawn();
       this.spawnSwiftray();
     }
   }
 
   stop(): void {
-    if (this.isRunning) {
-      this.isRunning = false;
-      this.proc?.kill();
+    // Never started: any running Swiftray belongs to another instance, leave it alone.
+    if (!this.hasStarted) return;
+
+    if (this.recoverTimerSwiftray) {
+      clearTimeout(this.recoverTimerSwiftray);
+      this.recoverTimerSwiftray = undefined;
+    }
+
+    if (this.recoverTimer) {
+      clearTimeout(this.recoverTimer);
+      this.recoverTimer = undefined;
+    }
+
+    // Not guarded by isRunning: stop() is also the last-chance cleanup on quit, and it must sweep
+    // orphans even when the manager already considers itself stopped.
+    this.isRunning = false;
+    this.proc?.kill();
+    this.proc = undefined;
+
+    try {
       this.killSwiftray();
+    } catch (error) {
+      console.error('Failed to kill Swiftray:', error);
     }
   }
 

--- a/apps/app/src/node/backend-manager.ts
+++ b/apps/app/src/node/backend-manager.ts
@@ -235,8 +235,6 @@ class BackendManager extends EventEmitter {
     });
     this.swiftrayProc.on('exit', () => {
       console.error('Swiftray terminated unexpectedly!');
-      // The handle is gone, but the daemon behind the shell wrapper may well have survived. It is
-      // no longer killable by pid, so hand it over to the name/port sweep.
       this.swiftrayProc = undefined;
 
       if (this.isRunning) {
@@ -269,7 +267,6 @@ class BackendManager extends EventEmitter {
   }
 
   stop(): void {
-    // Never started: any running Swiftray belongs to another instance, leave it alone.
     if (!this.hasStarted) return;
 
     if (this.recoverTimerSwiftray) {
@@ -282,8 +279,6 @@ class BackendManager extends EventEmitter {
       this.recoverTimer = undefined;
     }
 
-    // Not guarded by isRunning: stop() is also the last-chance cleanup on quit, and it must sweep
-    // orphans even when the manager already considers itself stopped.
     this.isRunning = false;
     this.proc?.kill();
     this.proc = undefined;

--- a/apps/app/src/node/backend-manager.ts
+++ b/apps/app/src/node/backend-manager.ts
@@ -38,8 +38,11 @@ class BackendManager extends EventEmitter {
 
   private isRunning: boolean;
 
-  /** Whether start() was ever called, i.e. whether any process is ours to clean up. */
+  /** Whether we have processes left to clean up, so stop() does not sweep twice. */
   private hasStarted = false;
+
+  /** Whether we spawned Swiftray, i.e. whether the daemon is ours to kill. */
+  private hasSpawnedSwiftray = false;
 
   private port?: number;
 
@@ -226,6 +229,7 @@ class BackendManager extends EventEmitter {
     const command = os.platform() === 'win32' ? `"${paths.exec}"` : `./"${paths.exec}"`;
 
     this.swiftrayProc = spawn(command, ['--daemon'], { cwd: paths.dir, shell: true });
+    this.hasSpawnedSwiftray = true;
 
     this.swiftrayProc.stdout?.on('data', (data) => {
       console.log(`Swiftray: ${data}`);
@@ -239,18 +243,22 @@ class BackendManager extends EventEmitter {
 
       if (this.isRunning) {
         this.setRecoverSwiftray();
-      } else {
-        killStaleSwiftray();
       }
     });
   }
 
   killSwiftray(): void {
-    const { pid } = this.swiftrayProc ?? {};
+    // Never spawned one: the running daemon belongs to another instance, so leave it alone.
+    if (!this.hasSpawnedSwiftray) return;
 
+    const proc = this.swiftrayProc;
+
+    this.hasSpawnedSwiftray = false;
     this.swiftrayProc = undefined;
+    // This exit is deliberate: skip the recover timer and the sweep the handler would add to ours.
+    proc?.removeAllListeners('exit');
 
-    if (pid) killSwiftrayPid(pid);
+    if (proc?.pid) killSwiftrayPid(proc.pid);
 
     // `pid` is the shell wrapper, and on Windows a tree kill can miss a re-parented daemon, so
     // always follow up with the name/port sweep.
@@ -262,12 +270,21 @@ class BackendManager extends EventEmitter {
       this.isRunning = true;
       this.hasStarted = true;
       this.spawn();
+    }
+  }
+
+  /** Separate from start() so the caller can keep the synchronous orphan sweep off the launch path. */
+  startSwiftray(): void {
+    if (this.isRunning && !this.swiftrayProc) {
       this.spawnSwiftray();
     }
   }
 
   stop(): void {
+    // Quitting can reach here twice (window close, then will-quit); one sweep is enough.
     if (!this.hasStarted) return;
+
+    this.hasStarted = false;
 
     if (this.recoverTimerSwiftray) {
       clearTimeout(this.recoverTimerSwiftray);

--- a/apps/app/src/node/electron-main.ts
+++ b/apps/app/src/node/electron-main.ts
@@ -175,11 +175,7 @@ const backendManager = new BackendManager({
   trace_pid: process.pid,
 });
 
-// Only the primary instance owns the backend processes. A duplicate instance is on its way out and
-// must not touch them, or it would kill the backend of the instance that holds the lock.
-if (gotTheLock) {
-  backendManager.start();
-}
+backendManager.start();
 
 // Run monitorexe api
 let monitorManager: MonitorManager | null = null;
@@ -498,6 +494,11 @@ const init = () => {
 app.whenReady().then(() => {
   init();
 
+  // After the window: the orphan sweep before the spawn is synchronous.
+  if (gotTheLock) {
+    backendManager.startSwiftray();
+  }
+
   app.on('activate', () => {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
@@ -513,10 +514,10 @@ app.on('window-all-closed', () => {
   }
 });
 
-// Last-chance cleanup: quitting does not always go through the main window close handler (auto
-// update restart, Cmd+Q, app.quit() from elsewhere), and an orphaned Swiftray keeps its port bound
-// so the next launch can never reach the daemon it spawns.
-app.on('before-quit', () => {
+// Last-chance cleanup for quit paths that skip the main window close handler (Cmd+Q, auto update
+// restart). 'will-quit' rather than 'before-quit': the latter fires before windows are asked to
+// close, so cancelling the unsaved-changes dialog would leave the app alive with a dead backend.
+app.on('will-quit', () => {
   monitorManager?.killProc();
   backendManager.stop();
 });

--- a/apps/app/src/node/electron-main.ts
+++ b/apps/app/src/node/electron-main.ts
@@ -175,12 +175,16 @@ const backendManager = new BackendManager({
   trace_pid: process.pid,
 });
 
-backendManager.start();
+// Only the primary instance owns the backend processes. A duplicate instance is on its way out and
+// must not touch them, or it would kill the backend of the instance that holds the lock.
+if (gotTheLock) {
+  backendManager.start();
+}
 
 // Run monitorexe api
 let monitorManager: MonitorManager | null = null;
 
-if (process.argv.includes('--monitor')) {
+if (gotTheLock && process.argv.includes('--monitor')) {
   console.log('Starting Monitor');
   monitorManager = new MonitorManager({ location: process.env.BACKEND || '' });
   // kill process first, in case last time shut down
@@ -509,4 +513,10 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('before-quit', () => {});
+// Last-chance cleanup: quitting does not always go through the main window close handler (auto
+// update restart, Cmd+Q, app.quit() from elsewhere), and an orphaned Swiftray keeps its port bound
+// so the next launch can never reach the daemon it spawns.
+app.on('before-quit', () => {
+  monitorManager?.killProc();
+  backendManager.stop();
+});

--- a/apps/app/src/node/helpers/swiftrayProcess.spec.ts
+++ b/apps/app/src/node/helpers/swiftrayProcess.spec.ts
@@ -1,18 +1,22 @@
-import { parseNetstatPids, parseTasklistName, SWIFTRAY_PORT } from './swiftrayProcess';
+import { SWIFTRAY_PORT } from '@core/app/constants/swiftray-constants';
+
+import { parseNetstatPids, parseTasklistName } from './swiftrayProcess';
 
 // Windows-only parsing, so it can only be covered here rather than by running the real commands.
 describe('parseNetstatPids', () => {
+  // Built from SWIFTRAY_PORT so the fixture cannot drift from the port the sweep actually uses.
+  const port = SWIFTRAY_PORT;
   const output = [
     '',
     'Active Connections',
     '',
     '  Proto  Local Address          Foreign Address        State           PID',
     '  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1080',
-    '  TCP    0.0.0.0:6611           0.0.0.0:0              LISTENING       9876',
-    '  TCP    [::]:6611              [::]:0                 LISTENING       9876',
-    '  TCP    127.0.0.1:6611         127.0.0.1:52341        ESTABLISHED     9876',
-    '  TCP    127.0.0.1:52341        127.0.0.1:6611         ESTABLISHED     4242',
-    '  TCP    0.0.0.0:16611          0.0.0.0:0              LISTENING       555',
+    `  TCP    0.0.0.0:${port}           0.0.0.0:0              LISTENING       9876`,
+    `  TCP    [::]:${port}              [::]:0                 LISTENING       9876`,
+    `  TCP    127.0.0.1:${port}         127.0.0.1:52341        ESTABLISHED     9876`,
+    `  TCP    127.0.0.1:52341        127.0.0.1:${port}         ESTABLISHED     4242`,
+    `  TCP    0.0.0.0:1${port}          0.0.0.0:0              LISTENING       555`,
     '',
   ].join('\r\n');
 
@@ -29,7 +33,7 @@ describe('parseNetstatPids', () => {
   });
 
   it('matches on the local address rather than the localized state word', () => {
-    const localized = '  TCP    0.0.0.0:6611           0.0.0.0:0              ABHOEREN        4321';
+    const localized = `  TCP    0.0.0.0:${port}           0.0.0.0:0              ABHOEREN        4321`;
 
     expect(parseNetstatPids(localized, SWIFTRAY_PORT)).toEqual([4321]);
   });

--- a/apps/app/src/node/helpers/swiftrayProcess.spec.ts
+++ b/apps/app/src/node/helpers/swiftrayProcess.spec.ts
@@ -1,0 +1,57 @@
+import { parseNetstatPids, parseTasklistName, SWIFTRAY_PORT } from './swiftrayProcess';
+
+// Windows-only parsing, so it can only be covered here rather than by running the real commands.
+describe('parseNetstatPids', () => {
+  const output = [
+    '',
+    'Active Connections',
+    '',
+    '  Proto  Local Address          Foreign Address        State           PID',
+    '  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1080',
+    '  TCP    0.0.0.0:6611           0.0.0.0:0              LISTENING       9876',
+    '  TCP    [::]:6611              [::]:0                 LISTENING       9876',
+    '  TCP    127.0.0.1:6611         127.0.0.1:52341        ESTABLISHED     9876',
+    '  TCP    127.0.0.1:52341        127.0.0.1:6611         ESTABLISHED     4242',
+    '  TCP    0.0.0.0:16611          0.0.0.0:0              LISTENING       555',
+    '',
+  ].join('\r\n');
+
+  it('returns the pid listening on the port, deduplicated', () => {
+    expect(parseNetstatPids(output, SWIFTRAY_PORT)).toEqual([9876]);
+  });
+
+  it('ignores our own client socket, whose local port is ephemeral', () => {
+    expect(parseNetstatPids(output, SWIFTRAY_PORT)).not.toContain(4242);
+  });
+
+  it('does not match a port that merely ends with the same digits', () => {
+    expect(parseNetstatPids(output, SWIFTRAY_PORT)).not.toContain(555);
+  });
+
+  it('matches on the local address rather than the localized state word', () => {
+    const localized = '  TCP    0.0.0.0:6611           0.0.0.0:0              ABHOEREN        4321';
+
+    expect(parseNetstatPids(localized, SWIFTRAY_PORT)).toEqual([4321]);
+  });
+
+  it('returns nothing for empty or header-only output', () => {
+    expect(parseNetstatPids('', SWIFTRAY_PORT)).toEqual([]);
+    expect(parseNetstatPids('Active Connections', SWIFTRAY_PORT)).toEqual([]);
+  });
+});
+
+describe('parseTasklistName', () => {
+  it('extracts the image name', () => {
+    expect(parseTasklistName('"Swiftray.exe","9876","Console","1","120,000 K"\r\n')).toBe('Swiftray.exe');
+  });
+
+  it('never yields a swiftray-like name when no task matched', () => {
+    const info = 'INFO: No tasks are running which match the specified criteria.\r\n';
+
+    expect(parseTasklistName(info).toLowerCase()).not.toContain('swiftray');
+  });
+
+  it('handles empty output', () => {
+    expect(parseTasklistName('')).toBe('');
+  });
+});

--- a/apps/app/src/node/helpers/swiftrayProcess.ts
+++ b/apps/app/src/node/helpers/swiftrayProcess.ts
@@ -1,0 +1,122 @@
+import { execSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+
+/** Port the Swiftray daemon listens on, must match the one used by @core/helpers/api/swiftray-client. */
+export const SWIFTRAY_PORT = 6611;
+
+export const getSwiftrayPaths = (): null | { dir: string; exec: string } => {
+  if (!process.env.BACKEND_ROOT) return null;
+
+  if (os.platform() === 'win32') {
+    return { dir: path.join(process.env.BACKEND_ROOT, 'swiftray'), exec: 'Swiftray.exe' };
+  }
+
+  if (os.platform() === 'darwin') {
+    return { dir: path.join(process.env.BACKEND_ROOT, 'Swiftray.app', 'Contents', 'MacOS'), exec: 'Swiftray' };
+  }
+
+  return null;
+};
+
+/** Best-effort command runner: a non-zero exit here just means "nothing to clean up". */
+const tryExec = (command: string): null | string => {
+  try {
+    return execSync(command, { stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 }).toString();
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Pids from `netstat -ano -p TCP` owning a socket whose *local* address is on `port`, i.e. the
+ * daemon's listener plus any connection it accepted. Sockets we opened as a client have an ephemeral
+ * local port and never match, so this cannot return Beam Studio itself.
+ *
+ * Column layout: Proto | Local Address | Foreign Address | State | PID. The state word is localized
+ * on non-English Windows, hence matching on the local address rather than on "LISTENING".
+ */
+export const parseNetstatPids = (output: string, port: number): number[] => {
+  const pids = new Set<number>();
+
+  for (const line of output.split('\n')) {
+    const columns = line.trim().split(/\s+/);
+
+    if (columns.length < 5 || columns[0].toUpperCase() !== 'TCP') continue;
+
+    if (!columns[1].endsWith(`:${port}`)) continue;
+
+    const pid = Number(columns[columns.length - 1]);
+
+    if (pid > 0) pids.add(pid);
+  }
+
+  return [...pids];
+};
+
+/** First field of a `tasklist /NH /FO CSV` row: `"Swiftray.exe","1234","Console","1","120,000 K"`. */
+export const parseTasklistName = (output: string): string => output.split(',')[0]?.replace(/"/g, '').trim() ?? '';
+
+const getPidsOnPort = (port: number): number[] => {
+  let pids: number[] = [];
+
+  if (os.platform() === 'win32') {
+    pids = parseNetstatPids(tryExec('netstat -ano -p TCP') ?? '', port);
+  } else if (os.platform() === 'darwin') {
+    pids = (tryExec(`lsof -nP -iTCP:${port} -sTCP:LISTEN -t`) ?? '')
+      .split('\n')
+      .map((line) => Number(line.trim()))
+      .filter((pid) => pid > 0);
+  }
+
+  return pids.filter((pid) => pid !== process.pid);
+};
+
+const getProcessName = (pid: number): string => {
+  if (os.platform() === 'win32') {
+    // When no task matches, tasklist prints an INFO line instead — harmless, it never says "swiftray".
+    return parseTasklistName(tryExec(`tasklist /NH /FO CSV /FI "PID eq ${pid}"`) ?? '');
+  }
+
+  // macOS `ps -o comm=` prints the full executable path, e.g. .../Swiftray.app/Contents/MacOS/Swiftray
+  return tryExec(`ps -p ${pid} -o comm=`)?.trim() ?? '';
+};
+
+const killPid = (pid: number): void => {
+  tryExec(os.platform() === 'win32' ? `taskkill /F /T /PID ${pid}` : `kill -9 ${pid}`);
+};
+
+/**
+ * Kill every Swiftray daemon we are not tracking: leftovers from a crashed or force-quit Beam Studio.
+ * A stale daemon keeps SWIFTRAY_PORT bound, so a freshly spawned one can never be reached and the
+ * user is stuck until they kill it by hand from the task manager.
+ */
+export const killStaleSwiftray = (): void => {
+  const platform = os.platform();
+
+  if (platform !== 'win32' && platform !== 'darwin') return;
+
+  // By image name: also catches an instance that never managed to bind the port.
+  const byName = platform === 'win32' ? tryExec('taskkill /F /T /IM Swiftray.exe') : tryExec('pkill -x Swiftray');
+
+  if (byName !== null) console.log('Killed stale Swiftray process by name');
+
+  // By port: catches a renamed or relocated binary still squatting on SWIFTRAY_PORT.
+  for (const pid of getPidsOnPort(SWIFTRAY_PORT)) {
+    const name = getProcessName(pid);
+
+    if (!name.toLowerCase().includes('swiftray')) {
+      console.warn(`Port ${SWIFTRAY_PORT} is held by "${name}" (pid ${pid}), not killing it`);
+      continue;
+    }
+
+    console.log(`Killing stale Swiftray (pid ${pid}) holding port ${SWIFTRAY_PORT}`);
+    killPid(pid);
+  }
+};
+
+/** Kill a Swiftray we spawned. On Windows `pid` is the cmd.exe wrapper, so the whole tree must go. */
+export const killSwiftrayPid = (pid: number): void => {
+  console.log(`Killing Swiftray process tree (pid ${pid})`);
+  killPid(pid);
+};

--- a/apps/app/src/node/helpers/swiftrayProcess.ts
+++ b/apps/app/src/node/helpers/swiftrayProcess.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import os from 'os';
 import path from 'path';
 
@@ -22,6 +22,15 @@ export const getSwiftrayPaths = (): null | { dir: string; exec: string } => {
 const tryExec = (command: string): null | string => {
   try {
     return execSync(command, { stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 }).toString();
+  } catch {
+    return null;
+  }
+};
+
+/** Same contract as {@link tryExec}, but argv-based so patterns need no shell quoting. */
+const tryExecFile = (file: string, args: string[]): null | string => {
+  try {
+    return execFileSync(file, args, { stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 }).toString();
   } catch {
     return null;
   }
@@ -95,8 +104,13 @@ export const killStaleSwiftray = (): void => {
 
   if (platform !== 'win32' && platform !== 'darwin') return;
 
-  // By image name: also catches an instance that never managed to bind the port.
-  const byName = platform === 'win32' ? tryExec('taskkill /F /T /IM Swiftray.exe') : tryExec('pkill -x Swiftray');
+  // By image name: also catches an instance that never managed to bind the port. macOS matches the
+  // `--daemon` argument so a Swiftray the user opened themselves survives; taskkill cannot filter on
+  // the command line, so on Windows the image name is all we have.
+  const byName =
+    platform === 'win32'
+      ? tryExec('taskkill /F /T /IM Swiftray.exe')
+      : tryExecFile('pkill', ['-f', 'Swiftray.*--daemon']);
 
   if (byName !== null) console.log('Killed stale Swiftray process by name');
 

--- a/apps/app/src/node/helpers/swiftrayProcess.ts
+++ b/apps/app/src/node/helpers/swiftrayProcess.ts
@@ -2,8 +2,7 @@ import { execSync } from 'child_process';
 import os from 'os';
 import path from 'path';
 
-/** Port the Swiftray daemon listens on, must match the one used by @core/helpers/api/swiftray-client. */
-export const SWIFTRAY_PORT = 6611;
+import { SWIFTRAY_PORT } from '@core/app/constants/swiftray-constants';
 
 export const getSwiftrayPaths = (): null | { dir: string; exec: string } => {
   if (!process.env.BACKEND_ROOT) return null;

--- a/packages/core/src/web/app/constants/swiftray-constants.ts
+++ b/packages/core/src/web/app/constants/swiftray-constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Port the Swiftray daemon listens on.
+ *
+ * Shared by the renderer (which connects to it) and the Electron main process (which spawns the
+ * daemon and sweeps orphans still holding the port), so both sides must agree on the value.
+ */
+export const SWIFTRAY_PORT = 6611;

--- a/packages/core/src/web/helpers/api/swiftray-client.ts
+++ b/packages/core/src/web/helpers/api/swiftray-client.ts
@@ -8,6 +8,7 @@ import MessageCaller, { MessageLevel } from '@core/app/actions/message-caller';
 import TopBarController from '@core/app/components/beambox/TopBar/contexts/TopBarController';
 import alertConstants from '@core/app/constants/alert-constants';
 import { BackendEvents } from '@core/app/constants/ipcEvents';
+import { SWIFTRAY_PORT } from '@core/app/constants/swiftray-constants';
 import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
 import { useDocumentStore } from '@core/app/stores/documentStore';
@@ -618,12 +619,12 @@ checkSwiftray()
   });
 
 const swiftrayHost = localStorage.getItem('swiftrayHost') || 'localhost';
-const swiftrayClient = new SwiftrayClient(`ws://${swiftrayHost}:6611`);
+const swiftrayClient = new SwiftrayClient(`ws://${swiftrayHost}:${SWIFTRAY_PORT}`);
 
 const getDeviceClient = async (port: string): Promise<SwiftrayClient> => {
   console.log(`Connecting to device on port ${port}`);
   // TODO:SWIFTRAY - Open a new instance of Swiftray, and use different port number
-  // const sc = new SwiftrayClient(`ws://localhost:6611/`);
+  // const sc = new SwiftrayClient(`ws://localhost:${SWIFTRAY_PORT}/`);
   await swiftrayClient.connectDevice(port);
 
   return swiftrayClient;


### PR DESCRIPTION
## 問題

有些時候 Swiftray 會在 Beam Studio 關閉後繼續存活。殘留的 daemon 一直佔住 6611 port，下次啟動時新生成的 Swiftray 就連不上——如果舊的那個已經卡在異常狀態，使用者就只能自己去工作管理員把它砍掉，否則 Swiftray 完全不能用。

目前有三條可能讓 daemon 存活的路徑：

- `spawnSwiftray` 使用 `shell: true`，所以在 Windows 上 `swiftrayProc.pid` 是 **cmd.exe 這層 wrapper**，不是 Swiftray 本身。wrapper 一結束，`exit` handler 就把 `swiftrayProc` 設回 `undefined`，之後 `killSwiftray()` 永遠是空操作，但 daemon 其實還活著。
- `stop()` 只會從主視窗關閉的 `doClose()` 進來。Cmd+Q、自動更新重啟，或任何其他 `app.quit()` 路徑都不會殺掉 Swiftray。
- `execSync('taskkill …')` 在 pid 已經消失時會 throw，導致 `stop()` 後面的清理全部中斷。

## 修正

不再只依賴我們手上的 pid，改成用 image name + port 佔用者一起掃——和 `MonitorManager.killProcSync()` 對 `monitorexe` 的做法一致。

- **新增 `helpers/swiftrayProcess.ts`** — `killStaleSwiftray()`（先依 image name 殺，再殺佔用 6611 port 的行程）、`killSwiftrayPid()`，以及 `getSwiftrayPaths()`（把 `checkSwiftrayExists` 和 `spawnSwiftray` 各自重複一份的路徑邏輯收斂起來）。
- **每次 spawn 前都先掃一次**，讓 crash 或強制關閉留下的殘骸不可能擋住我們正要啟動的實例。
- **殺掉追蹤中的 pid 後再補一次掃描**，因為活得比 shell wrapper 還久的 daemon 已經無法用 pid 殺掉。同時移除該 process 的 `exit` listener，避免這次「刻意的結束」觸發 recover timer。
- **`will-quit` 進行清理**，補上不會經過主視窗關閉 handler 的離開路徑（Cmd+Q、自動更新重啟）。用 `will-quit` 而不是 `before-quit`：後者在視窗被要求關閉「之前」就觸發，使用者若在未儲存提示中按取消，App 會繼續活著但 backend 已經死了。
- **`stop()`** 會取消還在等待的 recover timer、以 `hasStarted` 擋掉重複進入（關視窗後又 `will-quit`）只掃一次，並把 kill 包在 try/catch 裡。
- **重複啟動的第二個實例不再碰 backend。** 這是這次修改必要的配套：第二個實例拿不到 single-instance lock 但仍會走到 backend 啟動流程，新的掃描就會把**主實例**的 Swiftray 一起殺掉。現在只有拿到 lock 的實例會 `startSwiftray()`，而 `killSwiftray()` 也只在 `hasSpawnedSwiftray` 為真時才動手。
- **`startSwiftray()` 從 `start()` 拆出來**，改在 `app.whenReady()` 建立視窗之後才呼叫，把 spawn 前那段同步的掃描移出啟動關鍵路徑。
- **`SWIFTRAY_PORT` 移到 `@core/app/constants/swiftray-constants.ts`**，由 renderer（連線端）與 Electron main（spawn 與掃 port 端）共用，避免兩邊各寫一份而悄悄不同步。

### Port 掃描的兩個安全細節

- Windows `netstat` 的狀態字串**會被在地化**，比對 `"LISTENING"` 在非英文 Windows 上會失效。改成比對**本地位址**結尾是否為 `:6611`——這同時也在結構上排除了 Beam Studio 自己的 client socket（其本地 port 是 ephemeral）。
- 佔用 port 的行程只有在 image name 含有 `swiftray` 時才會被殺，否則只記錄警告，不會誤殺其他 App。
- macOS 依名稱清理時用 `pkill -f 'Swiftray.*--daemon'` 比對 `--daemon` 參數，使用者自己開的 Swiftray 不受影響；Windows 的 `taskkill` 無法用命令列參數過濾，只能用 image name。

## 測試

- 8 個新單元測試涵蓋 `netstat` / `tasklist` 的解析——這段 Windows-only 的程式碼在 macOS 上沒有其他方式驗證（在地化狀態字串、`:16611` 與 `:6611`、我們自己的 client socket、tasklist 的 "no tasks" INFO 行）。
- 所有異動檔案 `tsc` 與 `eslint` 皆無問題。
- macOS 的 `lsof` / `ps` 指令格式已對照實際 listener 驗證。

**未驗證：** Windows 上真的有一個卡住的 Swiftray 時的實際行為，這需要 Windows 機器。

---

## Problem

Windows users report Swiftray surviving Beam Studio. Because the orphan keeps port 6611 bound, the Swiftray spawned by the next launch is unreachable — so if the old one is stuck in a bad state, Swiftray is unusable until the user kills it manually from the task manager.

Three ways the daemon escapes today:

- `spawnSwiftray` uses `shell: true`, so on Windows `swiftrayProc.pid` is the **cmd.exe wrapper**, not Swiftray. Once that wrapper exits, the `exit` handler sets `swiftrayProc = undefined` and `killSwiftray()` is a no-op forever, even though the daemon is still alive.
- `stop()` only ran from `doClose()` on main-window close. Cmd+Q, auto-update restart, or any other `app.quit()` path never killed Swiftray.
- `execSync('taskkill …')` threw when the pid was already gone, aborting the rest of `stop()`.

## Fix

Stop relying solely on the pid we hold, and sweep by image name + port owner — the same approach `MonitorManager.killProcSync()` already uses for `monitorexe`.

- **New `helpers/swiftrayProcess.ts`** — `killStaleSwiftray()` (kill by image name, then anything owning port 6611), `killSwiftrayPid()`, and `getSwiftrayPaths()` (deduplicates the path logic `checkSwiftrayExists` and `spawnSwiftray` each carried).
- **Sweep before every spawn**, so a leftover from a crash or force quit can never block the instance we are about to start.
- **Sweep again after killing the tracked pid**, since a daemon that outlived its shell wrapper is no longer killable by pid. The process's `exit` listener is removed first, so this deliberate exit does not arm the recover timer.
- **`will-quit` now runs cleanup**, covering the quit paths that never reached the main-window close handler (Cmd+Q, auto-update restart). `will-quit` rather than `before-quit`: the latter fires *before* windows are asked to close, so cancelling the unsaved-changes dialog would leave the app alive with a dead backend.
- **`stop()`** cancels pending recover timers, is guarded by `hasStarted` so the window-close-then-`will-quit` path only sweeps once, and wraps the kill in try/catch.
- **Duplicate instances no longer touch the backend.** Required by this change: a second instance loses the single-instance lock but still reached backend startup, so the new sweep would have killed the *primary* instance's Swiftray on the duplicate's way out. Only the lock holder calls `startSwiftray()`, and `killSwiftray()` no-ops unless `hasSpawnedSwiftray`.
- **`startSwiftray()` split out of `start()`** and called from `app.whenReady()` after the window is created, keeping the synchronous pre-spawn sweep off the launch critical path.
- **`SWIFTRAY_PORT` moved to `@core/app/constants/swiftray-constants.ts`**, shared by the renderer (which connects) and the Electron main process (which spawns and sweeps the port), so the two cannot drift apart silently.

### Safety details in the port sweep

- Windows `netstat` state words are **localized**, so matching on `"LISTENING"` breaks on non-English Windows. We match on the *local* address ending in `:6611` instead — which also structurally excludes Beam Studio's own client socket, whose local port is ephemeral.
- A port holder is only killed if its image name contains `swiftray`; otherwise it logs a warning rather than killing an unrelated app.
- The macOS name sweep uses `pkill -f 'Swiftray.*--daemon'`, so a Swiftray the user opened themselves survives; Windows `taskkill` cannot filter on the command line, so the image name is all we have there.

## Testing

- 8 new unit tests cover the `netstat` / `tasklist` parsing — Windows-only code that cannot be exercised on macOS otherwise (localized state word, `:16611` vs `:6611`, our own client socket, the "no tasks" INFO line).
- `tsc` and `eslint` clean on all changed files.
- macOS `lsof` / `ps` command shapes verified against a live listener.

**Not verified:** real-world behavior on Windows with a genuinely stuck Swiftray — that needs a Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
