### PR TITLE
Only alert on backend failure, not on a slow start

### DIFF
--- a/apps/app/src/init-backend-events.ts
+++ b/apps/app/src/init-backend-events.ts
@@ -6,16 +6,18 @@ const initBackendEvents = (): void => {
     window.FLUX.ghostPort = status.port;
     window.FLUX.logFile = status.logFile;
     window.FLUX.backendAlive = status.alive;
+    window.FLUX.backendFailed = false;
     console.log(`Backend start at ${status.port}`);
   });
 
   communicator.on(
     BackendEvents.NotifyBackendStatus,
-    (_: any, status: { backend: { alive: boolean; logFile: any; port: number } }) => {
+    (_: any, status: { backend: { alive: boolean; failedToStart?: boolean; logFile: any; port: number } }) => {
       console.log(status);
       window.FLUX.ghostPort = status.backend.port;
       window.FLUX.logFile = status.backend.logFile;
       window.FLUX.backendAlive = status.backend.alive;
+      window.FLUX.backendFailed = Boolean(status.backend.failedToStart);
 
       if (status.backend.alive) {
         console.log(`Backend ready at ${status.backend.port}`);

--- a/apps/app/src/main.ts
+++ b/apps/app/src/main.ts
@@ -27,6 +27,8 @@ declare global {
     FLUX: {
       allowTracking: boolean;
       backendAlive: boolean;
+      /** Backend exited without ever coming up: waiting longer will not help. */
+      backendFailed?: boolean;
       debug: boolean;
       dev: boolean;
       ghostPort: number;

--- a/apps/app/src/node/backend-manager.ts
+++ b/apps/app/src/node/backend-manager.ts
@@ -11,6 +11,9 @@ import { BackendEvents } from '@core/app/constants/ipcEvents';
 
 import { getSwiftrayPaths, killStaleSwiftray, killSwiftrayPid } from './helpers/swiftrayProcess';
 
+/** Consecutive failed starts before we tell the renderer the backend is broken, not just slow. */
+const MAX_FAILED_STARTS = 3;
+
 function uglyJsonParser(data: string): any {
   try {
     return JSON.parse(data);
@@ -44,6 +47,9 @@ class BackendManager extends EventEmitter {
   /** Whether we spawned Swiftray, i.e. whether the daemon is ours to kill. */
   private hasSpawnedSwiftray = false;
 
+  /** Consecutive backend exits since it last reported ready. */
+  private failedStarts = 0;
+
   private port?: number;
 
   private recoverTimer?: NodeJS.Timeout;
@@ -65,7 +71,7 @@ class BackendManager extends EventEmitter {
     location?: string;
     on_ready?: (sender: any) => void;
     on_stderr?: (sender: any, data: any) => void;
-    on_stopped?: (sender: any) => void;
+    on_stopped?: (info: { failedToStart: boolean }) => void;
     server?: boolean;
     trace_pid?: number;
   }) {
@@ -165,6 +171,18 @@ class BackendManager extends EventEmitter {
     const ghostDirectoy = path.dirname(this.ghostLocation);
     const ghostExec = path.basename(this.ghostLocation);
 
+    // Nothing to run: anti-virus removed the binary, or the install is broken. Report it at once
+    // rather than leaving the renderer waiting for a port that will never arrive. Recovery still
+    // retries, so restoring the file heals without a restart.
+    if (!fs.existsSync(this.ghostLocation)) {
+      console.error(`Backend not found at ${this.ghostLocation}`);
+      this.emit('stopped', { failedToStart: true });
+
+      if (this.isRunning) this.setRecover();
+
+      return;
+    }
+
     if (os.platform() === 'win32') {
       this.proc = spawn(`"${ghostExec}"`, this.args, { cwd: ghostDirectoy, shell: true });
     } else {
@@ -179,6 +197,7 @@ class BackendManager extends EventEmitter {
           this.emit('ready', result);
         } finally {
           this.port = result.port;
+          this.failedStarts = 0;
         }
       }
     });
@@ -188,8 +207,13 @@ class BackendManager extends EventEmitter {
     });
 
     this.proc.on('exit', () => {
+      // A deliberate stop() is not a failure.
+      if (this.isRunning) this.failedStarts += 1;
+
       try {
-        this.emit('stopped');
+        // Repeated exits mean the backend cannot stay up: blocked by the OS, or crashing on start.
+        // One exit can be a hiccup, and a slow launch does not exit at all, so both keep waiting.
+        this.emit('stopped', { failedToStart: this.failedStarts >= MAX_FAILED_STARTS });
       } finally {
         this.proc = undefined;
 

--- a/apps/app/src/node/electron-main.ts
+++ b/apps/app/src/node/electron-main.ts
@@ -49,7 +49,7 @@ let DEBUG = false;
 let fileToOpenOnLaunch: null | string = null;
 
 const globalData: {
-  backend: { alive: boolean; logFile?: string; port?: number };
+  backend: { alive: boolean; failedToStart?: boolean; logFile?: string; port?: number };
   devices: { [key: string]: IDeviceInfo };
 } = { backend: { alive: false }, devices: {} };
 let logger: { write: (data: string) => void };
@@ -122,13 +122,21 @@ if (process.platform === 'linux') {
 
 function onGhostUp(data: { port: number }) {
   globalData.backend.alive = true;
+  globalData.backend.failedToStart = false;
   globalData.backend.port = data.port;
   tabManager?.sendToAllViews(BackendEvents.BackendUp, globalData.backend);
 }
 
-function onGhostDown() {
+function onGhostDown(info?: { failedToStart: boolean }) {
   globalData.backend.alive = false;
+  globalData.backend.failedToStart = Boolean(info?.failedToStart);
   globalData.backend.port = undefined;
+  // The renderer waits silently for a port, since a first launch can be slow. Tell it when the
+  // backend exited without ever coming up, so waiting longer is pointless.
+  tabManager?.sendToAllViews(BackendEvents.NotifyBackendStatus, {
+    backend: globalData.backend,
+    devices: globalData.devices,
+  });
 }
 
 function onDeviceUpdated(deviceInfo: IDeviceInfo) {

--- a/packages/core/src/web/helpers/websocket.ts
+++ b/packages/core/src/web/helpers/websocket.ts
@@ -18,6 +18,38 @@ let wsErrorCount = 0;
 let wsCreateFailedCount = 0;
 let WS_ERROR_ALERT_THRESHOLD = 50;
 let CREATE_FAILED_ALERT_THRESHOLD = 200;
+/**
+ * Retry interval used while the backend has not reported its port yet. A first launch on macOS can
+ * sit in Gatekeeper's binary verification for minutes, so poll gently instead of hammering.
+ */
+const NO_PORT_RETRY_INTERVAL = 1500;
+let hasAlerted = false;
+
+const popBackendErrorAlert = () => {
+  if (hasAlerted || isWeb()) return;
+
+  hasAlerted = true;
+
+  const LANG = i18n.lang.beambox.popup;
+
+  alertCaller.popById('backend-error');
+  alertCaller.popUp({
+    buttonType: alertConstants.YES_NO,
+    id: 'backend-error',
+    message: LANG.backend_connect_failed_ask_to_upload,
+    onYes: () => {
+      outputError.uploadBackendErrorLog();
+    },
+    type: alertConstants.SHOW_POPUP_ERROR,
+  });
+  MessageCaller.openMessage({
+    content: LANG.backend_error_hint,
+    duration: 0,
+    key: 'backend-error-hint',
+    level: MessageLevel.ERROR,
+    onClick: () => MessageCaller.closeMessage('backend-error-hint'),
+  });
+};
 
 export const setCurrentVersion = (version: string): void => {
   // Make sure this is called before beambox init write last-installed-version'
@@ -92,25 +124,7 @@ export default (options: Option): WrappedWebSocket => {
     wsCreateFailedCount += 1;
 
     if (wsCreateFailedCount === CREATE_FAILED_ALERT_THRESHOLD && !isWeb()) {
-      const LANG = i18n.lang.beambox.popup;
-
-      alertCaller.popById('backend-error');
-      alertCaller.popUp({
-        buttonType: alertConstants.YES_NO,
-        id: 'backend-error',
-        message: LANG.backend_connect_failed_ask_to_upload,
-        onYes: () => {
-          outputError.uploadBackendErrorLog();
-        },
-        type: alertConstants.SHOW_POPUP_ERROR,
-      });
-      MessageCaller.openMessage({
-        content: LANG.backend_error_hint,
-        duration: 0,
-        key: 'backend-error-hint',
-        level: MessageLevel.ERROR,
-        onClick: () => MessageCaller.closeMessage('backend-error-hint'),
-      });
+      popBackendErrorAlert();
     }
 
     if (socketOptions.autoReconnect === true) {
@@ -126,25 +140,7 @@ export default (options: Option): WrappedWebSocket => {
 
       // If ws error count exceed certain number Alert user there may be problems with backend
       if (wsErrorCount === WS_ERROR_ALERT_THRESHOLD && !isWeb()) {
-        const LANG = i18n.lang.beambox.popup;
-
-        alertCaller.popById('backend-error');
-        alertCaller.popUp({
-          buttonType: alertConstants.YES_NO,
-          id: 'backend-error',
-          message: LANG.backend_connect_failed_ask_to_upload,
-          onYes: () => {
-            outputError.uploadBackendErrorLog();
-          },
-          type: alertConstants.SHOW_POPUP_ERROR,
-        });
-        MessageCaller.openMessage({
-          content: LANG.backend_error_hint,
-          duration: 0,
-          key: 'backend-error-hint',
-          level: MessageLevel.ERROR,
-          onClick: () => MessageCaller.closeMessage('backend-error-hint'),
-        });
+        popBackendErrorAlert();
       }
     };
 
@@ -270,7 +266,14 @@ export default (options: Option): WrappedWebSocket => {
     const port = createWsOpts.port || defaultOptions.port;
 
     if (port === undefined) {
-      handleCreateWebSocketFailed();
+      // No port yet is not a connection failure: the backend may still be starting, and on a first
+      // launch that can take minutes. Only the main process can tell a slow start from a broken one
+      // (missing binary, crash loop), so wait quietly and alert only on its verdict.
+      if (window.FLUX.backendFailed) popBackendErrorAlert();
+
+      if (socketOptions.autoReconnect === true) {
+        setTimeout(() => createWebSocket(socketOptions), NO_PORT_RETRY_INTERVAL);
+      }
 
       return;
     }
@@ -290,6 +293,7 @@ export default (options: Option): WrappedWebSocket => {
         isCreatingWebsocket = false;
         wsCreateFailedCount = 0;
         wsErrorCount = 0;
+        hasAlerted = false;
         alertCaller.popById('backend-error');
         MessageCaller.closeMessage('backend-error-hint');
         attachHandlers(socket, createWsOpts);

--- a/packages/core/src/web/setupTests.ts
+++ b/packages/core/src/web/setupTests.ts
@@ -21,6 +21,7 @@ declare global {
     FLUX: {
       allowTracking: boolean;
       backendAlive: boolean;
+      backendFailed?: boolean;
       debug: boolean;
       dev: boolean;
       ghostPort: number;


### PR DESCRIPTION
## Summary

A newly installed Beam Studio on macOS pops the "backend connect failed" alert during launch, even though nothing is wrong: macOS runs a Gatekeeper verification pass over the freshly installed fluxghost binary, and until that finishes the backend has not reported its port.

The renderer treated "no port yet" as a **connection failure**: `websocket.ts` counted `wsCreateFailedCount += 1` every 300 ms while `window.FLUX.ghostPort` was `undefined`. Since that counter is module-global and shared by every live socket (discover, ai-extension, utils-ws…), the effective deadline was `threshold / socketCount × 300 ms` — roughly 30 s with four sockets polling.

The renderer cannot tell a slow start from a broken one, so the judgement moves to the main process:

| Situation | Signal | Result |
|---|---|---|
| Slow first launch (Gatekeeper) | process alive, no `ready` yet | wait quietly, retry at 1.5 s — **no alert** |
| Binary missing (removed by anti-virus, broken install) | `fs.existsSync` fails | alert immediately; recovery keeps retrying so restoring the file heals without a restart |
| Crash loop / blocked binary | 3 consecutive exits without `ready` | alert after ~7.5 s |

### Changes

- **`backend-manager.ts`** — `existsSync` guard before spawn; `failedStarts` counter, reset whenever the backend reports `ready`; the `stopped` event now carries `{ failedToStart }`.
- **`electron-main.ts`** — `onGhostDown` broadcasts `NotifyBackendStatus`. It previously mutated `globalData` and told nobody, so the renderer only learned about a dead backend if it happened to poll at init.
- **`init-backend-events.ts` / `main.ts` / `setupTests.ts`** — `window.FLUX.backendFailed`, alongside the existing `backendAlive` / `ghostPort`.
- **`websocket.ts`** — the no-port path retries silently and never counts toward `wsCreateFailedCount`; the alert fires only on the main process's verdict. The alert block duplicated verbatim in `handleCreateWebSocketFailed` and `onerror` is collapsed into one `popBackendErrorAlert()` with a once-flag, reset on a successful connect.

### Notes

- A backend that reports `ready` and *then* crash-loops resets `failedStarts` each cycle, so it does not trip this counter — but it connects and disconnects, so the existing `wsErrorCount` path still catches it.
- `MAX_FAILED_STARTS = 3` × the 2.5 s recover timer is the tuning knob if ~7.5 s proves too twitchy.
- Not yet verified on a real fresh-install machine or with the binary actually deleted; lint is clean and `packages/core` typechecks with 0 errors.

## 摘要

在 macOS 上全新安裝的 Beam Studio，啟動時會跳出「無法連接後端」的錯誤視窗，但其實一切正常：macOS 會對剛安裝好的 fluxghost 執行 Gatekeeper 驗證，在驗證完成前後端不會回報 port。

前端把「還沒拿到 port」當成**連線失敗**：`websocket.ts` 在 `window.FLUX.ghostPort` 為 `undefined` 期間，每 300 毫秒就 `wsCreateFailedCount += 1`。而這個計數器是 module 層級、由所有 socket（discover、ai-extension、utils-ws…）共用，實際期限等於 `門檻 / socket 數量 × 300 毫秒` — 四個 socket 同時輪詢時大約 30 秒就會跳窗。

前端無法分辨「啟動很慢」與「根本壞掉」，因此把判斷移到主行程：

| 情況 | 判斷依據 | 結果 |
|---|---|---|
| 首次啟動較慢（Gatekeeper） | 行程存活但尚未回報 `ready` | 安靜等待，每 1.5 秒重試 — **不跳窗** |
| 找不到執行檔（被防毒刪除、安裝損毀） | `fs.existsSync` 失敗 | 立即跳窗；仍持續重試，檔案還原後不需重啟即可恢復 |
| 反覆崩潰／被系統阻擋 | 連續 3 次未回報 `ready` 就結束 | 約 7.5 秒後跳窗 |

### 變更內容

- **`backend-manager.ts`** — spawn 前先以 `existsSync` 檢查；新增 `failedStarts` 計數，收到 `ready` 時歸零；`stopped` 事件改為帶 `{ failedToStart }`。
- **`electron-main.ts`** — `onGhostDown` 改為廣播 `NotifyBackendStatus`。原本只更新 `globalData` 而未通知任何人，前端唯有剛好在初始化時輪詢才會得知後端已停止。
- **`init-backend-events.ts` / `main.ts` / `setupTests.ts`** — 新增 `window.FLUX.backendFailed`，與既有的 `backendAlive` / `ghostPort` 並列。
- **`websocket.ts`** — 無 port 的路徑改為安靜重試，不再累加 `wsCreateFailedCount`；僅依主行程的判斷跳窗。原本在 `handleCreateWebSocketFailed` 與 `onerror` 中完全重複的跳窗程式碼，合併為單一的 `popBackendErrorAlert()`，並加上只跳一次的旗標，連線成功時重置。

### 備註

- 若後端已回報 `ready` 之後才反覆崩潰，`failedStarts` 每輪都會歸零，因此不會觸發此計數 — 但這種情況會不斷連線與斷線，仍由既有的 `wsErrorCount` 路徑處理。
- 若 7.5 秒過於敏感，可調整 `MAX_FAILED_STARTS = 3` 與 2.5 秒的 recover 間隔。
- 尚未在真實的全新安裝環境、或實際刪除執行檔的情況下驗證；lint 通過，`packages/core` 型別檢查 0 錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
