### PR TITLE
Fix tutorial hint misalignment on wide windows

### DIFF
--- a/packages/core/src/web/app/widgets/dockable/utils.ts
+++ b/packages/core/src/web/app/widgets/dockable/utils.ts
@@ -387,6 +387,14 @@ export const loadLayout = (type: 'cached' | 'default' | 'storage' | 'tutorial') 
     disableSaveLayout = true;
     api.fromJSON(layout ?? defaultLayout);
     api.layout(window.innerWidth, window.innerHeight - layoutConstants.topBarHeight);
+
+    if (type === 'tutorial') {
+      // Grid sizes in the serialized layout are scaled proportionally to window width,
+      // so pin the controls group; tutorial hints are positioned with a fixed rightPanelWidth.
+      const controlsGroup = api.getGroup('groupControls');
+
+      if (controlsGroup) forceSize(controlsGroup.api, { width: rightPanelWidth });
+    }
   } catch (e) {
     console.error('Failed to load layout', e);
   } finally {


### PR DESCRIPTION
## Summary

`loadLayout('tutorial')` feeds `defaultLayout` (grid width 1440, controls group size 260) into `api.fromJSON` + `api.layout(window.innerWidth, …)`, and dockview scales serialized grid sizes **proportionally** to the actual window width, capped by the panel's `maximumWidth: 520`. On a wide window the right panel ends up anywhere between 260 and 520 px, while every tutorial hint / hole position is computed from the fixed `layoutConstants.rightPanelWidth` (260) — so hints drift off the panel.

Fix: after loading the tutorial layout, pin the `groupControls` group to `rightPanelWidth` using the existing `forceSize()` helper (sets `minimumWidth = maximumWidth = 260` and the size). The pin also survives a window resize mid-tutorial, and is dropped when the tutorial ends since `loadLayout('cached')` rebuilds the groups from JSON.

`calculateRight(RightRef.RIGHT_PANEL)` has no consumers outside `tutorial-constants.tsx`, so nothing else needs a dynamic width.

## Test plan

- Start the new-user tutorial on a wide (>1440 px) window — right panel stays 260 px wide and the hint circles / holes line up with the panel and its tabs.
- Resize the window during the tutorial — panel width stays pinned.
- Close the tutorial — previous layout is restored and the right panel is resizable again.

## 摘要

`loadLayout('tutorial')` 會把 `defaultLayout`（grid 寬 1440、controls group 260）丟給 `api.fromJSON` 與 `api.layout(window.innerWidth, …)`，而 dockview 會依實際視窗寬度**等比例縮放**序列化的 grid 尺寸，上限為 panel 的 `maximumWidth: 520`。因此在寬螢幕上右側面板實際寬度會落在 260～520 px 之間，但教學提示的位置全都是用固定的 `layoutConstants.rightPanelWidth`（260）計算，導致提示框位置偏移。

修正方式：載入教學版面後，用既有的 `forceSize()` 將 `groupControls` 固定為 `rightPanelWidth`（同時設定 `minimumWidth = maximumWidth = 260`）。此鎖定在教學進行中調整視窗大小時仍有效，教學結束時 `loadLayout('cached')` 會重建 group，鎖定自然解除。

`calculateRight(RightRef.RIGHT_PANEL)` 除了 `tutorial-constants.tsx` 之外沒有其他使用者，因此不需要改成動態寬度。

🤖 Generated with [Claude Code](https://claude.com/claude-code)