### PR TITLE
Drive web menu disabled state from a shared store

### DIFF
--- a/apps/web/src/implementations/menu.ts
+++ b/apps/web/src/implementations/menu.ts
@@ -1,25 +1,18 @@
 /* eslint-disable import/order */
 import AbstractMenu from '@core/helpers/menubar/AbstractMenu';
-import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
+import { useMenuItemStatusStore } from '@core/app/stores/menuItemStatusStore';
 
 class Menu extends AbstractMenu {
-  private eventEmitter;
-
-  constructor() {
-    super();
-    this.eventEmitter = eventEmitterFactory.createEventEmitter('top-bar-menu');
-  }
-
   init(): void {
     this.initMenuEvents();
   }
 
   enable(items: string[]): void {
-    this.eventEmitter.emit('ENABLE_MENU_ITEM', items);
+    useMenuItemStatusStore.getState().enable(items);
   }
 
   disable(items: string[]): void {
-    this.eventEmitter.emit('DISABLE_MENU_ITEM', items);
+    useMenuItemStatusStore.getState().disable(items);
   }
 
   updateLanguage(): void {}

--- a/packages/core/src/web/app/components/beambox/TopBar/Menu.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/TopBar/Menu.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import { MenuEvents } from '@core/app/constants/ipcEvents';
 import { __setMockOS } from '@mocks/@core/helpers/getOS';
@@ -58,10 +58,14 @@ jest.mock('@core/app/stores/screenStore', () => ({
 
 __setMockOS('MacOS');
 
+import { useMenuItemStatusStore } from '@core/app/stores/menuItemStatusStore';
+import { INITIALLY_DISABLED_MENU_ITEMS } from '@core/helpers/menubar/menuItemStatus';
+
 import Menu from './Menu';
 
 describe('should render correctly', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     Object.assign(mockGlobalPreference, defaultGlobalPreference);
     mockUseGlobalPreferenceStore.mockImplementation((selector) => selector(mockGlobalPreference));
     mockRegister.mockReturnValue(mockUnregister);
@@ -92,6 +96,9 @@ describe('should render correctly', () => {
       mockGlobalPreference[key] = false;
     }
 
+    // as if the editor page had attached the menu, otherwise the items are disabled
+    useMenuItemStatusStore.getState().enable(INITIALLY_DISABLED_MENU_ITEMS);
+
     const { container, getByText, rerender } = render(<Menu />);
 
     expect(container).toMatchSnapshot();
@@ -108,6 +115,42 @@ describe('should render correctly', () => {
     mockGlobalPreference.show_rulers = true;
     rerender(<Menu />);
     expect(container).toMatchSnapshot();
+  });
+
+  test('disabled status follows menu item status store', () => {
+    mockUseGlobalPreferenceStore.mockReturnValue(true);
+
+    const { container, getByText } = render(<Menu />);
+
+    fireEvent.click(container.querySelector('div.menu-btn-container'));
+    fireEvent.click(getByText('Edit'));
+
+    // DUPLICATE starts disabled, like `enabled: false` in the electron menu template
+    expect(getByText('Duplicate').closest('[role="menuitem"]')).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(getByText('Duplicate'));
+    expect(emit).not.toHaveBeenCalled();
+
+    act(() => useMenuItemStatusStore.getState().enable(['DUPLICATE']));
+    expect(getByText('Duplicate').closest('[role="menuitem"]')).not.toHaveAttribute('aria-disabled');
+
+    fireEvent.click(getByText('Duplicate'));
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenNthCalledWith(1, MenuEvents.MenuClick, null, { id: 'DUPLICATE' });
+  });
+
+  test('submenu disabled status follows menu item status store', () => {
+    mockUseGlobalPreferenceStore.mockReturnValue(true);
+
+    const { container, getByText } = render(<Menu />);
+
+    fireEvent.click(container.querySelector('div.menu-btn-container'));
+    fireEvent.click(getByText('Edit'));
+
+    expect(getByText('Image').closest('[role="menuitem"]')).toHaveAttribute('aria-disabled', 'true');
+
+    act(() => useMenuItemStatusStore.getState().enable(['PHOTO_EDIT']));
+    expect(getByText('Image').closest('[role="menuitem"]')).not.toHaveAttribute('aria-disabled');
   });
 
   test('already signed in', () => {

--- a/packages/core/src/web/app/components/beambox/TopBar/__snapshots__/Menu.spec.tsx.snap
+++ b/packages/core/src/web/app/components/beambox/TopBar/__snapshots__/Menu.spec.tsx.snap
@@ -505,14 +505,16 @@ exports[`should render correctly open the browser and reach the correct page 3`]
             About Beam Studio
           </li>
           <li
-            class="szh-menu__item"
+            aria-disabled="true"
+            class="szh-menu__item szh-menu__item--disabled"
             role="menuitem"
             tabindex="-1"
           >
             Show Start Tutorial
           </li>
           <li
-            class="szh-menu__item"
+            aria-disabled="true"
+            class="szh-menu__item szh-menu__item--disabled"
             role="menuitem"
             tabindex="-1"
           >

--- a/packages/core/src/web/app/components/beambox/TopBar/useMenuData.ts
+++ b/packages/core/src/web/app/components/beambox/TopBar/useMenuData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { adorModels, fcodeV2Models, modelsWithModules, promarkModels } from '@core/app/actions/beambox/constant';
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
@@ -6,10 +6,10 @@ import type { MenuItemKey } from '@core/app/constants/menuItems';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
 import { useDockableStore } from '@core/app/stores/dockableStore';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
+import { useMenuItemStatusStore } from '@core/app/stores/menuItemStatusStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
 import { discoverManager } from '@core/helpers/api/discover';
 import { checkBM2, checkHxRf } from '@core/helpers/checkFeature';
-import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import isWeb from '@core/helpers/is-web';
 import { getModulesTranslations } from '@core/helpers/layer-module/layer-module-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -32,9 +32,20 @@ export interface MenuNode {
 
 const divider: MenuNode = { type: 'divider' };
 
+/**
+ * Resolve `disabled` from the shared menu item status, an explicit `disabled` on the node wins so
+ * that static conditions (mobile only items, ...) can still be expressed in the tree.
+ */
+const applyDisabledKeys = (nodes: MenuNode[], disabledKeys: Set<string>): MenuNode[] =>
+  nodes.map((node) => ({
+    ...node,
+    children: node.children ? applyDisabledKeys(node.children, disabledKeys) : undefined,
+    disabled: node.disabled ?? (node.id !== undefined && disabledKeys.has(node.id)),
+  }));
+
 const useMenuData = (email?: string): MenuNode[] => {
-  const eventEmitter = useMemo(() => eventEmitterFactory.createEventEmitter('top-bar-menu'), []);
   const [devices, setDevices] = useState<IDeviceInfo[]>([]);
+  const disabledKeys = useMenuItemStatusStore((state) => state.disabledKeys);
 
   const shouldShowRulers = useGlobalPreferenceStore((state) => state.show_rulers);
   const shouldShowGrids = useGlobalPreferenceStore((state) => state.show_grids);
@@ -47,49 +58,6 @@ const useMenuData = (email?: string): MenuNode[] => {
   const isPanelLayerControlsShown = useDockableStore((state) => state.panelLayerControls);
   const isPanelObjectControlsShown = useDockableStore((state) => state.panelObjectProperties);
   const isPanelPathControlsShown = useDockableStore((state) => state.panelPathEdit);
-
-  const [duplicateDisabled, setDuplicateDisabled] = useState(true);
-  const [svgEditDisabled, setSvgEditDisabled] = useState(true);
-  const [decomposePathDisabled, setDecomposePathDisabled] = useState(true);
-  const [groupDisabled, setGroupDisabled] = useState(true);
-  const [ungroupDisabled, setUngroupDisabled] = useState(true);
-  const [pathDisabled, setPathDisabled] = useState(true);
-  const [imageEditDisabled, setImageEditDisabled] = useState(true);
-  const [dockableDisabled, setDockableDisabled] = useState(false);
-
-  const menuItemUpdater = {
-    DECOMPOSE_PATH: setDecomposePathDisabled,
-    DUPLICATE: setDuplicateDisabled,
-    GROUP: setGroupDisabled,
-    PATH: setPathDisabled,
-    PHOTO_EDIT: setImageEditDisabled,
-    RESET_LAYOUT: setDockableDisabled,
-    SVG_EDIT: setSvgEditDisabled,
-    UNGROUP: setUngroupDisabled,
-  };
-
-  useEffect(() => {
-    eventEmitter.on('ENABLE_MENU_ITEM', (items: string[]) => {
-      for (let i = 0; i < items.length; i += 1) {
-        const item = items[i] as keyof typeof menuItemUpdater;
-
-        menuItemUpdater[item]?.(false);
-      }
-    });
-
-    eventEmitter.on('DISABLE_MENU_ITEM', (items: string[]) => {
-      for (let i = 0; i < items.length; i += 1) {
-        const item = items[i] as keyof typeof menuItemUpdater;
-
-        menuItemUpdater[item]?.(true);
-      }
-    });
-
-    return () => {
-      eventEmitter.removeListener('ENABLE_MENU_ITEM');
-      eventEmitter.removeListener('DISABLE_MENU_ITEM');
-    };
-  });
 
   useEffect(() => {
     const unregister = discoverManager.register('top-bar-menu', (newDevices: IDeviceInfo[]) => {
@@ -234,7 +202,7 @@ const useMenuData = (email?: string): MenuNode[] => {
           ]
         : []),
       divider,
-      { children: calibrationChildren, label: menuCms.calibration, type: 'submenu' },
+      { children: calibrationChildren, id: 'CALIBRATION', label: menuCms.calibration, type: 'submenu' },
       ...(!isPromark ? [divider] : []),
       ...(fcodeV2Models.has(model)
         ? [
@@ -451,6 +419,7 @@ const useMenuData = (email?: string): MenuNode[] => {
             type: 'submenu',
           },
         ],
+        id: 'SAMPLES',
         label: menuCms.samples,
         type: 'submenu',
       },
@@ -466,6 +435,7 @@ const useMenuData = (email?: string): MenuNode[] => {
             ? [{ id: 'EXPORT_UV_PRINT', label: menuCms.export_UV_print, type: 'item' as const }]
             : []),
         ],
+        id: 'EXPORT_TO',
         label: menuCms.export_to,
         type: 'submenu',
       },
@@ -485,17 +455,17 @@ const useMenuData = (email?: string): MenuNode[] => {
       { hotkey: 'copy', id: 'COPY', type: 'item' },
       { hotkey: 'paste', id: 'PASTE', type: 'item' },
       { hotkey: 'paste_in_place', id: 'PASTE_IN_PLACE', type: 'item' },
-      { disabled: duplicateDisabled, hotkey: 'duplicate', id: 'DUPLICATE', type: 'item' },
+      { hotkey: 'duplicate', id: 'DUPLICATE', type: 'item' },
       divider,
-      { disabled: groupDisabled, hotkey: 'group', id: 'GROUP', type: 'item' },
-      { disabled: ungroupDisabled, hotkey: 'ungroup', id: 'UNGROUP', type: 'item' },
+      { hotkey: 'group', id: 'GROUP', type: 'item' },
+      { hotkey: 'ungroup', id: 'UNGROUP', type: 'item' },
       divider,
       {
         children: [
           { id: 'OFFSET', label: menuCms.offset, type: 'item' },
-          { disabled: decomposePathDisabled, id: 'DECOMPOSE_PATH', label: menuCms.decompose_path, type: 'item' },
+          { id: 'DECOMPOSE_PATH', label: menuCms.decompose_path, type: 'item' },
         ],
-        disabled: pathDisabled,
+        id: 'PATH',
         label: menuCms.path,
         type: 'submenu',
       },
@@ -508,18 +478,19 @@ const useMenuData = (email?: string): MenuNode[] => {
           { id: 'IMAGE_VECTORIZE', label: menuCms.image_vectorize, type: 'item' },
           { id: 'IMAGE_CURVE', label: menuCms.image_curve, type: 'item' },
         ],
-        disabled: imageEditDisabled,
+        id: 'PHOTO_EDIT',
         label: menuCms.photo_edit,
         type: 'submenu',
       },
       {
         children: [{ id: 'DISASSEMBLE_USE', label: menuCms.disassemble_use, type: 'item' }],
-        disabled: svgEditDisabled,
+        id: 'SVG_EDIT',
         label: menuCms.svg_edit,
         type: 'submenu',
       },
       {
         children: [{ id: 'LAYER_COLOR_CONFIG', label: menuCms.layer_color_config, type: 'item' }],
+        id: 'LAYER',
         label: menuCms.layer_setting,
         type: 'submenu',
       },
@@ -578,25 +549,22 @@ const useMenuData = (email?: string): MenuNode[] => {
 
   const windowMenu: MenuNode = {
     children: [
-      { disabled: dockableDisabled, id: 'RESET_LAYOUT', label: menuCms.reset_layout, type: 'item' },
+      { id: 'RESET_LAYOUT', label: menuCms.reset_layout, type: 'item' },
       divider,
       {
         checked: isPanelLayerControlsShown,
-        disabled: dockableDisabled,
         id: 'SHOW_LAYER_CONTROLS_PANEL',
         label: menuCms.tab_layers,
         type: 'checkbox',
       },
       {
         checked: isPanelObjectControlsShown,
-        disabled: dockableDisabled,
         id: 'SHOW_OBJECT_CONTROLS_PANEL',
         label: menuCms.tab_objects,
         type: 'checkbox',
       },
       {
         checked: isPanelPathControlsShown,
-        disabled: dockableDisabled,
         id: 'SHOW_PATH_CONTROLS_PANEL',
         label: menuCms.tab_path_edit,
         type: 'checkbox',
@@ -635,7 +603,10 @@ const useMenuData = (email?: string): MenuNode[] => {
     type: 'submenu',
   };
 
-  return [fileMenu, editMenu, viewMenu, machinesMenu, toolsMenu, accountMenu, windowMenu, helpMenu];
+  return applyDisabledKeys(
+    [fileMenu, editMenu, viewMenu, machinesMenu, toolsMenu, accountMenu, windowMenu, helpMenu],
+    disabledKeys,
+  );
 };
 
 export default useMenuData;

--- a/packages/core/src/web/app/pages/Beambox.tsx
+++ b/packages/core/src/web/app/pages/Beambox.tsx
@@ -19,6 +19,7 @@ import workareaManager from '@core/app/svgedit/workarea';
 import DockViewLayout from '@core/app/widgets/dockable/DockViewLayout';
 import ToolBarDrawerContainer from '@core/app/widgets/dockable/ToolBarDrawerContainer';
 import { hashMap } from '@core/helpers/hashHelper';
+import isWeb from '@core/helpers/is-web';
 import sentryHelper from '@core/helpers/sentry-helper';
 import BeamboxInit from '@core/implementations/beamboxInit';
 import communicator from '@core/implementations/communicator';
@@ -41,7 +42,12 @@ const Beambox = (): React.JSX.Element => {
     workareaManager.resetView();
     beamboxInit.showStartUpDialogs();
 
-    communicator.on(MenuEvents.NewAppMenu, BeamboxGlobalInteraction.attach);
+    if (isWeb()) {
+      // web never receives NewAppMenu / TabFocused, attach on mount instead
+      BeamboxGlobalInteraction.attach();
+    } else {
+      communicator.on(MenuEvents.NewAppMenu, BeamboxGlobalInteraction.attach);
+    }
 
     return () => {
       BeamboxGlobalInteraction.detach();

--- a/packages/core/src/web/app/stores/menuItemStatusStore.spec.ts
+++ b/packages/core/src/web/app/stores/menuItemStatusStore.spec.ts
@@ -1,0 +1,46 @@
+import { INITIALLY_DISABLED_MENU_ITEMS } from '@core/helpers/menubar/menuItemStatus';
+
+import { useMenuItemStatusStore } from './menuItemStatusStore';
+
+describe('menuItemStatusStore', () => {
+  test('starts with the items disabled in the electron menu template', () => {
+    const { disabledKeys } = useMenuItemStatusStore.getState();
+
+    expect(disabledKeys.size).toBe(INITIALLY_DISABLED_MENU_ITEMS.length);
+    expect(disabledKeys.has('START_CURVE_ENGRAVING_MODE')).toBe(true);
+    expect(disabledKeys.has('DECOMPOSE_PATH')).toBe(true);
+    // always enabled items are not listed
+    expect(disabledKeys.has('ADD_NEW_MACHINE')).toBe(false);
+  });
+
+  test('enable removes ids and disable adds them back', () => {
+    const { disable, enable } = useMenuItemStatusStore.getState();
+
+    enable(['DUPLICATE', 'GROUP']);
+    expect(useMenuItemStatusStore.getState().disabledKeys.has('DUPLICATE')).toBe(false);
+    expect(useMenuItemStatusStore.getState().disabledKeys.has('GROUP')).toBe(false);
+    // untouched ids keep their status
+    expect(useMenuItemStatusStore.getState().disabledKeys.has('UNGROUP')).toBe(true);
+
+    disable(['DUPLICATE']);
+    expect(useMenuItemStatusStore.getState().disabledKeys.has('DUPLICATE')).toBe(true);
+    expect(useMenuItemStatusStore.getState().disabledKeys.has('GROUP')).toBe(false);
+  });
+
+  test('accepts ids that are not initially disabled', () => {
+    useMenuItemStatusStore.getState().disable(['ADD_NEW_MACHINE']);
+    expect(useMenuItemStatusStore.getState().disabledKeys.has('ADD_NEW_MACHINE')).toBe(true);
+  });
+
+  test('keeps the same set reference when nothing changes', () => {
+    const { disabledKeys: before } = useMenuItemStatusStore.getState();
+
+    // already disabled
+    useMenuItemStatusStore.getState().disable(['DUPLICATE']);
+    expect(useMenuItemStatusStore.getState().disabledKeys).toBe(before);
+
+    // never disabled
+    useMenuItemStatusStore.getState().enable(['ADD_NEW_MACHINE']);
+    expect(useMenuItemStatusStore.getState().disabledKeys).toBe(before);
+  });
+});

--- a/packages/core/src/web/app/stores/menuItemStatusStore.ts
+++ b/packages/core/src/web/app/stores/menuItemStatusStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+import { INITIALLY_DISABLED_MENU_ITEMS } from '@core/helpers/menubar/menuItemStatus';
+
+export type MenuItemStatusState = {
+  disable: (ids: string[]) => void;
+  /** ids of the menu items that should be rendered as disabled */
+  disabledKeys: Set<string>;
+  enable: (ids: string[]) => void;
+};
+
+const updateDisabledKeys = (current: Set<string>, ids: string[], disabled: boolean): Set<string> => {
+  // keep the same reference when nothing changes, enable/disable is called on every selection change
+  if (!ids.some((id) => current.has(id) !== disabled)) return current;
+
+  const next = new Set(current);
+
+  for (const id of ids) {
+    if (disabled) next.add(id);
+    else next.delete(id);
+  }
+
+  return next;
+};
+
+/**
+ * Disabled status of the web menu items, mirroring the `enabled` flag of the electron menu.
+ *
+ * It lives outside React so that enable/disable calls made before (or between) mounts of the
+ * top bar menu are not lost. The electron app updates its native menu instead and does not use it.
+ */
+export const useMenuItemStatusStore = create<MenuItemStatusState>((set) => ({
+  disable: (ids) => set(({ disabledKeys }) => ({ disabledKeys: updateDisabledKeys(disabledKeys, ids, true) })),
+  disabledKeys: new Set(INITIALLY_DISABLED_MENU_ITEMS),
+  enable: (ids) => set(({ disabledKeys }) => ({ disabledKeys: updateDisabledKeys(disabledKeys, ids, false) })),
+}));

--- a/packages/core/src/web/helpers/menubar/AbstractMenu.ts
+++ b/packages/core/src/web/helpers/menubar/AbstractMenu.ts
@@ -12,83 +12,12 @@ import { isAtPage } from '@core/helpers/hashHelper';
 import i18n from '@core/helpers/i18n';
 import type { ExampleFileKey } from '@core/helpers/menubar/exampleFiles';
 import { loadExampleFile } from '@core/helpers/menubar/exampleFiles';
+import { MENU_ITEMS } from '@core/helpers/menubar/menuItemStatus';
 import customMenuActionProvider from '@core/implementations/customMenuActionProvider';
 import menuEventListenerFactory from '@core/implementations/menuEventListenerFactory';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
 type MenuActions = { [key: string]: (device?: IDeviceInfo) => void };
-
-const FILE_MENU_ITEMS = [
-  'CLEAR_SCENE',
-  'OPEN',
-  'RECENT',
-  'SHOW_MY_CLOUD',
-  'SAVE_AS',
-  'SAVE_SCENE',
-  'SAVE_TO_CLOUD',
-  'SAMPLES',
-  'EXPORT_TO',
-];
-const EDIT_MENU_ITEMS = [
-  'UNDO',
-  'REDO',
-  // 'CUT',
-  // 'COPY',
-  // 'PASTE',
-  'PASTE_IN_PLACE',
-  'DUPLICATE',
-  'DELETE',
-  'GROUP',
-  'UNGROUP',
-  'PATH',
-  'PHOTO_EDIT',
-  'SVG_EDIT',
-  'LAYER',
-  'DOCUMENT_SETTING',
-  'ROTARY_SETUP',
-];
-const VIEW_MENU_ITEMS = [
-  'ZOOM_IN',
-  'ZOOM_OUT',
-  'FITS_TO_WINDOW',
-  'ZOOM_WITH_WINDOW',
-  'SHOW_GRIDS',
-  'SHOW_RULERS',
-  'SHOW_LAYER_COLOR',
-  'AUTO_ALIGN',
-  'ANTI_ALIASING',
-];
-
-const DOCKABLE_MENU_ITEMS = [
-  // window
-  'SHOW_LAYER_CONTROLS_PANEL',
-  'SHOW_OBJECT_CONTROLS_PANEL',
-  'SHOW_PATH_CONTROLS_PANEL',
-  'RESET_LAYOUT',
-];
-
-const TOOLS_MENU_ITEMS = ['START_CURVE_ENGRAVING_MODE'];
-const EDITOR_REQUIRED_DEVICE_ITEMS = ['CALIBRATION'];
-
-/**
- * Special menu items that should be disabled in certain pages
- *
- * Set `enabled: false` in electron menu and update them by attach/detach
- *
- * `enabled` in first-layer submenu won't take effect in Windows; list all items in the submenu
- */
-const MENU_ITEMS = [
-  ...FILE_MENU_ITEMS,
-  ...EDIT_MENU_ITEMS,
-  ...VIEW_MENU_ITEMS,
-  ...TOOLS_MENU_ITEMS,
-  ...DOCKABLE_MENU_ITEMS,
-  ...EDITOR_REQUIRED_DEVICE_ITEMS,
-  'NETWORK_TESTING',
-  // _help
-  'START_TUTORIAL',
-  'START_UI_INTRO',
-];
 
 export default abstract class AbstractMenu {
   abstract init(): void;
@@ -175,27 +104,24 @@ export default abstract class AbstractMenu {
   }
 
   attach(enabledItems?: string[]): void {
-    let disabledItems: string[] = [];
+    let itemsToEnable: string[] = [];
+    let itemsToDisable: string[] = [];
 
     if (!enabledItems) {
-      enabledItems = MENU_ITEMS;
+      itemsToEnable = [...MENU_ITEMS];
     } else if (enabledItems.length === 0) {
-      enabledItems = [];
-      disabledItems = MENU_ITEMS;
+      itemsToDisable = [...MENU_ITEMS];
     } else {
-      for (const item of MENU_ITEMS) {
-        if (!enabledItems.includes(item)) {
-          disabledItems.push(item);
-        }
-      }
+      itemsToEnable = enabledItems;
+      itemsToDisable = MENU_ITEMS.filter((item) => !enabledItems.includes(item));
     }
 
-    this.enable(enabledItems);
-    this.disable(disabledItems);
+    this.enable(itemsToEnable);
+    this.disable(itemsToDisable);
   }
 
   detach(): void {
-    this.disable(MENU_ITEMS);
+    this.disable([...MENU_ITEMS]);
   }
 
   checkCurveEngraving = () => {

--- a/packages/core/src/web/helpers/menubar/menuItemStatus.ts
+++ b/packages/core/src/web/helpers/menubar/menuItemStatus.ts
@@ -1,0 +1,83 @@
+const FILE_MENU_ITEMS = [
+  'CLEAR_SCENE',
+  'OPEN',
+  'RECENT',
+  'SHOW_MY_CLOUD',
+  'SAVE_AS',
+  'SAVE_SCENE',
+  'SAVE_TO_CLOUD',
+  'SAMPLES',
+  'EXPORT_TO',
+] as const;
+const EDIT_MENU_ITEMS = [
+  'UNDO',
+  'REDO',
+  // 'CUT',
+  // 'COPY',
+  // 'PASTE',
+  'PASTE_IN_PLACE',
+  'DUPLICATE',
+  'DELETE',
+  'GROUP',
+  'UNGROUP',
+  'PATH',
+  'PHOTO_EDIT',
+  'SVG_EDIT',
+  'LAYER',
+  'DOCUMENT_SETTING',
+  'ROTARY_SETUP',
+] as const;
+const VIEW_MENU_ITEMS = [
+  'ZOOM_IN',
+  'ZOOM_OUT',
+  'FITS_TO_WINDOW',
+  'ZOOM_WITH_WINDOW',
+  'SHOW_GRIDS',
+  'SHOW_RULERS',
+  'SHOW_LAYER_COLOR',
+  'AUTO_ALIGN',
+  'ANTI_ALIASING',
+] as const;
+
+const DOCKABLE_MENU_ITEMS = [
+  // window
+  'SHOW_LAYER_CONTROLS_PANEL',
+  'SHOW_OBJECT_CONTROLS_PANEL',
+  'SHOW_PATH_CONTROLS_PANEL',
+  'RESET_LAYOUT',
+] as const;
+
+const TOOLS_MENU_ITEMS = ['START_CURVE_ENGRAVING_MODE'] as const;
+const EDITOR_REQUIRED_DEVICE_ITEMS = ['CALIBRATION'] as const;
+
+/**
+ * Special menu items that should be disabled in certain pages
+ *
+ * Set `enabled: false` in electron menu and update them by attach/detach
+ *
+ * `enabled` in first-layer submenu won't take effect in Windows; list all items in the submenu
+ */
+export const MENU_ITEMS = [
+  ...FILE_MENU_ITEMS,
+  ...EDIT_MENU_ITEMS,
+  ...VIEW_MENU_ITEMS,
+  ...TOOLS_MENU_ITEMS,
+  ...DOCKABLE_MENU_ITEMS,
+  ...EDITOR_REQUIRED_DEVICE_ITEMS,
+  'NETWORK_TESTING',
+  // _help
+  'START_TUTORIAL',
+  'START_UI_INTRO',
+] as const;
+
+export type MenuItemId = (typeof MENU_ITEMS)[number];
+
+/**
+ * Menu items that are rendered as disabled before anything enables them, mirroring the
+ * `enabled: false` entries of the electron menu template (apps/app/src/node/menu-manager.ts and
+ * apps/app/src/node/menu/fileMenu.ts). Used as the initial state of the web menu.
+ *
+ * `DECOMPOSE_PATH` is not part of `MENU_ITEMS` because attach/detach never touches it (it is
+ * toggled by selection only), but it does start disabled in the electron template.
+ */
+export const INITIALLY_DISABLED_MENU_ITEMS: string[] = [...MENU_ITEMS, 'DECOMPOSE_PATH'];


### PR DESCRIPTION
## Summary

`useMenuData` tracked the disabled state of menu items with one `useState` each, so every new menu item needed its own state — and items that were never added silently ignored `enable`/`disable` entirely. `AbstractMenu.attach()`/`detach()` toggles ~40 ids, but web only understood 8 of them, so `START_CURVE_ENGRAVING_MODE` and ~30 others were never gated on web. `Beambox.tsx` also called `detach()` on unmount with nothing ever attaching on web, so the editor menu was effectively never gated at all.

- Move `MENU_ITEMS` out of `AbstractMenu` into `helpers/menubar/menuItemStatus.ts` as the shared source of truth. Contents and order are unchanged, so electron `attach`/`detach` behaves exactly as before
- Add `useMenuItemStatusStore` holding `disabledKeys`, seeded from that list plus `DECOMPOSE_PATH` (disabled in the electron template but only toggled by selection). It lives outside React so `enable`/`disable` calls made before the top bar menu mounts are not lost, and it keeps the same `Set` reference when nothing changes, so the churn on every selection change does not re-render the menu
- web `implementations/menu` writes to the store directly; the `ENABLE_MENU_ITEM` / `DISABLE_MENU_ITEM` events are removed (nothing else listened to them)
- `useMenuData` resolves `disabled` from the store in a single pass over the tree, so `DrawerMenu` gets it too with no changes. An explicit `disabled` on a node still wins, so static conditions (mobile-only items) are untouched. Submenu ids matching the electron template added: `PATH`, `PHOTO_EDIT`, `SVG_EDIT`, `LAYER`, `SAMPLES`, `EXPORT_TO`, `CALIBRATION`
- `Beambox.tsx` attaches on mount on web, which never receives `NewAppMenu` / `TabFocused`

Adding a menu item is now one line in the tree, plus one line in the shared list only if it should start disabled.

### Desktop is unaffected

`apps/app/src/implementations/menu.ts`, `menu-manager.ts` and `menu/fileMenu.ts` are untouched. `MENU_ITEMS` is byte-identical, `attach()` produces the same `enable`/`disable` arguments in all three branches, `DECOMPOSE_PATH` went into the web-only initial set rather than `MENU_ITEMS`, and the non-web branch in `Beambox.tsx` is unchanged — so a background tab can never clobber the shared application menu.

### Tests

New `menuItemStatusStore.spec.ts` (4 tests) and two `Menu.spec.tsx` tests covering item and submenu gating. The snapshot diff is 6 lines: `START_TUTORIAL` / `START_UI_INTRO` now correctly render disabled before attach. `test checkbox menu item` now enables the items first, the way the editor page does. Full suite: 387 suites / 2108 tests / 614 snapshots passing.

## 摘要

`useMenuData` 以每個選單項目一個 `useState` 的方式管理 disabled 狀態，因此每新增一個選單項目就要新增一個 state — 而沒有被加進去的項目則完全忽略 `enable`/`disable`。`AbstractMenu.attach()`/`detach()` 會切換約 40 個 id，但 web 只認得其中 8 個，所以 `START_CURVE_ENGRAVING_MODE` 等約 30 個項目在 web 上從未被正確禁用。`Beambox.tsx` 也只在 unmount 時呼叫 `detach()`，web 端從未 attach，等同於編輯器選單完全沒有被控管。

- 將 `MENU_ITEMS` 從 `AbstractMenu` 移到 `helpers/menubar/menuItemStatus.ts` 作為共用的唯一來源。內容與順序皆未更動，因此 electron 的 `attach`/`detach` 行為完全相同
- 新增 `useMenuItemStatusStore` 保存 `disabledKeys`，初始值取自該清單再加上 `DECOMPOSE_PATH`(在 electron template 中同樣預設禁用，但僅由選取狀態切換)。它存在於 React 之外，因此在 top bar 選單掛載前發出的 `enable`/`disable` 不會遺失；當狀態沒有變化時維持同一個 `Set` reference，避免每次選取變更都觸發重新渲染
- web 的 `implementations/menu` 直接寫入 store；移除 `ENABLE_MENU_ITEM` / `DISABLE_MENU_ITEM` 事件(已無其他監聽者)
- `useMenuData` 以單一走訪解析 `disabled`，`DrawerMenu` 無需修改即可套用。節點上明確指定的 `disabled` 仍優先，因此僅限桌面的靜態條件不受影響。並補上與 electron template 對應的 submenu id：`PATH`、`PHOTO_EDIT`、`SVG_EDIT`、`LAYER`、`SAMPLES`、`EXPORT_TO`、`CALIBRATION`
- `Beambox.tsx` 在 web 上於 mount 時 attach，因為 web 不會收到 `NewAppMenu` / `TabFocused`

新增選單項目現在只需在樹狀結構加一行，若需預設禁用再於共用清單加一行。

### 桌面版不受影響

`apps/app/src/implementations/menu.ts`、`menu-manager.ts` 與 `menu/fileMenu.ts` 皆未更動。`MENU_ITEMS` 完全相同，`attach()` 三個分支產生的 `enable`/`disable` 參數一致，`DECOMPOSE_PATH` 只加入 web 專用的初始集合而非 `MENU_ITEMS`，且 `Beambox.tsx` 的非 web 分支維持原樣 — 因此背景分頁不可能覆寫共用的應用程式選單。

### 測試

新增 `menuItemStatusStore.spec.ts`(4 個測試)與兩個 `Menu.spec.tsx` 測試，涵蓋一般項目與 submenu 的禁用行為。Snapshot 差異為 6 行：`START_TUTORIAL` / `START_UI_INTRO` 在 attach 前正確顯示為禁用。`test checkbox menu item` 改為先啟用項目，與編輯器頁面的實際流程一致。完整測試：387 suites / 2108 tests / 614 snapshots 全數通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)