### PR TITLE
Add blend K with CMY option and restore 4C prespray area setting

### DIFF
--- a/apps/app/src/implementations/changelog.ts
+++ b/apps/app/src/implementations/changelog.ts
@@ -2,13 +2,17 @@ import type { IChangeLog } from '@core/interfaces/IChangeLog';
 
 // 2.7.0 beta
 const CHANGES_TW = {
-  added: ['新增 切割精準對位功能。', '新增 Beambox II 舊版本更新通知。'],
+  added: ['新增 切割精準對位功能。', '新增 圖層進階設定雕刻紋理功能。', '新增 Beambox II 舊版本更新通知。'],
   changed: ['改善 HEXA RF雕刻效能。', '變更 beamo II 預噴及刷新墨頭行為（需配合韌體 6.0.14 以上）'],
   fixed: ['修正 HEXA RF 相機預覽模式精準預覽有時沒有正確套用。', '修正 新手教學時可能會有框起位置位移。'],
 };
 
 const CHANGES_EN = {
-  added: ['Added Print and Cut feature.', 'Added Beambox II old version update notification.'],
+  added: [
+    'Added Print and Cut feature.',
+    'Added texture setting in layer panel advanced settings.',
+    'Added Beambox II old version update notification.',
+  ],
   changed: [
     'Improved HEXA RF engraving performance.',
     'Changed beamo II purge and refresh nozzle behavior (requires firmware 6.0.14 or above).',

--- a/apps/app/src/implementations/changelog.ts
+++ b/apps/app/src/implementations/changelog.ts
@@ -1,76 +1,21 @@
 import type { IChangeLog } from '@core/interfaces/IChangeLog';
 
-// 2.6.9 beta
+// 2.7.0 beta
 const CHANGES_TW = {
-  added: [
-    '新增 鑰匙圈生成器。',
-    '新增 機器保養檢查清單。',
-    '新增 連線問題排除指南。',
-    '新增 HEXA RF 各 DPI 預設參數。',
-    '新增 beamo II 預噴次數設定。',
-    '新增 beamo II 列印測試範例檔案。',
-    '新增 Promark 設定機器時相機校正。',
-    '新增 Ador 進階相機校正。',
-    '新增 支援貼上剪貼簿中的 DXF 文字。',
-    '新增 自動對位功能中可以去背或重新拍照。',
-    '新增 Beambox II 與 HEXA RF 切換相機時的門蓋檢查提醒。',
-  ],
-  changed: [
-    '調整 條碼 / QR Code 產生器介面。',
-    '調整 無法啟動相機預覽時對話窗。',
-    '提升 相機預覽啟動的穩定性。',
-    '在首頁時停用上方校正選單。',
-    '調整 Beambox II 以及 HEXA RF 的進階相機校正拍攝校正圖案步驟。',
-    '調整 範例檔案選單順序。',
-    '調整 錯誤訊息文字與說明中心連結。',
-  ],
-  fixed: [
-    '修正 Promark 相機校正時，有時會選擇錯相機的問題。',
-    '修正 Promark 機器按鈕觸發工作的問題。',
-    '修正 Promark 自訂工作範圍時旋轉軸預設位置的問題。',
-    '修正 beamo II 有時無法啟動預覽的問題。',
-    '修正 beamo II 局部預覽時預覽誤差問題。',
-    '修正 beamo II 開啟自動曝光時的預覽問題。',
-    '修正 使用路徑計算加速時部分的物件輸出結果為空白的問題。',
-    '修正 圖層顏色設定未使用正確名稱的問題。',
-    '修正 圖層名稱包含特殊字元時顯示錯誤的問題。',
-    '修正 工作錯誤訊息以及結束工作後仍跳出錯誤回報的問題。',
-    '修正 左側工具列按鈕選取狀態的問題。',
-    '修正 文字內容欄位剪下快捷鍵的問題。',
-  ],
+  added: ['新增 切割精準對位功能。', '新增 Beambox II 舊版本更新通知。'],
+  changed: ['改善 HEXA RF雕刻效能。', '變更 beamo II 預噴及刷新墨頭行為（需配合韌體 6.0.14 以上）'],
+  fixed: ['修正 HEXA RF 相機預覽模式精準預覽有時沒有正確套用。', '修正 新手教學時可能會有框起位置位移。'],
 };
 
 const CHANGES_EN = {
-  added: [
-    'Added Keychain Generator.',
-    'Added Maintenance Checklist.',
-    'Added connection issue troubleshooting guide.',
-    'Added beamo II printing test example file.',
-    'Added Promark camera calibration when setting up the machine.',
-    'Added Ador camera calibration (advanced).',
-    'Added support for importing DXF text pasted from the clipboard.',
-    'Added background remove and retake for Auto Fit.',
-    'Added door check alert when switching cameras on Beambox II and HEXA RF.',
-  ],
+  added: ['Added Print and Cut feature.', 'Added Beambox II old version update notification.'],
   changed: [
-    'Updated the Barcode / QR Code Generator interface.',
-    'Updated the camera preview setup error dialog.',
-    'Improved camera preview setup stability.',
-    'Disabled the calibration menu on non-editor pages.',
-    'Updated the calibration pattern capture steps for Beambox II.',
-    'Updated the order of example files in the menu.',
-    'Updated error messages and Help Center links.',
+    'Improved HEXA RF engraving performance.',
+    'Changed beamo II purge and refresh nozzle behavior (requires firmware 6.0.14 or above).',
   ],
   fixed: [
-    'Fixed Promark camera calibration sometimes selecting the wrong camera.',
-    'Fixed starting jobs with the Promark machine button.',
-    'Fixed the default rotary axis position for custom work area dimensions on Promark.',
-    'Fixed an issue where some objects could be exported as empty when path calculation acceleration was enabled.',
-    'Fixed an issue where layer color config did not use the correct name.',
-    'Fixed layer names with special characters being displayed incorrectly.',
-    'Fixed work error messages and error reports appearing after a job was exited.',
-    'Fixed the selected state of left panel tool buttons.',
-    'Fixed the cut shortcut in the text content field.',
+    'Fixed HEXA RF camera preview mode sometimes not applying the precise preview correctly.',
+    'Fixed the position of the frame may shift during the tutorial.',
   ],
 };
 

--- a/apps/app/src/implementations/changelog.ts
+++ b/apps/app/src/implementations/changelog.ts
@@ -4,7 +4,11 @@ import type { IChangeLog } from '@core/interfaces/IChangeLog';
 const CHANGES_TW = {
   added: ['新增 切割精準對位功能。', '新增 圖層進階設定雕刻紋理功能。', '新增 Beambox II 舊版本更新通知。'],
   changed: ['改善 HEXA RF雕刻效能。', '變更 beamo II 預噴及刷新墨頭行為（需配合韌體 6.0.14 以上）'],
-  fixed: ['修正 HEXA RF 相機預覽模式精準預覽有時沒有正確套用。', '修正 新手教學時可能會有框起位置位移。'],
+  fixed: [
+    '修正 機器保養檢查清單沒有正確顯示。',
+    '修正 HEXA RF 相機預覽模式精準預覽有時沒有正確套用。',
+    '修正 新手教學時可能會有框起位置位移。',
+  ],
 };
 
 const CHANGES_EN = {
@@ -18,6 +22,7 @@ const CHANGES_EN = {
     'Changed beamo II purge and refresh nozzle behavior (requires firmware 6.0.14 or above).',
   ],
   fixed: [
+    'Fixed the maintenance checklist not displaying correctly.',
     'Fixed HEXA RF camera preview mode sometimes not applying the precise preview correctly.',
     'Fixed the position of the frame may shift during the tutorial.',
   ],

--- a/packages/core/public/js/lib/svgeditor/sanitize.js
+++ b/packages/core/public/js/lib/svgeditor/sanitize.js
@@ -221,6 +221,7 @@
       'data-pulseWidth',
       'data-fillAngle',
       'data-biDirectional',
+      'data-blendKWithCmy',
       'data-crossHatch',
       'data-dottingTime',
       'data-wobbleDiameter',

--- a/packages/core/src/web/app/actions/beambox/beambox-preference.spec.ts
+++ b/packages/core/src/web/app/actions/beambox/beambox-preference.spec.ts
@@ -67,6 +67,7 @@ test('test beambox-preference', () => {
     diode_offset_x: 70,
     diode_offset_y: 7,
     'enable-4c': false,
+    'enable-4c-prespray-area': true,
     'enable-1064': false,
     'enable-custom-backlash': false,
     'enable-custom-preview-height': false,

--- a/packages/core/src/web/app/actions/beambox/beambox-preference.ts
+++ b/packages/core/src/web/app/actions/beambox/beambox-preference.ts
@@ -30,6 +30,7 @@ const DEFAULT_PREFERENCE: BeamboxPreference = {
   diode_offset_x: constant.diode.defaultOffsetX,
   diode_offset_y: constant.diode.defaultOffsetY,
   'enable-4c': false,
+  'enable-4c-prespray-area': true,
   'enable-1064': false,
   'enable-custom-backlash': false,
   'enable-custom-preview-height': false,

--- a/packages/core/src/web/app/actions/canvas/prespray-area.spec.ts
+++ b/packages/core/src/web/app/actions/canvas/prespray-area.spec.ts
@@ -73,6 +73,7 @@ describe('test canvas/prespray-area', () => {
     mockGetExpansion.mockReturnValue([0, 0]);
     mockRequestAnimationFrame.mockImplementation((cb) => cb());
     mockGetState.mockReturnValue({
+      'enable-4c-prespray-area': true,
       'enable-job-origin': false,
       rotary_mode: false,
     });
@@ -95,6 +96,7 @@ describe('test canvas/prespray-area', () => {
     mockGetModel.mockReturnValue('fbm2');
     setHasModuleLayer(LayerModule.PRINTER_4C);
     mockGetState.mockReturnValue({
+      'enable-4c-prespray-area': true,
       'enable-job-origin': false,
       rotary_mode: false,
     });
@@ -107,6 +109,7 @@ describe('test canvas/prespray-area', () => {
 
   test('hide prespray area when rotary mode is on', () => {
     mockGetState.mockReturnValue({
+      'enable-4c-prespray-area': true,
       'enable-job-origin': false,
       rotary_mode: true,
     });
@@ -162,6 +165,7 @@ describe('test canvas/prespray-area', () => {
     setHasModuleLayer(LayerModule.PRINTER_4C);
     mockGetModel.mockReturnValue('fbm2');
     mockGetState.mockReturnValue({
+      'enable-4c-prespray-area': true,
       'enable-job-origin': false,
       rotary_mode: false,
     });

--- a/packages/core/src/web/app/actions/canvas/prespray-area.ts
+++ b/packages/core/src/web/app/actions/canvas/prespray-area.ts
@@ -24,7 +24,12 @@ const areaHeight = 300;
 const areaWidth4C = 103;
 
 const getPresprayMode = (): LayerModuleType | null => {
-  if (hasModuleLayer([LayerModule.PRINTER_4C], { checkVisible: true })) return LayerModule.PRINTER_4C;
+  if (
+    hasModuleLayer([LayerModule.PRINTER_4C], { checkVisible: true }) &&
+    useDocumentStore.getState()['enable-4c-prespray-area']
+  ) {
+    return LayerModule.PRINTER_4C;
+  }
 
   if (hasModuleLayer([LayerModule.PRINTER], { checkVisible: true })) return LayerModule.PRINTER;
 
@@ -82,7 +87,7 @@ const togglePresprayArea = (): void => {
 };
 
 useDocumentStore.subscribe(
-  (state) => [state['enable-job-origin'], state.rotary_mode],
+  (state) => [state['enable-4c-prespray-area'], state['enable-job-origin'], state.rotary_mode],
   () => togglePresprayArea(),
 );
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/BlendKWithCmyBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/BlendKWithCmyBlock.tsx
@@ -12,13 +12,15 @@ import { writeData } from '@core/helpers/layer/layer-config-helper';
 import styles from './Block.module.scss';
 import initState from './initState';
 
-const BlendKWithCmyBlock = (): React.JSX.Element => {
+const BlendKWithCmyBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | 'panel-item' }): React.JSX.Element => {
   const { blendKWithCmy, change } = useConfigPanelStore();
 
   const handleToggle = () => {
     const newValue = !blendKWithCmy.value;
 
     change({ blendKWithCmy: newValue });
+
+    if (type === 'modal') return;
 
     const batchCmd = new history.BatchCommand('Change blend K with CMY');
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/BlendKWithCmyBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/BlendKWithCmyBlock.tsx
@@ -1,0 +1,48 @@
+import React, { memo } from 'react';
+
+import { Switch } from 'antd';
+import classNames from 'classnames';
+
+import { useConfigPanelStore } from '@core/app/stores/configPanel';
+import useLayerStore from '@core/app/stores/layer/layerStore';
+import history from '@core/app/svgedit/history/history';
+import undoManager from '@core/app/svgedit/history/undoManager';
+import { writeData } from '@core/helpers/layer/layer-config-helper';
+
+import styles from './Block.module.scss';
+import initState from './initState';
+
+const BlendKWithCmyBlock = (): React.JSX.Element => {
+  const { blendKWithCmy, change } = useConfigPanelStore();
+
+  const handleToggle = () => {
+    const newValue = !blendKWithCmy.value;
+
+    change({ blendKWithCmy: newValue });
+
+    const batchCmd = new history.BatchCommand('Change blend K with CMY');
+
+    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+      writeData(layerName, 'blendKWithCmy', newValue, { batchCmd });
+    });
+    batchCmd.onAfter = initState;
+    undoManager.addCommandToHistory(batchCmd);
+  };
+
+  return (
+    <div className={classNames(styles.panel, styles.switch)}>
+      <label className={styles.title} htmlFor="blend-k-with-cmy">
+        Blend K with CMY
+      </label>
+      <Switch
+        checked={blendKWithCmy.value}
+        className={styles.switch}
+        id="blend-k-with-cmy"
+        onChange={handleToggle}
+        size="small"
+      />
+    </div>
+  );
+};
+
+export default memo(BlendKWithCmyBlock);

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DevBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DevBlock.tsx
@@ -39,7 +39,7 @@ const DevBlock = ({ type = 'default' }: Props): React.ReactNode => {
   const contents = [];
 
   if (isPrinting && fullcolor.value) {
-    contents.push(<WhiteInkCheckbox key="white-ink-checkbox" type={type} />, <BlendKWithCmyBlock key="blend-k" />);
+    contents.push(<WhiteInkCheckbox key="white-ink-checkbox" type={type} />, <BlendKWithCmyBlock key="blend-k" type={type} />);
   }
 
   if (isCustomBacklashEnabled) contents.push(<Backlash key="backlash" type={type} />);

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DevBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DevBlock.tsx
@@ -39,7 +39,10 @@ const DevBlock = ({ type = 'default' }: Props): React.ReactNode => {
   const contents = [];
 
   if (isPrinting && fullcolor.value) {
-    contents.push(<WhiteInkCheckbox key="white-ink-checkbox" type={type} />, <BlendKWithCmyBlock key="blend-k" type={type} />);
+    contents.push(
+      <WhiteInkCheckbox key="white-ink-checkbox" type={type} />,
+      <BlendKWithCmyBlock key="blend-k" type={type} />,
+    );
   }
 
   if (isCustomBacklashEnabled) contents.push(<Backlash key="backlash" type={type} />);

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DevBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DevBlock.tsx
@@ -12,6 +12,7 @@ import isDev from '@core/helpers/is-dev';
 
 import styles from './AdvancedBlock.module.scss';
 import Backlash from './Backlash';
+import BlendKWithCmyBlock from './BlendKWithCmyBlock';
 import ColorAdvancedSettingButton from './ColorAdvancedSetting/ColorAdvancedSettingButton';
 import LaserDevOptions from './LaserDevOptions';
 import MinPadding from './MinPadding';
@@ -37,7 +38,9 @@ const DevBlock = ({ type = 'default' }: Props): React.ReactNode => {
   const isPrinting = printingModules.has(module.value);
   const contents = [];
 
-  if (isPrinting && fullcolor.value) contents.push(<WhiteInkCheckbox key="white-ink-checkbox" type={type} />);
+  if (isPrinting && fullcolor.value) {
+    contents.push(<WhiteInkCheckbox key="white-ink-checkbox" type={type} />, <BlendKWithCmyBlock key="blend-k" />);
+  }
 
   if (isCustomBacklashEnabled) contents.push(<Backlash key="backlash" type={type} />);
 

--- a/packages/core/src/web/app/components/dialogs/DocumentSettings/ModuleSettings4C.tsx
+++ b/packages/core/src/web/app/components/dialogs/DocumentSettings/ModuleSettings4C.tsx
@@ -22,8 +22,12 @@ export const ModuleSettings4C = ({ onClose }: Props) => {
   } = useI18n();
   const [skipPrespray, setSkipPrespray] = useState(useDocumentStore.getState().skip_prespray);
   const [presprayTimes, setPresprayTimes] = useState(useDocumentStore.getState().prespray_times);
+  const [enablePresprayArea, setEnablePresprayArea] = useState(
+    Boolean(useDocumentStore.getState()['enable-4c-prespray-area']),
+  );
   const handleSave = () => {
     useDocumentStore.getState().update({
+      'enable-4c-prespray-area': enablePresprayArea,
       prespray_times: presprayTimes,
       skip_prespray: skipPrespray,
     });
@@ -61,6 +65,11 @@ export const ModuleSettings4C = ({ onClose }: Props) => {
             precision={0}
             value={presprayTimes}
           />
+        </div>
+        <div>
+          <Checkbox checked={enablePresprayArea} onChange={(e) => setEnablePresprayArea(e.target.checked)}>
+            {tDocument.enable_nozzle_refresh_area}
+          </Checkbox>
         </div>
       </div>
     </DraggableModal>

--- a/packages/core/src/web/app/lang/ca.ts
+++ b/packages/core/src/web/app/lang/ca.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Disponible només amb Promark Safe+.',
       enable_autofocus: 'Enfocament automàtic',
       enable_diode: 'Làser de díode',
+      enable_nozzle_refresh_area: 'Habilitar àrea de refresc del broquet',
       extend_y_area: 'Estendre àrea Y',
       frame_before_start: "Emmarcar abans d'executar",
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/cs.ts
+++ b/packages/core/src/web/app/lang/cs.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Dostupné pouze s Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Diodový laser',
+      enable_nozzle_refresh_area: 'Povolit oblast obnovení trysky',
       extend_y_area: 'Rozšířit oblast Y',
       frame_before_start: 'Nejprve rámec, pak provést',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/da.ts
+++ b/packages/core/src/web/app/lang/da.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Kun tilgængelig med Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Diodelaser',
+      enable_nozzle_refresh_area: 'Aktivér dyse opdateringsområde',
       extend_y_area: 'Udvid Y-område',
       frame_before_start: 'Ramme før udførelse',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/de.ts
+++ b/packages/core/src/web/app/lang/de.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Nur mit Promark Safe+ verfügbar.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Diodenlaser',
+      enable_nozzle_refresh_area: 'Düsen-Aktualisierungsbereich aktivieren',
       extend_y_area: 'Y-Bereich erweitern',
       frame_before_start: 'Zuerst Rahmen, dann ausführen',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/el.ts
+++ b/packages/core/src/web/app/lang/el.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Διαθέσιμο μόνο με το Promark Safe+.',
       enable_autofocus: 'Αυτόματη εστίαση',
       enable_diode: 'Λέιζερ διόδου',
+      enable_nozzle_refresh_area: 'Ενεργοποίηση περιοχής ανανέωσης ακροφυσίου',
       extend_y_area: 'Επέκταση περιοχής Y',
       frame_before_start: 'Πλαίσιο πριν από την εκτέλεση',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/en.ts
+++ b/packages/core/src/web/app/lang/en.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Available with Promark Safe+ only.',
       enable_autofocus: 'Autofocus',
       enable_diode: 'Diode Laser',
+      enable_nozzle_refresh_area: 'Enable nozzle refresh area',
       extend_y_area: 'Extend Y Area',
       frame_before_start: 'Frame before executing',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/es.ts
+++ b/packages/core/src/web/app/lang/es.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Disponible solo con Promark Safe+.',
       enable_autofocus: 'Enfoque automático',
       enable_diode: 'Diodo láser',
+      enable_nozzle_refresh_area: 'Habilitar área de renovación de la boquilla',
       extend_y_area: 'Ampliar el área Y',
       frame_before_start: 'Enmarcar antes de ejecutar',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/fi.ts
+++ b/packages/core/src/web/app/lang/fi.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Saatavilla vain Promark Safe+:n kanssa.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Diodilaser',
+      enable_nozzle_refresh_area: 'Ota käyttöön suuttimen päivitysalue',
       extend_y_area: 'Laajenna Y-aluetta',
       frame_before_start: 'Ruutu ennen suoritusta',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/fr.ts
+++ b/packages/core/src/web/app/lang/fr.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Disponible uniquement avec Promark Safe+.',
       enable_autofocus: 'Mise au point automatique',
       enable_diode: 'Laser à diode',
+      enable_nozzle_refresh_area: "Activer la zone d'actualisation de la buse",
       extend_y_area: 'Étendre la zone Y',
       frame_before_start: "Cadre avant d'exécuter",
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/id.ts
+++ b/packages/core/src/web/app/lang/id.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Tersedia hanya dengan Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Laser Diode',
+      enable_nozzle_refresh_area: 'Aktifkan area penyegaran nozel',
       extend_y_area: 'Perpanjang area Y',
       frame_before_start: 'Frame sebelum menjalankan',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/it.ts
+++ b/packages/core/src/web/app/lang/it.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Disponibile solo con Promark Safe+.',
       enable_autofocus: 'Messa a fuoco automatica',
       enable_diode: 'Laser a diodi',
+      enable_nozzle_refresh_area: 'Abilita area di aggiornamento ugello',
       extend_y_area: 'Estendi area Y',
       frame_before_start: 'Frame prima di eseguire',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/ja.ts
+++ b/packages/core/src/web/app/lang/ja.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Promark Safe+ のみで利用可能です。',
       enable_autofocus: 'オートフォーカス',
       enable_diode: 'ダイオードレーザー',
+      enable_nozzle_refresh_area: 'ノズル更新エリアを有効にする',
       extend_y_area: 'Y軸エリアを拡張',
       frame_before_start: '実行前にフレーム',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/kr.ts
+++ b/packages/core/src/web/app/lang/kr.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Promark Safe+에서만 사용 가능합니다.',
       enable_autofocus: '오토포커스',
       enable_diode: '다이오드 레이저',
+      enable_nozzle_refresh_area: '노즐 새로 고침 영역 활성화',
       extend_y_area: 'Y축 영역 확장',
       frame_before_start: '실행 전에 프레임',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/ms.ts
+++ b/packages/core/src/web/app/lang/ms.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Tersedia hanya dengan Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Laser Diod',
+      enable_nozzle_refresh_area: 'Benarkan kawasan penyegaran muncung',
       extend_y_area: 'Lanjutkan kawasan Y',
       frame_before_start: 'Frame sebelum melaksanakan',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/nl.ts
+++ b/packages/core/src/web/app/lang/nl.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Alleen beschikbaar met Promark Safe+.',
       enable_autofocus: 'Autofocus',
       enable_diode: 'Diode laser',
+      enable_nozzle_refresh_area: 'Nozzle verversingsgebied inschakelen',
       extend_y_area: 'Y-gebied uitbreiden',
       frame_before_start: 'Frame voordat uitgevoerd wordt',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/no.ts
+++ b/packages/core/src/web/app/lang/no.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Kun tilgjengelig med Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Diode-laser',
+      enable_nozzle_refresh_area: 'Aktiver dysefornyelsesområde',
       extend_y_area: 'Utvid Y-område',
       frame_before_start: 'Ramme før utførelse',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/pl.ts
+++ b/packages/core/src/web/app/lang/pl.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Dostępne tylko z Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Laser diodowy',
+      enable_nozzle_refresh_area: 'Włącz obszar odświeżania dyszy',
       extend_y_area: 'Rozszerz obszar Y',
       frame_before_start: 'Ramka przed wykonaniem',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/pt.ts
+++ b/packages/core/src/web/app/lang/pt.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Disponível apenas com Promark Safe+.',
       enable_autofocus: 'Foco automático',
       enable_diode: 'Laser de diodo',
+      enable_nozzle_refresh_area: 'Ativar área de atualização do bocal',
       extend_y_area: 'Estender área Y',
       frame_before_start: 'Quadro antes de executar',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/se.ts
+++ b/packages/core/src/web/app/lang/se.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Endast tillgänglig med Promark Safe+.',
       enable_autofocus: 'Autofokus',
       enable_diode: 'Diodlaser',
+      enable_nozzle_refresh_area: 'Aktivera munstyckets uppdateringsområde',
       extend_y_area: 'Utöka Y-område',
       frame_before_start: 'Ram innan utförande',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/th.ts
+++ b/packages/core/src/web/app/lang/th.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'สามารถใช้งานได้เฉพาะกับ Promark Safe+ เท่านั้น',
       enable_autofocus: 'โฟกัสอัตโนมัติ',
       enable_diode: 'เลเซอร์ไดโอด',
+      enable_nozzle_refresh_area: 'เปิดใช้งานพื้นที่รีเฟรชหัวฉีด',
       extend_y_area: 'ขยายพื้นที่แกน Y',
       frame_before_start: 'กรอบก่อนดำเนินการ',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/vi.ts
+++ b/packages/core/src/web/app/lang/vi.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: 'Chỉ có sẵn với Promark Safe+.',
       enable_autofocus: 'Tự động lấy nét',
       enable_diode: 'Laser điốt',
+      enable_nozzle_refresh_area: 'Bật vùng làm mới vòi phun',
       extend_y_area: 'Mở rộng vùng Y',
       frame_before_start: 'Khung trước khi thực thi',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/zh-cn.ts
+++ b/packages/core/src/web/app/lang/zh-cn.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: '仅适用于 Promark Safe+。',
       enable_autofocus: '自动对焦',
       enable_diode: '二极管激光',
+      enable_nozzle_refresh_area: '启用喷嘴刷新区域',
       extend_y_area: '扩展 Y 轴区域',
       frame_before_start: '先预览后执行',
       frame_before_start_url: 'https://support.flux3dp.com/hc/en-us/articles/11494925637135',

--- a/packages/core/src/web/app/lang/zh-tw.ts
+++ b/packages/core/src/web/app/lang/zh-tw.ts
@@ -208,6 +208,7 @@ const lang: ILang = {
       door_protect_desc: '僅適用於 Promark Safe+。',
       enable_autofocus: '自動對焦',
       enable_diode: '二極體雷射',
+      enable_nozzle_refresh_area: '啟用噴墨刷新區域',
       extend_y_area: '擴展 Y 軸區域',
       frame_before_start: '先預覽後執行',
       frame_before_start_url: 'https://support.flux3dp.com/hc/zh-tw/articles/11494925637135',

--- a/packages/core/src/web/app/stores/documentStore.ts
+++ b/packages/core/src/web/app/stores/documentStore.ts
@@ -43,6 +43,7 @@ const getInitDocumentStore = (): DocumentState => {
     borderless: isBorderlessEnabled,
     'customized-dimension': preference['customized-dimension'],
     'enable-4c': preference['enable-4c'],
+    'enable-4c-prespray-area': preference['enable-4c-prespray-area'],
     'enable-1064': preference['enable-1064'],
     'enable-autofocus': isAutofocusEnabled,
     'enable-diode': isDiodeEnabled,

--- a/packages/core/src/web/helpers/api/svg-laser-parser.ts
+++ b/packages/core/src/web/helpers/api/svg-laser-parser.ts
@@ -173,7 +173,9 @@ export const getExportOpt = async (
         }
       }
 
-      config.prespray = [x, y - minY, w, h];
+      if (documentState['enable-4c-prespray-area']) {
+        config.prespray = [x, y - minY, w, h];
+      }
     } else if (model === 'ado1') {
       config.prespray = rotaryMode && !hasJobOrigin ? [workareaWidth - 12, 45, 12, h] : [x, y - minY, w, h];
     }

--- a/packages/core/src/web/helpers/api/utils-ws.ts
+++ b/packages/core/src/web/helpers/api/utils-ws.ts
@@ -251,7 +251,7 @@ class UtilsWebSocket extends EventEmitter {
 
   splitColor = async (
     blob: Blob,
-    opts: { colorType: 'cmyk' | 'rgb'; onProgress?: (progress: number) => void } = {
+    opts: { colorType: 'cmy' | 'cmyk' | 'rgb'; onProgress?: (progress: number) => void } = {
       colorType: 'rgb',
     },
   ) => {

--- a/packages/core/src/web/helpers/layer/full-color/splitColor.spec.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitColor.spec.ts
@@ -1,0 +1,41 @@
+jest.mock('@core/helpers/api/utils-ws', () => jest.fn());
+
+// Import AFTER mocks.
+import { foldBlackIntoCmy } from './splitColor';
+
+// one pixel per channel, [value, value, value, alpha], 255 means no ink
+const channel = (value: number, alpha: number) => new Uint8ClampedArray([value, value, value, alpha]);
+
+describe('foldBlackIntoCmy', () => {
+  it('moves black ink into channels that had none', () => {
+    const channels = [channel(55, 255), channel(255, 0), channel(255, 0), channel(255, 0)];
+    const empty = [false, true, true, true];
+
+    foldBlackIntoCmy(channels, empty);
+
+    // 200 of black ink (255 - 55) lands on each of cyan, magenta and yellow
+    channels.slice(1).forEach((data) => expect([...data]).toEqual([55, 55, 55, 255]));
+    expect(empty).toEqual([true, false, false, false]);
+  });
+
+  it('adds to the ink already there and clamps at full ink', () => {
+    const channels = [channel(55, 255), channel(200, 255), channel(0, 255), channel(255, 0)];
+    const empty = [false, false, false, true];
+
+    foldBlackIntoCmy(channels, empty);
+
+    expect([...channels[1]]).toEqual([0, 0, 0, 255]); // 55 of ink + 200 clamps to full
+    expect([...channels[2]]).toEqual([0, 0, 0, 255]); // already full
+    expect([...channels[3]]).toEqual([55, 55, 55, 255]);
+  });
+
+  it('leaves the other channels alone when there is no black ink', () => {
+    const channels = [channel(255, 0), channel(120, 255), channel(255, 0), channel(255, 0)];
+    const empty = [true, false, true, true];
+
+    foldBlackIntoCmy(channels, empty);
+
+    expect([...channels[1]]).toEqual([120, 120, 120, 255]);
+    expect(empty).toEqual([true, false, true, true]);
+  });
+});

--- a/packages/core/src/web/helpers/layer/full-color/splitColor.spec.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitColor.spec.ts
@@ -18,14 +18,14 @@ describe('foldBlackIntoCmy', () => {
     expect(empty).toEqual([true, false, false, false]);
   });
 
-  it('adds to the ink already there and clamps at full ink', () => {
+  it('combines with the ink already there the way two inks overlap', () => {
     const channels = [channel(55, 255), channel(200, 255), channel(0, 255), channel(255, 0)];
     const empty = [false, false, false, true];
 
     foldBlackIntoCmy(channels, empty);
 
-    expect([...channels[1]]).toEqual([0, 0, 0, 255]); // 55 of ink + 200 clamps to full
-    expect([...channels[2]]).toEqual([0, 0, 0, 255]); // already full
+    expect([...channels[1]]).toEqual([43, 43, 43, 255]); // 55 and 200 of ink cover 212 together
+    expect([...channels[2]]).toEqual([0, 0, 0, 255]); // already full ink
     expect([...channels[3]]).toEqual([55, 55, 55, 255]);
   });
 

--- a/packages/core/src/web/helpers/layer/full-color/splitColor.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitColor.ts
@@ -91,10 +91,9 @@ const handleRgb = async (rgbBlob: Blob, colorType: 'cmy' | 'rgb'): Promise<Parti
 };
 
 /**
- * Fold the black channel into cyan, magenta and yellow so nothing is left for the black nozzle.
- * fluxghost >= 2.5.6 already separates without black when asked for 'cmy', this covers older
- * backends and the cmyk blobs. Channels are inverted, 255 means no ink, so folding black into a
- * channel is subtracting its ink. Mutates channelDatas and empty.
+ * Fold K into CMY so nothing is left for the black nozzle. Channels are inverted, 255 means no ink,
+ * so folding is subtracting K's ink from each channel. Mutates channelDatas and empty.
+ * Only needed for fluxghost < 2.5.6, which has no cmy color type.
  */
 export const foldBlackIntoCmy = (channelDatas: Uint8ClampedArray[], empty: boolean[]): void => {
   const [kData, ...cmyData] = channelDatas;
@@ -115,6 +114,7 @@ export const foldBlackIntoCmy = (channelDatas: Uint8ClampedArray[], empty: boole
     }
   }
 
+  // the folded channels may have been blank, an empty one would be dropped as null
   if (folded) empty.fill(false, 1);
 
   empty[0] = true;
@@ -134,6 +134,7 @@ const splitColor = async (
 ): Promise<Array<{ color: PrintingColors; data: Blob | null }>> => {
   const { blendKWithCmy = false, includeWhite = false } = opts;
   const rgbRes = await handleRgb(rgbBlob, blendKWithCmy ? 'cmy' : 'rgb');
+
   const channelDatas: Uint8ClampedArray[] = [null, null, null, null] as any; // null as placeholder
   let width: number = 0;
   let height: number = 0;

--- a/packages/core/src/web/helpers/layer/full-color/splitColor.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitColor.ts
@@ -92,7 +92,8 @@ const handleRgb = async (rgbBlob: Blob, colorType: 'cmy' | 'rgb'): Promise<Parti
 
 /**
  * Fold K into CMY so nothing is left for the black nozzle. Channels are inverted, 255 means no ink,
- * so folding is subtracting K's ink from each channel. Mutates channelDatas and empty.
+ * so folding adds K's ink to each channel, the way two inks overlap on paper rather than stacking.
+ * Mutates channelDatas and empty.
  * Only needed for fluxghost < 2.5.6, which has no cmy color type.
  */
 export const foldBlackIntoCmy = (channelDatas: Uint8ClampedArray[], empty: boolean[]): void => {
@@ -107,7 +108,10 @@ export const foldBlackIntoCmy = (channelDatas: Uint8ClampedArray[], empty: boole
     folded = true;
 
     for (const channel of cmyData) {
-      channel[i] = Math.max(0, (channel[i + 3] === 0 ? 255 : channel[i]) - kInk);
+      const ink = channel[i + 3] === 0 ? 0 : 255 - channel[i];
+      const combined = ink + kInk - (ink * kInk) / 255;
+
+      channel[i] = 255 - combined;
       channel[i + 1] = channel[i];
       channel[i + 2] = channel[i];
       channel[i + 3] = 255;

--- a/packages/core/src/web/helpers/layer/full-color/splitColor.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitColor.ts
@@ -1,11 +1,11 @@
 import { PrintingColors } from '@core/app/constants/color-constants';
 import getUtilWS from '@core/helpers/api/utils-ws';
 
-const handleRgb = async (rgbBlob: Blob): Promise<Partial<Record<PrintingColors, string>>> => {
+const handleRgb = async (rgbBlob: Blob, colorType: 'cmy' | 'rgb'): Promise<Partial<Record<PrintingColors, string>>> => {
   const utilWS = getUtilWS();
 
   try {
-    const { c, k, m, y } = await utilWS.splitColor(rgbBlob, { colorType: 'rgb' });
+    const { c, k, m, y } = await utilWS.splitColor(rgbBlob, { colorType });
 
     return {
       [PrintingColors.BLACK]: k,
@@ -91,6 +91,36 @@ const handleRgb = async (rgbBlob: Blob): Promise<Partial<Record<PrintingColors, 
 };
 
 /**
+ * Fold the black channel into cyan, magenta and yellow so nothing is left for the black nozzle.
+ * fluxghost >= 2.5.6 already separates without black when asked for 'cmy', this covers older
+ * backends and the cmyk blobs. Channels are inverted, 255 means no ink, so folding black into a
+ * channel is subtracting its ink. Mutates channelDatas and empty.
+ */
+export const foldBlackIntoCmy = (channelDatas: Uint8ClampedArray[], empty: boolean[]): void => {
+  const [kData, ...cmyData] = channelDatas;
+  let folded = false;
+
+  for (let i = 0; i < kData.length; i += 4) {
+    const kInk = kData[i + 3] === 0 ? 0 : 255 - kData[i];
+
+    if (!kInk) continue;
+
+    folded = true;
+
+    for (const channel of cmyData) {
+      channel[i] = Math.max(0, (channel[i + 3] === 0 ? 255 : channel[i]) - kInk);
+      channel[i + 1] = channel[i];
+      channel[i + 2] = channel[i];
+      channel[i + 3] = 255;
+    }
+  }
+
+  if (folded) empty.fill(false, 1);
+
+  empty[0] = true;
+};
+
+/**
  * split img into desired color channels, return null if empty
  */
 // TODO: add unit test
@@ -98,11 +128,12 @@ const splitColor = async (
   rgbBlob: Blob,
   cmykBlob?: { c: Blob; k: Blob; m: Blob; y: Blob },
   opts: {
+    blendKWithCmy?: boolean;
     includeWhite?: boolean;
   } = {},
 ): Promise<Array<{ color: PrintingColors; data: Blob | null }>> => {
-  const { includeWhite = false } = opts;
-  const rgbRes = await handleRgb(rgbBlob);
+  const { blendKWithCmy = false, includeWhite = false } = opts;
+  const rgbRes = await handleRgb(rgbBlob, blendKWithCmy ? 'cmy' : 'rgb');
   const channelDatas: Uint8ClampedArray[] = [null, null, null, null] as any; // null as placeholder
   let width: number = 0;
   let height: number = 0;
@@ -221,6 +252,8 @@ const splitColor = async (
       }
     }
   }
+
+  if (blendKWithCmy) foldBlackIntoCmy(channelDatas, empty);
 
   const canvas = document.createElement('canvas');
 

--- a/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
@@ -81,7 +81,8 @@ const splitFullColorLayer = async (
 
   const whiteInkSaturation = getData(layer, 'wInk')!;
   const includeWhite = isDev() && whiteInkSaturation > 0;
-  const colorData = await splitColor(rgbBlob, cmykBlob, { includeWhite });
+  const blendKWithCmy = getData(layer, 'blendKWithCmy');
+  const colorData = await splitColor(rgbBlob, cmykBlob, { blendKWithCmy, includeWhite });
 
   const createImage = (blob: Blob) => {
     const imgUrl = URL.createObjectURL(blob);

--- a/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
@@ -62,11 +62,13 @@ const splitFullColorLayer = async (
   });
 
   const is4c = layerModule === LayerModule.PRINTER_4C;
+  const blendKWithCmy = getData(layer, 'blendKWithCmy');
   const uses = [...layer.querySelectorAll('use')];
 
   uses.forEach((use) => symbolMaker.switchImageSymbol(use as SVGUseElement, false));
 
   const { bbox, cmykBlob, rgbBlob } = await layerToImage(layer as SVGGElement, {
+    blendKWithCmy,
     dpmm: is4c ? 600 / 25.4 : 300 / 25.4,
     isFullColor: true,
   });
@@ -81,7 +83,6 @@ const splitFullColorLayer = async (
 
   const whiteInkSaturation = getData(layer, 'wInk')!;
   const includeWhite = isDev() && whiteInkSaturation > 0;
-  const blendKWithCmy = getData(layer, 'blendKWithCmy');
   const colorData = await splitColor(rgbBlob, cmykBlob, { blendKWithCmy, includeWhite });
 
   const createImage = (blob: Blob) => {

--- a/packages/core/src/web/helpers/layer/layer-config-helper.ts
+++ b/packages/core/src/web/helpers/layer/layer-config-helper.ts
@@ -27,6 +27,7 @@ const attributeMap: Record<ConfigKey, string> = {
   amDensity: 'data-amDensity',
   backlash: 'data-backlash',
   biDirectional: 'data-biDirectional',
+  blendKWithCmy: 'data-blendKWithCmy',
   ceZHighSpeed: 'data-ceZHighSpeed',
   clipRect: 'data-clipRect',
   color: 'data-color',
@@ -107,6 +108,7 @@ export const baseConfig: Partial<ConfigKeyTypeMap> = {
   amDensity: 2,
   backlash: 0,
   biDirectional: true,
+  blendKWithCmy: false,
   ceZHighSpeed: false,
   configName: '',
   cRatio: 100,
@@ -213,6 +215,7 @@ export const moduleBaseConfig: Partial<Record<LayerModuleType, Partial<Omit<Conf
 };
 
 export const booleanConfig: ConfigKey[] = [
+  'blendKWithCmy',
   'fullcolor',
   'ref',
   'split',

--- a/packages/core/src/web/helpers/layer/layerToImage.ts
+++ b/packages/core/src/web/helpers/layer/layerToImage.ts
@@ -8,13 +8,13 @@ import updateImageForSplitting from './full-color/updateImageForSplitting';
 
 const layerToImage = async (
   layer: SVGGElement,
-  opt?: { dpmm?: number; isFullColor?: boolean; shapesOnly?: boolean },
+  opt?: { blendKWithCmy?: boolean; dpmm?: number; isFullColor?: boolean; shapesOnly?: boolean },
 ): Promise<{
   bbox: { height: number; width: number; x: number; y: number };
   cmykBlob?: { c: Blob; k: Blob; m: Blob; y: Blob };
   rgbBlob: Blob | null;
 }> => {
-  const { dpmm = 300 / 25.4, isFullColor = false, shapesOnly = false } = opt || {};
+  const { blendKWithCmy = false, dpmm = 300 / 25.4, isFullColor = false, shapesOnly = false } = opt || {};
   const layerClone = layer.cloneNode(true) as SVGGElement;
 
   if (shapesOnly) {
@@ -75,7 +75,7 @@ const layerToImage = async (
 
       const blob = await (await fetch(base64)).blob();
 
-      const { c, k, m, y } = await utilWS.splitColor(blob, { colorType: 'cmyk' });
+      const { c, k, m, y } = await utilWS.splitColor(blob, { colorType: blendKWithCmy ? 'cmy' : 'cmyk' });
 
       cLayer.querySelectorAll('image[cmyk="1"]')[i].setAttribute('xlink:href', `data:image/jpeg;base64,${c}`);
       mLayer.querySelectorAll('image[cmyk="1"]')[i].setAttribute('xlink:href', `data:image/jpeg;base64,${m}`);

--- a/packages/core/src/web/interfaces/ILang.ts
+++ b/packages/core/src/web/interfaces/ILang.ts
@@ -208,6 +208,7 @@ export interface ILang {
       door_protect_desc: string;
       enable_autofocus: string;
       enable_diode: string;
+      enable_nozzle_refresh_area: string;
       extend_y_area: string;
       frame_before_start: string;
       frame_before_start_url: string;

--- a/packages/core/src/web/interfaces/ILayerConfig.d.ts
+++ b/packages/core/src/web/interfaces/ILayerConfig.d.ts
@@ -67,7 +67,6 @@ type SCurveConfigs = {
 type PrintingConfig = {
   amAngleMap: Record<'c' | 'k' | 'm' | 'y', number> | undefined;
   amDensity: number;
-  /** print the black channel with cyan, magenta and yellow instead of black ink */
   blendKWithCmy: boolean;
   colorCurvesMap: Record<'c' | 'k' | 'm' | 'y', number[]> | undefined;
   cRatio: number;

--- a/packages/core/src/web/interfaces/ILayerConfig.d.ts
+++ b/packages/core/src/web/interfaces/ILayerConfig.d.ts
@@ -67,6 +67,8 @@ type SCurveConfigs = {
 type PrintingConfig = {
   amAngleMap: Record<'c' | 'k' | 'm' | 'y', number> | undefined;
   amDensity: number;
+  /** print the black channel with cyan, magenta and yellow instead of black ink */
+  blendKWithCmy: boolean;
   colorCurvesMap: Record<'c' | 'k' | 'm' | 'y', number[]> | undefined;
   cRatio: number;
   fullcolor: boolean;

--- a/packages/core/src/web/interfaces/Preference.d.ts
+++ b/packages/core/src/web/interfaces/Preference.d.ts
@@ -15,6 +15,7 @@ export type DocumentState = {
   borderless: boolean;
   'customized-dimension': Partial<Record<WorkAreaModel, { height: number; width: number }>>;
   'enable-4c': boolean;
+  'enable-4c-prespray-area'?: boolean;
   'enable-1064': boolean;
   'enable-autofocus'?: boolean;
   'enable-diode'?: boolean;


### PR DESCRIPTION
## Summary

Two 4C printing changes.

**Restore `enable-4c-prespray-area`** — the burst refresh PR (#963) removed the nozzle refresh area option entirely. This puts the preference, the document setting checkbox, the canvas area gate and the `prespray` export gate back. The left edge spawn position and the unconditional `burst_refresh` flag from #963 are kept as they are.

**Blend K with CMY** — a dev only layer setting for full color printing layers that prints the artwork without the black cartridge. When on, both separation requests go to fluxghost as `cmy`: the layer render (`splitColor`) and any image tagged `cmyk="1"` (`layerToImage`). fluxghost inverts the Fogra39 profile with K pinned to 0 for RGB sources; for CMYK sources it keeps C, M and Y as the file authored them and moves only the black, so a pure cyan stays a pure cyan. Either way no `data-color="k"` image is emitted. `foldBlackIntoCmy` stays as a fallback for fluxghost < 2.5.6, which has no `cmy` color type — it folds whatever black ink still comes back into cyan, magenta and yellow, and is a no op once the backend answers with a blank K channel.

Requires fluxghost `2.5.6` (tag moved, flux3dp/fluxghost@7c5802f).

## Test plan

- `pnpm test splitColor prespray-area layer-config-helper` — the `foldBlackIntoCmy` tests, the prespray suite and the sanitize whitelist check
- fluxghost: `tests/usage/test_image_utils.py` covers `split_color ... cmy` for both RGB and CMYK uploads over the websocket, `tools/ws_smoke.py` passes
- Not verified on hardware: the ink load of composite black needs a test print

## 摘要

兩項 4C 列印相關變更。

**還原 `enable-4c-prespray-area`** — burst refresh (#963) 把噴頭刷新區域的選項整個移除了，這裡把偏好設定、文件設定中的勾選框、畫布區域的顯示條件以及輸出時的 `prespray` 參數都加回來。#963 中的靠左起始位置與固定送出的 `burst_refresh` 維持不變。

**以 CMY 混合黑色** — 全彩列印圖層的開發者選項，啟用後不使用黑色墨水匣列印。開啟時兩種分色請求都會以 `cmy` 送給 fluxghost：圖層畫面（`splitColor`）以及標記為 `cmyk="1"` 的圖片（`layerToImage`）。fluxghost 對 RGB 來源會以 K 固定為 0 的方式反推 Fogra39 色彩描述檔；對 CMYK 來源則保留檔案本身的 C、M、Y，只轉換黑色，因此純青色仍然是純青色。兩者都不會產生 `data-color="k"` 的圖片。`foldBlackIntoCmy` 保留作為 fluxghost < 2.5.6（沒有 `cmy` 色彩類型）的備援，把仍然回傳的黑色墨量疊加到青、洋紅、黃三個通道；當後端回傳空白 K 通道時不會有任何作用。


需搭配 fluxghost `2.5.6`（tag 已更新至 flux3dp/fluxghost@7c5802f）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
