### PR TITLE
Init solve pnp pose with default points

### DIFF
--- a/.agents/skills/camera-calibration/SKILL.md
+++ b/.agents/skills/camera-calibration/SKILL.md
@@ -101,7 +101,11 @@ and supports an embedded `renderWrapper` (used by `InitializeMachine/Promark/Ini
 
 - **`ChArUco`** — capture ChArUco board at N positions → `updateParam({ d, k, rvec, tvec, ret, is_fisheye })`.
 - **`Calibration`** — chessboard/charuco capture wrapper (Promark).
-- **`SolvePnP`** — drag marker points → `onNext(rvec, tvec, point)`.
+- **`SolvePnP`** — drag marker points → `onNext(rvec, tvec, point)`. `defaultPoints` (per model/region,
+  hard-coded image points for a typical placement) feeds the dev-only Reset Points button and, with
+  `initPoseWithDefaultPoints` (callers pass `isAdvanced`), seeds `rvec`/`tvec` via `solve_pnp_calculate`
+  before the **first** step's find-corners — after ChArUco the stored pose is the hand-held board's, so
+  corner detection would otherwise project from a random pose. Later steps reuse the previous step's solve.
 - **`CheckPnP`** — overlay a grid using the params to verify alignment.
 - **`Instruction`** — video + steps + `buttons: Array<{label,onClick,type?}>` (+ optional `renderWrapper`).
 - **`ProcessingDialog`** — runs a `process()` with progress, then `onNext`.

--- a/packages/core/src/web/app/components/dialogs/camera/LaserHeadFisheyeCalibration.tsx
+++ b/packages/core/src/web/app/components/dialogs/camera/LaserHeadFisheyeCalibration.tsx
@@ -215,6 +215,7 @@ const LaserHeadFisheyeCalibration = ({ currentData, isAdvanced, isOblique, onClo
         defaultPoints={isOblique ? DEFAULT_POINTS_OBLIQUE : DEFAULT_POINTS}
         dh={0}
         hasNext
+        initPoseWithDefaultPoints={isAdvanced}
         onBack={() => setStep(Steps.SOLVE_PNP_INSTRUCTION)}
         onClose={onClose}
         onNext={async (rvec, tvec) => {

--- a/packages/core/src/web/app/components/dialogs/camera/beamo2Calibration/Beamo2Calibration.tsx
+++ b/packages/core/src/web/app/components/dialogs/camera/beamo2Calibration/Beamo2Calibration.tsx
@@ -302,6 +302,7 @@ const Beamo2Calibration = ({ currentData, isAdvanced, onClose }: Props): ReactNo
           initExposure={exposure}
           initialPoints={calibratingParam.current.imgPoints1?.[region]}
           initInterestArea={interestArea}
+          initPoseWithDefaultPoints={isAdvanced && solvePnPStep === 0}
           label={['A', 'B', 'C', 'D'][solvePnPStep]}
           onBack={prev}
           onClose={onClose}

--- a/packages/core/src/web/app/components/dialogs/camera/common/SolvePnP.tsx
+++ b/packages/core/src/web/app/components/dialogs/camera/common/SolvePnP.tsx
@@ -148,7 +148,7 @@ const SolvePnP = ({
           return true;
         }
 
-        if (initPoseWithDefaultPoints && defaultPoints && (currentStep ?? 0) === 0) {
+        if (initPoseWithDefaultPoints && defaultPoints) {
           await cameraCalibrationApi.solvePnPCalculate(dh, defaultPoints, refPoints);
         }
 
@@ -190,7 +190,7 @@ const SolvePnP = ({
     },
     // omit initInterestArea on purpose
     // eslint-disable-next-line hooks/exhaustive-deps
-    [currentStep, defaultPoints, dh, initPoseWithDefaultPoints, params, refPoints],
+    [defaultPoints, dh, initPoseWithDefaultPoints, params, refPoints],
   );
 
   const {

--- a/packages/core/src/web/app/components/dialogs/camera/common/SolvePnP.tsx
+++ b/packages/core/src/web/app/components/dialogs/camera/common/SolvePnP.tsx
@@ -36,6 +36,7 @@ interface Props {
   initExposure?: number;
   initialPoints?: Array<[number, number]>;
   initInterestArea?: { height: number; width: number; x: number; y: number };
+  initPoseWithDefaultPoints?: boolean;
   label?: string;
   onBack: () => void;
   onClose: (complete: boolean) => void;
@@ -64,6 +65,7 @@ const SolvePnP = ({
   initExposure,
   initialPoints,
   initInterestArea,
+  initPoseWithDefaultPoints,
   label,
   onBack,
   onClose,
@@ -146,6 +148,10 @@ const SolvePnP = ({
           return true;
         }
 
+        if (initPoseWithDefaultPoints && defaultPoints && (currentStep ?? 0) === 0) {
+          await cameraCalibrationApi.solvePnPCalculate(dh, defaultPoints, refPoints);
+        }
+
         const res = await cameraCalibrationApi.solvePnPFindCorners(
           imgBlob,
           dh,
@@ -184,7 +190,7 @@ const SolvePnP = ({
     },
     // omit initInterestArea on purpose
     // eslint-disable-next-line hooks/exhaustive-deps
-    [dh, params, refPoints],
+    [currentStep, defaultPoints, dh, initPoseWithDefaultPoints, params, refPoints],
   );
 
   const {

--- a/packages/core/src/web/helpers/api/camera-calibration.ts
+++ b/packages/core/src/web/helpers/api/camera-calibration.ts
@@ -294,6 +294,7 @@ class CameraCalibrationApi {
         if (response.status === 'fail') {
           success = false;
           console.log('fail', response);
+          resolve({ data, success });
         } else if (response.status === 'ok') {
           const { status, ...rest } = response;
 
@@ -416,6 +417,7 @@ class CameraCalibrationApi {
         if (response.status === 'fail') {
           success = false;
           console.log('fail', response);
+          resolve({ data, success });
         } else if (response.status === 'ok') {
           const { status, ...rest } = response;
 


### PR DESCRIPTION
## Summary

The first SolvePnP step used to find corners with whatever `rvec`/`tvec` was stored. In advanced mode that pose comes straight out of ChArUco calibration, where it is the pose of the **hand-held board** — effectively random — so the projected reference points can land anywhere and corner matching starts from a bad guess.

`SolvePnP` now takes `initPoseWithDefaultPoints`. When set (callers pass `isAdvanced`) and this is the **first** step, it solves the pose from the model's `defaultPoints` via `solve_pnp_calculate` before running find-corners. Steps 2-4 are unchanged: they already reuse the previous step's real solve, which is a good prior for a neighbouring region.

Basic mode deliberately does **not** seed — there the stored pose is the machine's own previous calibration and is a better prior than generic default points.

Also fixes `solvePnPCalculate` and `extrinsicRegression` in `camera-calibration.ts`: both set `success = false` on a `fail` response but never called `resolve`, so the caller's promise hung forever instead of surfacing the error.

Pairs with https://github.com/flux3dp/fluxghost/pull/119, which adds the absolute term to the corner-matching score. This PR works without it (the seeded pose alone improves the projection); the fluxghost side makes the pose actually influence which corners get picked.

## Test plan

- `tsc --noEmit` and eslint clean on the touched files
- Hardware verified on bb2 laser head and bm2 advanced calibration: the first step's corners land on the engraved marks instead of an arbitrary spot
- hexa-rf (`fhx2rf`) shares `DEFAULT_POINTS` with bb2 but has not been checked on hardware yet

---

## 摘要

第一個 SolvePnP 步驟過去是用已儲存的 `rvec`/`tvec` 去找角點。在 advanced 模式下，這組外參直接來自 ChArUco 校正，而那是**使用者手持校正板**當下的姿態，等於是隨機的，因此投影出來的參考點可能落在任何地方，角點比對一開始就從錯誤的位置猜起。

`SolvePnP` 新增 `initPoseWithDefaultPoints` 參數。啟用時（呼叫端傳入 `isAdvanced`）且為**第一個**步驟，會先用該機種的 `defaultPoints` 透過 `solve_pnp_calculate` 解出姿態，再進行角點偵測。第 2-4 步維持原樣，它們本來就會沿用前一步實際解出的姿態，對相鄰區域來說已是良好的初始值。

basic 模式刻意**不**做這件事：該情況下儲存的姿態來自這台機器自己先前的校正結果，比通用的預設點更可靠。

另外修正 `camera-calibration.ts` 中的 `solvePnPCalculate` 與 `extrinsicRegression`：兩者在收到 `fail` 回應時只設定 `success = false` 卻沒有呼叫 `resolve`，導致呼叫端的 promise 永遠不會結束，錯誤也無法浮現。

與 https://github.com/flux3dp/fluxghost/pull/119 搭配，該 PR 為角點比對分數加入絕對項。本 PR 可獨立運作（單靠初始化姿態即可改善投影結果），fluxghost 那側則讓姿態真正影響到選中哪些角點。

## 測試計畫

- 已修改檔案的 `tsc --noEmit` 與 eslint 皆通過
- 已完成實機驗證：bb2 雷射頭與 bm2 的 advanced 校正，第一步的角點會落在雕刻標記上，而非任意位置
- hexa-rf（`fhx2rf`）與 bb2 共用 `DEFAULT_POINTS`，但尚未實機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
