### PR TITLE
Fix glyph placement when converting rtl text to path

### DIFF
--- a/packages/core/src/web/app/actions/beambox/font-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/font-funcs.ts
@@ -7,7 +7,9 @@ import Progress from '@core/app/actions/progress-caller';
 import AlertConstants from '@core/app/constants/alert-constants';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
 import { useGoogleFontStore } from '@core/app/stores/googleFontStore';
+import changeAttribute from '@core/app/svgedit/history/changeAttribute';
 import history from '@core/app/svgedit/history/history';
+import undoManager from '@core/app/svgedit/history/undoManager';
 import { moveElements } from '@core/app/svgedit/operations/move';
 import textedit from '@core/app/svgedit/text/textedit';
 import { recalculateDimensions } from '@core/app/svgedit/transform/recalculate';
@@ -690,12 +692,13 @@ const convertTextToPath = async (
         const doSub = await showSubstitutedFamilyPopup(newFont.family!);
 
         if (doSub === SubstituteResult.DO_SUB) {
-          svgCanvas.undoMgr.beginUndoableChange('font-family', [textElement]);
-          textElement.setAttribute('font-family', newFont.family!);
-          batchCmd.addSubCommand(svgCanvas.undoMgr.finishUndoableChange());
-          svgCanvas.undoMgr.beginUndoableChange('font-postscript', [textElement]);
-          textElement.setAttribute('font-postscript', newFont.postscriptName!);
-          batchCmd.addSubCommand(svgCanvas.undoMgr.finishUndoableChange());
+          const changeCmd = changeAttribute(textElement, {
+            'font-family': newFont.family!,
+            'font-postscript': newFont.postscriptName!,
+          });
+
+          if (changeCmd) batchCmd.addSubCommand(changeCmd);
+
           fontObj = await getFontObj(newFont);
           font = newFont;
         } else if (doSub === SubstituteResult.CANCEL_OPERATION) {
@@ -807,7 +810,7 @@ const convertTextToPath = async (
     batchCmd.addSubCommand(new history.RemoveElementCommand(elem, nextSibling!, parent));
 
     if (!batchCmd.isEmpty() && !isSubCommand) {
-      svgCanvas.undoMgr.addCommandToHistory(batchCmd);
+      undoManager.addCommandToHistory(batchCmd);
     }
 
     const finalStatus = hasUnsupportedFont ? ConvertResult.UNSUPPORT : ConvertResult.CONTINUE;

--- a/packages/core/src/web/app/actions/beambox/font-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/font-funcs.ts
@@ -31,7 +31,7 @@ import type { GeneralFont, GoogleFont, IFontQuery } from '@core/interfaces/IFont
 import type { IBatchCommand } from '@core/interfaces/IHistory';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
-import { loadGoogleFont, loadWebFont } from './font-funcs.util';
+import { getGlyphCharRanges, loadGoogleFont, loadWebFont } from './font-funcs.util';
 
 let svgCanvas: ISVGCanvas;
 let svgedit: any;
@@ -247,7 +247,6 @@ export const convertTextToPathByFontkit = (
       );
     }
 
-    const maxChar = 0xffff;
     const fontSize = textedit.getFontSize(textElem as SVGTextElement);
     const sizeRatio = fontSize / fontObj.unitsPerEm;
     let d: string[] = [];
@@ -290,26 +289,27 @@ export const convertTextToPathByFontkit = (
         positions.reverse();
       }
 
-      let i = 0;
+      const charRanges = getGlyphCharRanges(glyphs);
 
       d.push(
         ...glyphs.map((char, idx) => {
-          if (i >= charCount) return '';
+          const [firstChar, lastChar] = charRanges[idx];
+
+          if (lastChar >= charCount) return '';
 
           const pos = positions[idx];
-          const start = textPath.getStartPositionOfChar(i);
-          const end = textPath.getEndPositionOfChar(i);
+          const start = textPath.getStartPositionOfChar(firstChar);
+          const end = textPath.getEndPositionOfChar(lastChar);
 
           if ([start.x, start.y, end.x, end.y].every((v) => v === 0)) {
             return '';
           }
 
-          const rot = (textPath.getRotationOfChar(i) / 180) * Math.PI;
-          const { x, y } = isRtl ? end : start;
-
-          char.codePoints.forEach((codePoint) => {
-            i = codePoint > maxChar ? i + 2 : i + 1;
-          });
+          const rot = (textPath.getRotationOfChar(firstChar) / 180) * Math.PI;
+          // The glyph is drawn from its leading edge: `start` in ltr, `end` in rtl. Decide per
+          // character, since bidi can flip direction mid-run; on a path the advance is rotated.
+          const advance = (end.x - start.x) * Math.cos(rot) + (end.y - start.y) * Math.sin(rot);
+          const { x, y } = advance < 0 ? end : start;
 
           return char.path
             .translate(pos.xOffset, pos.yOffset)
@@ -327,34 +327,42 @@ export const convertTextToPathByFontkit = (
     tSpans.forEach((tspan) => {
       const text = tspan.textContent;
       const charCount = tspan.getNumberOfChars();
-      const run = fontObj.layout(text!);
-      const { direction, glyphs, positions } = run;
-      const isRtl = direction === 'rtl';
+      // Vertical text positions every character absolutely, making each its own text chunk; the
+      // browser shapes chunks in isolation, so nothing ligates and arabic loses its cursive joining.
+      const isPerCharPositioned = Math.max(tspan.x.baseVal.numberOfItems, tspan.y.baseVal.numberOfItems) > 1;
+      const runs = isPerCharPositioned
+        ? Array.from(text!).map((char) => fontObj.layout(char))
+        : [fontObj.layout(text!)];
+      const glyphs: fontkit.Glyph[] = [];
+      const positions: fontkit.GlyphPosition[] = [];
+
+      // fontkit emits rtl runs in visual order; flip back to logical so glyphs track char indices.
+      runs.forEach(({ direction, glyphs: runGlyphs, positions: runPositions }) => {
+        const isRtl = direction === 'rtl';
+
+        glyphs.push(...(isRtl ? [...runGlyphs].reverse() : runGlyphs));
+        positions.push(...(isRtl ? [...runPositions].reverse() : runPositions));
+      });
 
       // Debug: Check if layout produced glyphs
       if (glyphs.length === 0 && text && text.length > 0) {
-        console.error(`No glyphs produced for textPath: "${text}" with font ${fontObj.postscriptName}`);
+        console.error(`No glyphs produced for tspan: "${text}" with font ${fontObj.postscriptName}`);
       }
 
-      if (isRtl) {
-        glyphs.reverse();
-        positions.reverse();
-      }
-
-      let i = 0;
+      const charRanges = getGlyphCharRanges(glyphs);
 
       d.push(
         ...glyphs.map((char, idx) => {
-          if (i >= charCount) return '';
+          const [firstChar, lastChar] = charRanges[idx];
+
+          if (lastChar >= charCount) return '';
 
           const pos = positions[idx];
-          const start = tspan.getStartPositionOfChar(i);
-          const end = tspan.getEndPositionOfChar(i);
-          const { x, y } = isRtl ? end : start;
-
-          char.codePoints.forEach((codePoint) => {
-            i = codePoint > maxChar ? i + 2 : i + 1;
-          });
+          const start = tspan.getStartPositionOfChar(firstChar);
+          const end = tspan.getEndPositionOfChar(lastChar);
+          // The glyph is drawn from its left edge. Decide per character rather than per run: the
+          // browser has resolved bidi, so a latin word or digit run inside rtl text runs the other way.
+          const { x, y } = start.x > end.x ? end : start;
 
           return char.path.translate(pos.xOffset, pos.yOffset).scale(sizeRatio, -sizeRatio).translate(x, y).toSVG();
         }),

--- a/packages/core/src/web/app/actions/beambox/font-funcs.util.spec.ts
+++ b/packages/core/src/web/app/actions/beambox/font-funcs.util.spec.ts
@@ -1,0 +1,42 @@
+jest.mock('@core/helpers/fonts/fontHelper', () => ({}));
+jest.mock('@core/helpers/is-web', () => () => false);
+
+import { getGlyphCharRanges } from './font-funcs.util';
+
+const glyphs = (...codePointGroups: number[][]) => codePointGroups.map((codePoints) => ({ codePoints }));
+
+describe('getGlyphCharRanges', () => {
+  it('should map one glyph per character', () => {
+    expect(getGlyphCharRanges(glyphs([0x627], [0x62a], [0x628]))).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+    ]);
+  });
+
+  // 'اتبلبان' in Mishafi shapes to 5 glyphs: teh+beh and lam+beh become ligatures
+  it('should span every character of a ligature', () => {
+    expect(getGlyphCharRanges(glyphs([0x627], [0x62a, 0x628], [0x644, 0x628], [0x627], [0x646]))).toEqual([
+      [0, 0],
+      [1, 2],
+      [3, 4],
+      [5, 5],
+      [6, 6],
+    ]);
+  });
+
+  it('should keep a mark glyph on the cluster it decorates', () => {
+    expect(getGlyphCharRanges(glyphs([0x62a], [], [0x628]))).toEqual([
+      [0, 0],
+      [0, 0],
+      [1, 1],
+    ]);
+  });
+
+  it('should count a surrogate pair as two characters', () => {
+    expect(getGlyphCharRanges(glyphs([0x1f600], [0x41]))).toEqual([
+      [0, 1],
+      [2, 2],
+    ]);
+  });
+});

--- a/packages/core/src/web/app/actions/beambox/font-funcs.util.ts
+++ b/packages/core/src/web/app/actions/beambox/font-funcs.util.ts
@@ -1,4 +1,4 @@
-import { create, type Font } from 'fontkit';
+import { create, type Font, type Glyph } from 'fontkit';
 
 import fontHelper from '@core/helpers/fonts/fontHelper';
 import isWeb from '@core/helpers/is-web';
@@ -108,4 +108,25 @@ export const loadWebFont = async (font: WebFont): Promise<Font | undefined> => {
 
   // It's a single font
   return fontCollection;
+};
+
+/**
+ * Map every shaped glyph to the character range it covers, since glyph positions are read back from
+ * the browser per character: a ligature spans several, while a mark or dot carries no codePoints at
+ * all and stays on the cluster it decorates.
+ */
+export const getGlyphCharRanges = (glyphs: Array<Pick<Glyph, 'codePoints'>>): Array<[number, number]> => {
+  let cursor = 0;
+  let previous: [number, number] = [0, 0];
+
+  return glyphs.map(({ codePoints }) => {
+    const length = codePoints.reduce((sum, codePoint) => sum + (codePoint > 0xffff ? 2 : 1), 0);
+
+    if (length === 0) return previous;
+
+    previous = [cursor, cursor + length - 1];
+    cursor += length;
+
+    return previous;
+  });
 };

--- a/packages/core/src/web/app/components/beambox/SvgEditor/ElementTitle.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/SvgEditor/ElementTitle.spec.tsx
@@ -111,7 +111,7 @@ describe('should render correctly', () => {
 
     test('data-textpath-g', () => {
       mockGetObjectLayer.mockReturnValue({ title: 'Layer 1' });
-      document.body.innerHTML = '<g id="svg_1" data-textpath-g="true" />';
+      document.body.innerHTML = '<g id="svg_1" data-textpath-g="1" />';
       useSelectedElementStore.getState().setSelectedElement(document.getElementById('svg_1'));
 
       const { container } = render(<ElementTitle />);

--- a/packages/core/src/web/app/stores/selectedElementStore.spec.ts
+++ b/packages/core/src/web/app/stores/selectedElementStore.spec.ts
@@ -78,7 +78,7 @@ describe('selectedElementStore', () => {
     });
 
     it('should treat data-textpath-g as text_path (not groupable)', () => {
-      const data = getDerivedData(makeElem('g', { 'data-textpath-g': 'true' }));
+      const data = getDerivedData(makeElem('g', { 'data-textpath-g': '1' }));
 
       expect(data.nodeType).toBe('text_path');
       expect(data.canGroup).toBe(false);

--- a/packages/core/src/web/app/svgedit/history/changeAttribute.ts
+++ b/packages/core/src/web/app/svgedit/history/changeAttribute.ts
@@ -3,19 +3,27 @@ import type { HistoryActionOptions, IBatchCommand } from '@core/interfaces/IHist
 import { BatchCommand, ChangeElementCommand } from './history';
 import { handleHistoryActionOptions } from './utils/handleHistoryActionOptions';
 
-export const changeAttribute = (elem: Element, newAttributes: Record<string, string>): ChangeElementCommand | null => {
+export const changeAttribute = (
+  elem: Element,
+  newAttributes: Record<string, null | string | undefined>,
+): ChangeElementCommand | null => {
   const oldAttributes: Record<string, string> = {};
 
   for (const key in newAttributes) {
     const oldValue = elem.getAttribute(key) || '';
 
-    if (oldValue === newAttributes[key]) {
+    if (oldValue === (newAttributes[key] ?? '')) {
       delete newAttributes[key];
       continue;
     }
 
     oldAttributes[key] = oldValue;
-    elem.setAttribute(key, newAttributes[key]);
+
+    if (newAttributes[key] === undefined || newAttributes[key] === null) {
+      elem.removeAttribute(key);
+    } else {
+      elem.setAttribute(key, newAttributes[key]);
+    }
   }
 
   if (Object.keys(newAttributes).length === 0) {
@@ -27,7 +35,7 @@ export const changeAttribute = (elem: Element, newAttributes: Record<string, str
 
 export const changeElementsAttribute = (
   elems: Element[],
-  newAttributes: Record<string, string>,
+  newAttributes: Record<string, null | string | undefined>,
   options: HistoryActionOptions = {},
 ): IBatchCommand => {
   const batchCmd = new BatchCommand('Change Elements Attribute');

--- a/packages/core/src/web/app/svgedit/history/history.spec.ts
+++ b/packages/core/src/web/app/svgedit/history/history.spec.ts
@@ -1,0 +1,65 @@
+const mockGetTransformList = jest.fn();
+
+window.svgedit.transformlist = {
+  getTransformList: mockGetTransformList,
+  removeElementFromListMap: jest.fn(),
+};
+window.svgedit.utilities = {
+  getRotationAngleFromTransformList: (tlist: any) => {
+    for (let i = 0; i < (tlist?.numberOfItems ?? 0); i += 1) {
+      const xform = tlist.getItem(i);
+
+      if (xform.type === 4) return xform.angle;
+    }
+
+    return 0;
+  },
+};
+
+import { ChangeElementCommand } from './history';
+
+const makeTlist = (items: Array<{ angle?: number; type: number }>) => ({
+  getItem: (i: number) => items[i],
+  numberOfItems: items.length,
+});
+
+describe('ChangeElementCommand transform relocation', () => {
+  beforeAll(() => {
+    (SVGElement.prototype as any).getBBox = () => ({ height: 10, width: 10, x: 10, y: 20 });
+  });
+
+  const makeElem = (transform: string) => {
+    const elem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+
+    elem.setAttribute('transform', transform);
+    elem.setAttribute('font-family', 'NewFont');
+
+    return elem;
+  };
+
+  test('keeps scale matrix on rotated element when undoing a non-transform attribute', () => {
+    const transform = 'rotate(30 10 10) matrix(2 0 0 2 0 0)';
+    const elem = makeElem(transform);
+
+    mockGetTransformList.mockReturnValue(makeTlist([{ angle: 30, type: 4 }, { type: 1 }]));
+
+    const cmd = new ChangeElementCommand(elem, { 'font-family': 'OldFont' });
+
+    cmd.unapply();
+
+    expect(elem.getAttribute('font-family')).toBe('OldFont');
+    expect(elem.getAttribute('transform')).toBe(transform);
+  });
+
+  test('still re-centers a pure rotational transform', () => {
+    const elem = makeElem('rotate(30 10 10)');
+
+    mockGetTransformList.mockReturnValue(makeTlist([{ angle: 30, type: 4 }]));
+
+    const cmd = new ChangeElementCommand(elem, { 'font-family': 'OldFont' });
+
+    cmd.unapply();
+
+    expect(elem.getAttribute('transform')).toBe('rotate(30 15, 25)');
+  });
+});

--- a/packages/core/src/web/app/svgedit/history/history.ts
+++ b/packages/core/src/web/app/svgedit/history/history.ts
@@ -220,6 +220,25 @@ export class ChangeElementCommand extends BaseHistoryCommand implements ICommand
 
   type = ChangeElementCommand.type;
 
+  // Re-center a pure rotational transform after attribute changes move the bbox center.
+  // Only safe when the rotation is the whole transform: text/use elements keep scale as
+  // an extra matrix, which overwriting with a bare rotate() would destroy.
+  private relocateRotationalTransform = (): void => {
+    const tlist = svgedit.transformlist.getTransformList(this.elem);
+    const angle = svgedit.utilities.getRotationAngleFromTransformList(tlist);
+
+    if (!angle || tlist.numberOfItems !== 1) return;
+
+    const bbox = this.elem.getBBox();
+    const cx = bbox.x + bbox.width / 2;
+    const cy = bbox.y + bbox.height / 2;
+    const rotate = `rotate(${angle} ${cx}, ${cy})`;
+
+    if (rotate !== this.elem.getAttribute('transform')) {
+      this.elem.setAttribute('transform', rotate);
+    }
+  };
+
   doApply = (): void => {
     let bChangedTransform = false;
     const keys = Object.keys(this.newValues);
@@ -249,20 +268,7 @@ export class ChangeElementCommand extends BaseHistoryCommand implements ICommand
 
     // relocate rotational transform, if necessary
     if (!bChangedTransform) {
-      const angle = svgedit.utilities.getRotationAngle(this.elem);
-
-      if (angle) {
-        // TODO: These instances of elem either need to be declared as global
-        // (which would not be good for conflicts) or declare/use this.elem
-        const bbox = this.elem.getBBox();
-        const cx = bbox.x + bbox.width / 2;
-        const cy = bbox.y + bbox.height / 2;
-        const rotate = `rotate(${angle} ${cx}, ${cy})`;
-
-        if (rotate !== this.elem.getAttribute('transform')) {
-          this.elem.setAttribute('transform', rotate);
-        }
-      }
+      this.relocateRotationalTransform();
     }
   };
 
@@ -294,18 +300,7 @@ export class ChangeElementCommand extends BaseHistoryCommand implements ICommand
 
     // relocate rotational transform, if necessary
     if (!bChangedTransform) {
-      const angle = svgedit.utilities.getRotationAngle(this.elem);
-
-      if (angle) {
-        const bbox = this.elem.getBBox();
-        const cx = bbox.x + bbox.width / 2;
-        const cy = bbox.y + bbox.height / 2;
-        const rotate = `rotate(${angle} ${cx}, ${cy})`;
-
-        if (rotate !== this.elem.getAttribute('transform')) {
-          this.elem.setAttribute('transform', rotate);
-        }
-      }
+      this.relocateRotationalTransform();
     }
 
     // Remove transformlist to prevent confusion that causes bugs like 575.

--- a/packages/core/src/web/app/svgedit/history/history.ts
+++ b/packages/core/src/web/app/svgedit/history/history.ts
@@ -239,25 +239,24 @@ export class ChangeElementCommand extends BaseHistoryCommand implements ICommand
     }
   };
 
-  doApply = (): void => {
+  private applyValues = (values: { [key: string]: any }): void => {
     let bChangedTransform = false;
-    const keys = Object.keys(this.newValues);
+    const keys = Object.keys(values);
 
     for (let i = 0; i < keys.length; i += 1) {
       const attr = keys[i];
 
-      if (this.newValues[attr]) {
+      if (values[attr]) {
         if (attr === '#text') {
-          this.elem.textContent = this.newValues[attr];
+          this.elem.textContent = values[attr];
         } else if (attr === '#href') {
-          svgedit.utilities.setHref(this.elem, this.newValues[attr]);
+          svgedit.utilities.setHref(this.elem, values[attr]);
         } else {
-          this.elem.setAttribute(attr, this.newValues[attr]);
+          this.elem.setAttribute(attr, values[attr]);
         }
       } else if (attr === '#text') {
         this.elem.textContent = '';
       } else {
-        this.elem.setAttribute(attr, '');
         this.elem.removeAttribute(attr);
       }
 
@@ -272,36 +271,12 @@ export class ChangeElementCommand extends BaseHistoryCommand implements ICommand
     }
   };
 
+  doApply = (): void => {
+    this.applyValues(this.newValues);
+  };
+
   doUnapply = (): void => {
-    let bChangedTransform = false;
-    const keys = Object.keys(this.oldValues);
-
-    for (let i = 0; i < keys.length; i += 1) {
-      const attr = keys[i];
-
-      if (this.oldValues[attr]) {
-        if (attr === '#text') {
-          this.elem.textContent = this.oldValues[attr];
-        } else if (attr === '#href') {
-          svgedit.utilities.setHref(this.elem, this.oldValues[attr]);
-        } else {
-          this.elem.setAttribute(attr, this.oldValues[attr]);
-        }
-      } else if (attr === '#text') {
-        this.elem.textContent = '';
-      } else {
-        this.elem.removeAttribute(attr);
-      }
-
-      if (!bChangedTransform && attr === 'transform') {
-        bChangedTransform = true;
-      }
-    }
-
-    // relocate rotational transform, if necessary
-    if (!bChangedTransform) {
-      this.relocateRotationalTransform();
-    }
+    this.applyValues(this.oldValues);
 
     // Remove transformlist to prevent confusion that causes bugs like 575.
     svgedit.transformlist.removeElementFromListMap(this.elem);

--- a/packages/core/src/web/helpers/convertToPath.spec.ts
+++ b/packages/core/src/web/helpers/convertToPath.spec.ts
@@ -44,21 +44,23 @@ jest.mock('@core/app/actions/beambox/font-funcs', () => ({
   },
 }));
 
-class FakeChangeElementCommand {
-  constructor(
-    public elem: Element,
-    public oldValues: Record<string, null | string>,
-  ) {}
-}
+// Applies the attributes like the real helper so DOM assertions hold.
+const mockChangeAttribute = jest.fn((elem: Element, attrs: Record<string, null | string | undefined>) => {
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (value === undefined || value === null) elem.removeAttribute(key);
+    else elem.setAttribute(key, value);
+  });
+
+  return { attrs, elem, type: 'change-attr-cmd' };
+});
+
+jest.mock('@core/app/svgedit/history/changeAttribute', () => ({
+  changeAttribute: (...args: any[]) => mockChangeAttribute(...(args as [Element, Record<string, string>])),
+}));
 
 jest.mock('@core/app/svgedit/history/history', () => ({
-  __esModule: true,
   BatchCommand: FakeBatchCommand,
-  default: {
-    BatchCommand: FakeBatchCommand,
-    ChangeElementCommand: FakeChangeElementCommand,
-    InsertElementCommand: class {},
-  },
+  InsertElementCommand: class {},
 }));
 
 jest.mock('@core/app/svgedit/history/undoManager', () => ({
@@ -277,6 +279,10 @@ describe('convertToPath', () => {
       expect(result.path).toBe(newPath);
       expect(group.getAttribute('transform')).toBe('rotate(45)');
       expect(group.getAttribute('data-textpath-g')).toBeNull();
+      expect(mockChangeAttribute).toHaveBeenCalledWith(group, {
+        'data-ratiofixed': 'true',
+        'data-textpath-g': undefined,
+      });
       expect(Array.from(group.children)).toEqual([pathElement, newPath]);
       expect(mockSelectOnly).toHaveBeenCalledWith([group]);
     });

--- a/packages/core/src/web/helpers/convertToPath.spec.ts
+++ b/packages/core/src/web/helpers/convertToPath.spec.ts
@@ -44,10 +44,21 @@ jest.mock('@core/app/actions/beambox/font-funcs', () => ({
   },
 }));
 
+class FakeChangeElementCommand {
+  constructor(
+    public elem: Element,
+    public oldValues: Record<string, null | string>,
+  ) {}
+}
+
 jest.mock('@core/app/svgedit/history/history', () => ({
   __esModule: true,
   BatchCommand: FakeBatchCommand,
-  default: { BatchCommand: FakeBatchCommand, InsertElementCommand: class {} },
+  default: {
+    BatchCommand: FakeBatchCommand,
+    ChangeElementCommand: FakeChangeElementCommand,
+    InsertElementCommand: class {},
+  },
 }));
 
 jest.mock('@core/app/svgedit/history/undoManager', () => ({
@@ -102,7 +113,7 @@ jest.mock('./svg-editor-helper', () => ({
 
 import { ConvertResult } from '@core/app/actions/beambox/font-funcs';
 
-import { convertAllTextToPath, convertSvgToPath, convertTextToPath } from './convertToPath';
+import { convertAllTextToPath, convertSvgToPath, convertTextOnPathToPath, convertTextToPath } from './convertToPath';
 
 // jsdom lacks SVG geometry APIs (Gotcha 10): stub getBBox on the prototype.
 const fakeBBox = { height: 10, width: 20, x: 1, y: 2 } as DOMRect;
@@ -232,6 +243,42 @@ describe('convertToPath', () => {
       expect(result.path).toBeUndefined();
       expect(result.command).toBeUndefined();
       expect(result.status).toBe(ConvertResult.UNSUPPORT);
+    });
+  });
+
+  describe('convertTextOnPathToPath', () => {
+    test('converts text in place and keeps the original group with its transform', async () => {
+      const group = document.createElementNS('http://www.w3.org/2000/svg', 'g') as SVGGElement;
+
+      group.setAttribute('data-textpath-g', '1');
+      group.setAttribute('transform', 'rotate(45)');
+
+      const pathElement = makePath();
+      const text = makeText();
+
+      group.append(pathElement, text);
+      document.body.appendChild(group);
+
+      const newPath = makePath();
+
+      mockFontFuncsConvertTextToPath.mockImplementation(() => {
+        text.replaceWith(newPath);
+
+        return Promise.resolve({
+          command: new FakeBatchCommand('font'),
+          path: newPath,
+          status: ConvertResult.CONTINUE,
+        });
+      });
+
+      const result = await convertTextOnPathToPath(group);
+
+      expect(result.group).toBe(group);
+      expect(result.path).toBe(newPath);
+      expect(group.getAttribute('transform')).toBe('rotate(45)');
+      expect(group.getAttribute('data-textpath-g')).toBeNull();
+      expect(Array.from(group.children)).toEqual([pathElement, newPath]);
+      expect(mockSelectOnly).toHaveBeenCalledWith([group]);
     });
   });
 

--- a/packages/core/src/web/helpers/convertToPath.ts
+++ b/packages/core/src/web/helpers/convertToPath.ts
@@ -2,7 +2,8 @@ import alertCaller from '@core/app/actions/alert-caller';
 import type { ConvertResultType } from '@core/app/actions/beambox/font-funcs';
 import fontFuncs, { ConvertResult } from '@core/app/actions/beambox/font-funcs';
 import alertConstants from '@core/app/constants/alert-constants';
-import history, { BatchCommand } from '@core/app/svgedit/history/history';
+import { changeAttribute } from '@core/app/svgedit/history/changeAttribute';
+import { BatchCommand, InsertElementCommand } from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import { handleHistoryActionOptions } from '@core/app/svgedit/history/utils/handleHistoryActionOptions';
 import { deleteElements } from '@core/app/svgedit/operations/delete';
@@ -161,9 +162,10 @@ export const convertTextOnPathToPath = async (
 
   // Keep the original group so its transform (e.g. rotation) is preserved;
   // the converted path is inserted in place of the text, so no regrouping is needed.
-  group.removeAttribute('data-textpath-g');
-  group.setAttribute('data-ratiofixed', 'true');
-  cmd.addSubCommand(new history.ChangeElementCommand(group, { 'data-ratiofixed': null, 'data-textpath-g': '1' }));
+
+  const changeAttrCmd = changeAttribute(group, { 'data-ratiofixed': 'true', 'data-textpath-g': undefined });
+
+  if (changeAttrCmd) cmd.addSubCommand(changeAttrCmd);
 
   selectionManager.selectOnly([group]);
 
@@ -223,7 +225,7 @@ export const generateImageRect = (element?: SVGImageElement): { command?: IBatch
     return { command: undefined, rect: undefined };
   }
 
-  const batchCommand = new history.BatchCommand('Generate Image Rect');
+  const batchCommand = new BatchCommand('Generate Image Rect');
   const bbox = element.getBBox();
   const rotation = svgedit.utilities.getRotationAngle(element);
   const rect = svgCanvas.addSvgElementFromJson({
@@ -242,7 +244,7 @@ export const generateImageRect = (element?: SVGImageElement): { command?: IBatch
     element: 'rect',
   });
 
-  batchCommand.addSubCommand(new history.InsertElementCommand(rect));
+  batchCommand.addSubCommand(new InsertElementCommand(rect));
 
   return { command: batchCommand, rect };
 };
@@ -256,7 +258,7 @@ export const convertAllTextToPath = async ({ pathPerChar = false }: { pathPerCha
   success: boolean;
 }> => {
   // 1. Create a master command to record all changes.
-  const batchCmd = new history.BatchCommand('Convert All Text to Path');
+  const batchCmd = new BatchCommand('Convert All Text to Path');
   const texts = [
     ...document.querySelectorAll('#svgcontent g.layer:not([display="none"]) text'),
     ...document.querySelectorAll('#svg_defs text'),

--- a/packages/core/src/web/helpers/convertToPath.ts
+++ b/packages/core/src/web/helpers/convertToPath.ts
@@ -144,7 +144,6 @@ export const convertTextOnPathToPath = async (
 ): Promise<ConvertToPathResult & { group: SVGGElement }> => {
   const cmd = new BatchCommand('Convert Text on Path to Path');
 
-  const pathElement = element.querySelector('path');
   const textElement = element.querySelector('text');
 
   if (textActions.isEditing) textActions.toSelectMode();
@@ -152,22 +151,29 @@ export const convertTextOnPathToPath = async (
   selectionManager.clearSelection();
 
   const { command, path } = await fontFuncs.convertTextToPath(textElement!, { isSubCommand: true, weldingTexts });
+  const group = element as SVGGElement;
 
-  selectionManager.selectOnly([pathElement!, path!]);
-
-  const { command: groupCmd, group } = svgCanvas.groupSelectedElements(true)!;
+  if (!path) {
+    return { bbox: group.getBBox(), command: undefined, group };
+  }
 
   if (command) cmd.addSubCommand(command);
 
-  if (groupCmd) cmd.addSubCommand(groupCmd);
+  // Keep the original group so its transform (e.g. rotation) is preserved;
+  // the converted path is inserted in place of the text, so no regrouping is needed.
+  group.removeAttribute('data-textpath-g');
+  group.setAttribute('data-ratiofixed', 'true');
+  cmd.addSubCommand(new history.ChangeElementCommand(group, { 'data-ratiofixed': null, 'data-textpath-g': '1' }));
+
+  selectionManager.selectOnly([group]);
 
   handleHistoryActionOptions(cmd, historyOptions);
 
   return {
-    bbox: path!.getBBox(),
+    bbox: path.getBBox(),
     command: historyOptions.parentCmd ?? cmd,
     group,
-    path: path || undefined,
+    path,
   };
 };
 
@@ -325,7 +331,7 @@ export const dispatchConvertToPath = async (
     if (element.getAttribute('data-tempgroup') === 'true') {
       // Note: adds command to history; returns void instead of ConvertToPathResult
       return convertTempGroupToPath({ element, isToSelect, weldingTexts });
-    } else if (element.getAttribute('data-textpath-g') === 'true') {
+    } else if (element.getAttribute('data-textpath-g')) {
       // Note: selects resulting path with group
       return convertTextOnPathToPath(element, { weldingTexts, ...historyOptions });
     }


### PR DESCRIPTION
https://flux3dp.slack.com/archives/C2KV9ULLC/p1787120692634979

## Summary

A user reported that converting `اتبلبان` to path produced position offsets. `convertTextToPathByFontkit` takes glyph outlines from fontkit but reads positions back from the browser per *character*, walking a cursor forward one glyph at a time. That mapping broke in three ways:

**1. Ligatures.** One glyph can cover several characters. In rtl the glyph's left edge is the end of its *last* character, but the cursor anchored on its first — sliding the glyph right by roughly half its width. `اتبلبان` in Mishafi shapes to 5 glyphs with two ligatures, both displaced:

| glyph | correct x | before | error |
|---|---|---|---|
| `ت+ب` | 128.61 | 140.59 | +11.98 |
| `ل+ب` | 100.39 | 114.50 | +14.11 |

**2. Mark and dot glyphs** carry no codePoints. The cursor had already moved past their base, so they landed on the next letter. SF Arabic — the macOS Arabic fallback — shapes the same string into 10 glyphs, 3 of them dots.

**3. Mixed bidi.** `start`/`end` was picked from a single run-level direction flag, so a latin word or digit run inside rtl text anchored on the wrong edge:

| text | before | after |
|---|---|---|
| `اتب abc` | 4 glyphs wrong, max 55.6px | 0 wrong |
| `שלום world 42` | 9 wrong, max 72.2px | 0 wrong |

**4. Vertical text.** Vertical mode positions every character absolutely, which makes each one its own text chunk. The browser shapes chunks in isolation, so it drops ligatures *and* arabic cursive joining and renders isolated forms — while the code emitted a fully joined word. Shaping per character now matches what the canvas actually draws.

## Approach

`getGlyphCharRanges` maps each glyph to the character range it covers. The anchor is then chosen per character from the positions the browser reports, which already reflect resolved bidi — no direction flag needed. On a `textPath` the advance is rotated, so the direction is read by projecting `start → end` onto it.

## Testing

Verified against real SVG layout in Electron across arabic, hebrew with niqqud, mixed bidi and vertical text: **29 strings reproduce the browser's glyph positions exactly, 0 wrong.** A separate check confirmed the glyph→character count invariant the mapping relies on holds across 789 (font, string) pairs.

Hebrew was already correct and is unchanged — every hebrew cluster is base + zero-advance mark, so both anchors resolve to the same x. Unit tests cover `getGlyphCharRanges`; lint and tsc clean.

## Not fixed

- Arial Unicode MS ships no GPOS mark positioning for hebrew, so niqqud sit at the base's origin rather than centred under it. Pre-existing and font-specific — Arial and New Peninim MT are correct.
- Vertical arabic still renders stacked isolated letters. That matches the canvas, which is the point; proper vertical arabic is a horizontal line rotated 90°, which the app already supports.

---

## 摘要

有使用者回報將 `اتبلبان` 轉為路徑時出現位置偏移。`convertTextToPathByFontkit` 的字形外框取自 fontkit,但位置是**逐字元**從瀏覽器讀回,並以游標逐一往前推進。這個對應關係有三處錯誤:

**1. 連字(ligature)**:一個字形可能涵蓋多個字元。在 rtl 中字形左緣是其**最後**一個字元的 end,但游標卻錨定在第一個字元,使字形向右偏移約半個字寬。`اتبلبان` 在 Mishafi 中會產生兩個連字,兩者皆偏移(100px 字級下約 12px 與 14px)。

**2. 標記與點的字形**不帶 codePoints。游標當時已越過其基底字元,因而落到下一個字母上。SF Arabic(macOS 的阿拉伯文備援字型)會將同一字串塑形為 10 個字形,其中 3 個是點。

**3. 混合書寫方向**:`start`/`end` 依整段的單一方向旗標挑選,因此 rtl 文字中的拉丁文字或數字會錨定在錯誤的一側(最多偏移 78px)。

**4. 直書**:直書模式為每個字元指定絕對座標,使每個字元自成一個 text chunk。瀏覽器會各自獨立塑形,因此連字與阿拉伯文的連筆全部失效、改以獨立字形呈現,但程式碼卻輸出完整連接的字。改為逐字元塑形後即與畫布實際繪製的結果一致。

## 作法

`getGlyphCharRanges` 將每個字形對應到它涵蓋的字元範圍;錨點改為逐字元依瀏覽器回報的位置決定——瀏覽器已完成 bidi 解析,因此不再需要方向旗標。在 `textPath` 上前進方向會隨路徑旋轉,故改以 `start → end` 對前進方向做投影來判斷。

## 測試

在 Electron 中對照真實 SVG 排版驗證,涵蓋阿拉伯文、含母音符號的希伯來文、混合書寫方向與直書:**29 個字串完全重現瀏覽器的字形位置,0 個錯誤。**另以 789 組(字型, 字串)確認此對應所依賴的「字形→字元數」不變式成立。

希伯來文原本即正確且未受影響——其字元叢集皆為基底字元加上零前進寬度的標記,兩種錨點會解析到相同的 x。已為 `getGlyphCharRanges` 補上單元測試;lint 與 tsc 皆通過。

## 未處理

- Arial Unicode MS 未提供希伯來文的 GPOS 標記定位,母音符號會落在基底字元原點而非其正下方。此為既有且僅限該字型的問題,Arial 與 New Peninim MT 皆正常。
- 直書阿拉伯文仍呈現堆疊的獨立字形。這正是本次的目的——與畫布一致;真正的直書阿拉伯文應是將橫排文字旋轉 90°,而 app 已支援此作法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)