### PR TITLE
Keep pendingPreviewMode across preview start reset

### DIFF
--- a/packages/core/src/web/app/actions/beambox/preview-mode-controller.ts
+++ b/packages/core/src/web/app/actions/beambox/preview-mode-controller.ts
@@ -125,7 +125,7 @@ class PreviewModeController {
 
   async start(device: IDeviceInfo) {
     this.startPromise = (async () => {
-      this.reset();
+      this.reset({ keepPendingPreviewMode: true });
       this.setIsStarting(true);
 
       const res = await deviceMaster.select(device);
@@ -389,14 +389,14 @@ class PreviewModeController {
     return this.previewManager?.getCameraOffsetStandard?.() || null;
   }
 
-  async reset() {
+  async reset({ keepPendingPreviewMode = false }: { keepPendingPreviewMode?: boolean } = {}) {
     this.previewManager = null;
     this.currentDevice = null;
     this.setIsPreviewMode(false);
     setCameraPreviewState({
-      pendingPreviewMode: undefined,
       previewCameraIndex: undefined,
       previewMode: PreviewMode.REGION,
+      ...(keepPendingPreviewMode ? {} : { pendingPreviewMode: undefined }),
     });
     this.isPreviewBlocked = false;
     deviceMaster.disconnectCamera();


### PR DESCRIPTION
## Summary

- `PreviewModeController.start()` begins with `reset()`, which also cleared `pendingPreviewMode` — the preview mode the user picked from the floating bar before setup finished. `setupPreviewMode` then found nothing pending, so the first capture ran with the old mode's grid.
- Repro on fbb2/fhx2rf with the door closed: no full-area preview runs first, and picking PRECISE_REGION before drawing a region still previewed with the REGION (wide) grid; the user had to wait for the first preview, switch again, and preview again.
- Fix: `start()` now calls `reset({ keepPendingPreviewMode: true })` so the pending choice survives and is applied right after setup. `end()` still clears it as before. Being in the shared controller, this also covers the same wipe for other managers (e.g. a pending FULL_AREA pick on fbm2).

## 摘要

- `PreviewModeController.start()` 一開始會呼叫 `reset()`，而 `reset()` 也會清掉 `pendingPreviewMode`（使用者在預覽尚未啟動完成前，從浮動工具列選擇的預覽模式）。因此 `setupPreviewMode` 讀不到待套用的模式，第一次拍攝仍使用舊模式的網格。
- 重現方式（fbb2/fhx2rf、門關閉時）：不會先執行全域預覽，此時先點選「精準區域預覽」再框選區域，第一次預覽仍使用 REGION（廣角）網格；必須等第一次預覽結束後再切換一次、再預覽一次才正確。
- 修正：`start()` 改為呼叫 `reset({ keepPendingPreviewMode: true })`，保留使用者選擇的模式，並在 setup 完成後立即套用；`end()` 的清除行為維持不變。由於修改在共用的 controller，其他機型的相同問題（例如 fbm2 待套用的 FULL_AREA）也一併修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)