### PR TITLE
Add preview region indicator and single-shot capture message

### DIFF
--- a/.agents/skills/camera-preview/SKILL.md
+++ b/.agents/skills/camera-preview/SKILL.md
@@ -12,6 +12,7 @@ Store: `packages/core/src/web/app/stores/cameraPreview.ts`
 Entry/mode helpers: `packages/core/src/web/helpers/device/camera/previewMode.ts`
 Exposure: `packages/core/src/web/helpers/device/camera/cameraExposure.ts`
 UI: `components/beambox/SvgEditor/PreviewFloatingBar.tsx` (mode buttons), `PreviewSlider.tsx` (exposure)
+Region indicator: `packages/core/src/web/app/actions/canvas/preview-region-indicator.ts`
 
 ## Overview
 
@@ -72,6 +73,49 @@ Zustand + `subscribeWithSelector`. Fields: `isPreviewMode`, `isStarting`, `isDra
 - `previewCameraIndex` — physical camera used by the current mode, mirrored from the
   manager's optional `currentCameraIndex` (see Exposure below). `undefined` for
   single-camera managers.
+
+## Capture messages
+
+`previewRegionFromPoints` (batch) shows a `capturing_image i/n` counter and passes
+`silent: true` down to each per-point `preview()` call. Single-shot region captures
+(`RegionPreviewMixin.regionPreviewAtPoint`, `BeamPreviewManager.preview`) show
+`capturing_image` + `succeeded` themselves unless `silent` is set. All messages share the
+manager's `progressId` as Ant Design message key, so they replace each other — a
+non-silent per-point message would stomp the batch counter.
+
+## Preview region indicator
+
+`preview-region-indicator.ts` draws a dashed rect (`#previewRegionIndicator` in
+`#fixedSizeSvg`, canvas px) showing the single-shot capture footprint while hovering in
+`preview`/`pre_preview` mouse modes with mode REGION/PRECISE_REGION. Called from
+`mouse/index.ts` mouseMove (`!started` block); hidden on drag start and, via the
+`mouseMode.ts` store subscription, when the mouse mode leaves preview.
+
+- Cached `config` = footprint size + clamp bounds for the capture **center**.
+  Recomputed only by subscriptions: cameraPreview store
+  `[previewMode, pendingPreviewMode, isPreviewMode, supportedPreviewModes]`
+  (`supportedPreviewModes` is what fires on pre-preview entry; `isPreviewMode` swaps
+  ideal → live calibration) and canvas `canvas-change` (workarea/model switch).
+  Mouse move only clamps and moves the rect.
+- Grid models (`fbb2`/`fhx2rf`/`fbm2`): size from `getRegionPreviewGrid`
+  (`fisheyeCameraConstants.ts` — **mirrors** `RegionPreviewMixin`'s constructor and
+  `Bb2Hx2PreviewManager.switchPreviewMode` grid choice; keep in sync); footprint clamped
+  inside workarea ⇔ center ≥ half-footprint from edges.
+- Legacy Beam: square of side `imgHeight × scaleRatioY / (cos θ + sin θ)`; center clamped
+  like `constrainPreviewXY` (footprint may overhang edges). Live `getCameraOffset()` when
+  previewing, ideal camera constants in pre-preview.
+- Model source: `previewModeController.currentDevice` when `isPreviewMode`, else
+  `workareaManager.model`. `ado1`/promark (full-area only) show no indicator.
+
+## Stale supportedPreviewModes
+
+`supportedPreviewModes` is a snapshot of async device checks taken in
+`handlePreviewClick` (via `updateSupportedPreviewModes(device)` in `previewMode.ts`).
+A `SET_SELECTED_DEVICE` (top-bar emitter) listener re-runs it when the user switches
+device **while in `pre_preview`** — it must `deviceMaster.select(device)` first so the
+camera/setting queries hit the new machine, and it uses the event payload (not
+`getDevice()`, whose backing React state updates asynchronously). Active preview is
+excluded: a running session keeps its manager's modes.
 
 ## Mode switching
 

--- a/.agents/skills/camera-preview/SKILL.md
+++ b/.agents/skills/camera-preview/SKILL.md
@@ -110,12 +110,11 @@ non-silent per-point message would stomp the batch counter.
 ## Stale supportedPreviewModes
 
 `supportedPreviewModes` is a snapshot of async device checks taken in
-`handlePreviewClick` (via `updateSupportedPreviewModes(device)` in `previewMode.ts`).
-A `SET_SELECTED_DEVICE` (top-bar emitter) listener re-runs it when the user switches
-device **while in `pre_preview`** — it must `deviceMaster.select(device)` first so the
-camera/setting queries hit the new machine, and it uses the event payload (not
-`getDevice()`, whose backing React state updates asynchronously). Active preview is
-excluded: a running session keeps its manager's modes.
+`handlePreviewClick` (`previewMode.ts`), so it can go stale if the selected device
+changes while waiting in `pre_preview`. `SelectMachineButton.handleClick` handles
+device changes (uuid compared against the previous selection): during active preview
+it ends the session; during `pre_preview` it drops the mouse mode back to `select`,
+closing the floating bar so the next preview click recomputes everything fresh.
 
 ## Mode switching
 

--- a/nx.json
+++ b/nx.json
@@ -57,5 +57,6 @@
         "unitTestRunner": "jest"
       }
     }
-  }
+  },
+  "analytics": false
 }

--- a/packages/core/src/web/app/actions/camera/preview-helper/BasePreviewManager.tsx
+++ b/packages/core/src/web/app/actions/camera/preview-helper/BasePreviewManager.tsx
@@ -92,7 +92,7 @@ class BasePreviewManager implements PreviewManager {
   public preview = async (
     x: number,
     y: number,
-    opts?: { overlapFlag?: number; overlapRatio?: number },
+    opts?: { overlapFlag?: number; overlapRatio?: number; silent?: boolean },
   ): Promise<boolean> => {
     throw new Error('Method not implemented.');
   };
@@ -101,7 +101,7 @@ class BasePreviewManager implements PreviewManager {
     throw new Error('Method not implemented.');
   };
 
-  // for Beam Series, BB2
+  // for Beam Series, RegionPreviewMixin
   previewRegionFromPoints = async (
     x1: number,
     y1: number,
@@ -142,7 +142,7 @@ class BasePreviewManager implements PreviewManager {
 
         const { overlapFlag, point } = points[i];
 
-        const result = await this.preview(point[0], point[1], { overlapFlag, overlapRatio });
+        const result = await this.preview(point[0], point[1], { overlapFlag, overlapRatio, silent: true });
 
         if (!result) {
           return false;

--- a/packages/core/src/web/app/actions/camera/preview-helper/Bb2Hx2PreviewManager.ts
+++ b/packages/core/src/web/app/actions/camera/preview-helper/Bb2Hx2PreviewManager.ts
@@ -273,7 +273,11 @@ class Bb2Hx2PreviewManager extends RegionPreviewMixin(BasePreviewManager) implem
     }
   };
 
-  public preview = (x: number, y: number, opts?: { overlapFlag?: number; overlapRatio?: number }): Promise<boolean> => {
+  public preview = (
+    x: number,
+    y: number,
+    opts?: { overlapFlag?: number; overlapRatio?: number; silent?: boolean },
+  ): Promise<boolean> => {
     return match(this._previewMode)
       .with(PreviewMode.FULL_AREA, () => this.previewWithWideAngleCamera())
       .otherwise(() => this.regionPreviewAtPoint(x, y, opts));

--- a/packages/core/src/web/app/actions/camera/preview-helper/BeamPreviewManager.ts
+++ b/packages/core/src/web/app/actions/camera/preview-helper/BeamPreviewManager.ts
@@ -11,6 +11,7 @@ import i18n from '@core/helpers/i18n';
 import versionChecker from '@core/helpers/version-checker';
 import type { CameraConfig, CameraParameters } from '@core/interfaces/Camera';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
+import { MessageLevel } from '@core/interfaces/IMessage';
 import type { PreviewManager } from '@core/interfaces/PreviewManager';
 
 import BasePreviewManager from './BasePreviewManager';
@@ -295,24 +296,38 @@ class BeamPreviewManager extends BasePreviewManager implements PreviewManager {
   preview = async (
     x: number,
     y: number,
-    opts: { overlapFlag?: number; overlapRatio?: number } = {},
+    opts: { overlapFlag?: number; overlapRatio?: number; silent?: boolean } = {},
   ): Promise<boolean> => {
     if (this.ended) {
       return false;
     }
 
-    const { overlapFlag, overlapRatio = 0 } = opts;
-    const constrainedXY = this.constrainPreviewXY(x, y);
-    const { x: newX, y: newY } = constrainedXY;
-    const imgUrl = await this.getPhotoAfterMove(newX, newY);
-    const imgCanvas = await this.preprocessImage(imgUrl, { overlapFlag, overlapRatio });
+    // batch region preview passes silent because it shows its own i/n progress message
+    const { overlapFlag, overlapRatio = 0, silent = false } = opts;
 
-    // await this if you want wait for the image to be drawn
-    await PreviewModeBackgroundDrawer.drawImageToCanvas(imgCanvas, newX, newY, {
-      opacityMerge: overlapRatio > 0,
-    });
+    try {
+      if (!silent) this.showMessage({ content: i18n.lang.message.preview.capturing_image });
 
-    return true;
+      const constrainedXY = this.constrainPreviewXY(x, y);
+      const { x: newX, y: newY } = constrainedXY;
+      const imgUrl = await this.getPhotoAfterMove(newX, newY);
+      const imgCanvas = await this.preprocessImage(imgUrl, { overlapFlag, overlapRatio });
+
+      // await this if you want wait for the image to be drawn
+      await PreviewModeBackgroundDrawer.drawImageToCanvas(imgCanvas, newX, newY, {
+        opacityMerge: overlapRatio > 0,
+      });
+
+      if (!silent) {
+        this.showMessage({ content: i18n.lang.message.preview.succeeded, duration: 3, level: MessageLevel.SUCCESS });
+      }
+
+      return true;
+    } catch (error) {
+      if (!silent) this.closeMessage();
+
+      throw error;
+    }
   };
 
   private getTileSizePx = (): number => {

--- a/packages/core/src/web/app/actions/camera/preview-helper/Beamo2PreviewManager.ts
+++ b/packages/core/src/web/app/actions/camera/preview-helper/Beamo2PreviewManager.ts
@@ -178,7 +178,7 @@ class Beamo2PreviewManager extends RegionPreviewMixin(BasePreviewManager) implem
   public preview = async (
     x: number,
     y: number,
-    opts?: { overlapFlag?: number; overlapRatio?: number },
+    opts?: { overlapFlag?: number; overlapRatio?: number; silent?: boolean },
   ): Promise<boolean> => {
     await this.checkCameraModeAndReHome();
 

--- a/packages/core/src/web/app/actions/camera/preview-helper/RegionPreviewMixin.ts
+++ b/packages/core/src/web/app/actions/camera/preview-helper/RegionPreviewMixin.ts
@@ -8,7 +8,9 @@ import {
   bm2PerspectiveGrid,
 } from '@core/app/constants/fisheyeCameraConstants';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
+import i18n from '@core/helpers/i18n';
 import type { PerspectiveGrid } from '@core/interfaces/FisheyePreview';
+import { MessageLevel } from '@core/interfaces/IMessage';
 
 import type BasePreviewManager from './BasePreviewManager';
 
@@ -126,29 +128,43 @@ export function RegionPreviewMixin<TBase extends new (...args: any[]) => BasePre
     regionPreviewAtPoint = async (
       x: number,
       y: number,
-      opts: { overlapFlag?: number; overlapRatio?: number } = {},
+      opts: { overlapFlag?: number; overlapRatio?: number; silent?: boolean } = {},
     ): Promise<boolean> => {
       if (this.ended) return false;
 
-      const { overlapFlag, overlapRatio = 0 } = opts;
-      const cameraPosition = this.getPreviewPosition(x, y);
-      const imgUrl = await this.getPhotoAfterMoveTo(cameraPosition.x, cameraPosition.y);
-      const imgCanvas = await this.preprocessImage(imgUrl, { overlapFlag, overlapRatio });
+      // batch region preview passes silent because it shows its own i/n progress message
+      const { overlapFlag, overlapRatio = 0, silent = false } = opts;
 
-      if (!imgCanvas) return false;
+      try {
+        if (!silent) this.showMessage({ content: i18n.lang.message.preview.capturing_image });
 
-      URL.revokeObjectURL(imgUrl);
+        const cameraPosition = this.getPreviewPosition(x, y);
+        const imgUrl = await this.getPhotoAfterMoveTo(cameraPosition.x, cameraPosition.y);
+        const imgCanvas = await this.preprocessImage(imgUrl, { overlapFlag, overlapRatio });
 
-      const drawCenter = {
-        x: (cameraPosition.x + this.regionPreviewOffset.x) * constant.dpmm,
-        y: (cameraPosition.y + this.regionPreviewOffset.y) * constant.dpmm,
-      };
+        if (!imgCanvas) return false;
 
-      await previewModeBackgroundDrawer.drawImageToCanvas(imgCanvas, drawCenter.x, drawCenter.y, {
-        opacityMerge: overlapRatio > 0,
-      });
+        URL.revokeObjectURL(imgUrl);
 
-      return true;
+        const drawCenter = {
+          x: (cameraPosition.x + this.regionPreviewOffset.x) * constant.dpmm,
+          y: (cameraPosition.y + this.regionPreviewOffset.y) * constant.dpmm,
+        };
+
+        await previewModeBackgroundDrawer.drawImageToCanvas(imgCanvas, drawCenter.x, drawCenter.y, {
+          opacityMerge: overlapRatio > 0,
+        });
+
+        if (!silent) {
+          this.showMessage({ content: i18n.lang.message.preview.succeeded, duration: 3, level: MessageLevel.SUCCESS });
+        }
+
+        return true;
+      } catch (error) {
+        if (!silent) this.closeMessage();
+
+        throw error;
+      }
     };
 
     /** Serpentine capture points covering the region: rows top to bottom, odd rows reversed */

--- a/packages/core/src/web/app/actions/canvas/preview-region-indicator.ts
+++ b/packages/core/src/web/app/actions/canvas/preview-region-indicator.ts
@@ -45,10 +45,6 @@ const hide = (): void => {
   indicatorRect?.setAttribute('display', 'none');
 };
 
-/**
- * Footprint size and clamp bounds for the capture *center*, in canvas px. Static per
- * preview state; recomputed by the store subscription below, not on mouse move.
- */
 interface IndicatorConfig {
   height: number;
   maxCenterX: number;
@@ -141,9 +137,6 @@ const updateConfig = (): void => {
     : getBeamConfig(model);
 };
 
-// supportedPreviewModes is watched because entering pre-preview updates it without
-// touching the other fields; isPreviewMode because live calibration replaces the
-// ideal fallback in getBeamConfig once preview starts.
 useCameraPreviewStore.subscribe(
   (state) => [state.previewMode, state.pendingPreviewMode, state.isPreviewMode, state.supportedPreviewModes],
   updateConfig,

--- a/packages/core/src/web/app/actions/canvas/preview-region-indicator.ts
+++ b/packages/core/src/web/app/actions/canvas/preview-region-indicator.ts
@@ -1,0 +1,177 @@
+import constant, { promarkModels } from '@core/app/actions/beambox/constant';
+import previewModeController from '@core/app/actions/beambox/preview-mode-controller';
+import { getAddOnInfo } from '@core/app/constants/addOn';
+import { PreviewMode } from '@core/app/constants/cameraConstants';
+import { getRegionPreviewGrid } from '@core/app/constants/fisheyeCameraConstants';
+import NS from '@core/app/constants/namespaces';
+import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
+import { getWorkarea } from '@core/app/constants/workarea-constants';
+import { useCameraPreviewStore } from '@core/app/stores/cameraPreview';
+import { useDocumentStore } from '@core/app/stores/documentStore';
+import workareaManager from '@core/app/svgedit/workarea';
+import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
+import type { PerspectiveGrid } from '@core/interfaces/FisheyePreview';
+
+// Models whose region preview capture footprint is defined by a perspective grid.
+const gridPreviewModels = ['fbb2', 'fbm2', 'fhx2rf'];
+// Models whose preview only supports full-area capture; no region indicator.
+const fullAreaOnlyModels = new Set(['ado1', ...promarkModels]);
+
+let indicatorRect: null | SVGRectElement = null;
+
+const getIndicatorElement = (): null | SVGRectElement => {
+  if (indicatorRect?.isConnected) return indicatorRect;
+
+  const fixedSizeSvg = document.getElementById('fixedSizeSvg');
+
+  if (!fixedSizeSvg) return null;
+
+  indicatorRect = document.createElementNS(NS.SVG, 'rect') as SVGRectElement;
+  indicatorRect.setAttribute('id', 'previewRegionIndicator');
+  indicatorRect.setAttribute('fill', '#1890ff');
+  indicatorRect.setAttribute('fill-opacity', '0.1');
+  indicatorRect.setAttribute('stroke', '#1890ff');
+  indicatorRect.setAttribute('stroke-width', '1');
+  indicatorRect.setAttribute('stroke-dasharray', '8 4');
+  indicatorRect.setAttribute('vector-effect', 'non-scaling-stroke');
+  indicatorRect.setAttribute('pointer-events', 'none');
+  indicatorRect.setAttribute('display', 'none');
+  fixedSizeSvg.appendChild(indicatorRect);
+
+  return indicatorRect;
+};
+
+const hide = (): void => {
+  indicatorRect?.setAttribute('display', 'none');
+};
+
+/**
+ * Footprint size and clamp bounds for the capture *center*, in canvas px. Static per
+ * preview state; recomputed by the store subscription below, not on mouse move.
+ */
+interface IndicatorConfig {
+  height: number;
+  maxCenterX: number;
+  maxCenterY: number;
+  minCenterX: number;
+  minCenterY: number;
+  width: number;
+}
+
+let config: IndicatorConfig | null = null;
+
+/**
+ * Mirrors RegionPreviewMixin.getPreviewPosition: the capture is centered on the click
+ * point and the footprint (grid.x/y ranges in mm) is clamped inside the workarea —
+ * equivalently, the center stays at least half a footprint away from every edge.
+ */
+const getGridConfig = (model: WorkAreaModel, grid: PerspectiveGrid): IndicatorConfig => {
+  const { dpmm } = constant;
+  const { displayHeight, height: origHeight, width: workareaWidth } = getWorkarea(model);
+  const workareaHeight = displayHeight ?? origHeight;
+  const width = (grid.x[1] - grid.x[0]) * dpmm;
+  const height = (grid.y[1] - grid.y[0]) * dpmm;
+
+  return {
+    height,
+    maxCenterX: workareaWidth * dpmm - width / 2,
+    maxCenterY: workareaHeight * dpmm - height / 2,
+    minCenterX: width / 2,
+    minCenterY: height / 2,
+    width,
+  };
+};
+
+/**
+ * Mirrors BeamPreviewManager for legacy Beam Series (offset laser-head camera): the
+ * capture is a square of side imgHeight * scaleRatioY / (cos(angle) + sin(angle)),
+ * and constrainPreviewXY clamps the *center* (not the footprint, which may overhang
+ * the edges). Uses the live calibration when preview is running, ideal camera
+ * constants otherwise.
+ */
+const getBeamConfig = (model: WorkAreaModel): IndicatorConfig => {
+  const { camera, dpmm } = constant;
+  const offset = previewModeController.previewManager?.getCameraOffset?.() ?? {
+    angle: 0,
+    scaleRatioY: camera.scaleRatio_ideal,
+    x: camera.offsetX_ideal,
+    y: camera.offsetY_ideal,
+  };
+  const side = (camera.imgHeight * offset.scaleRatioY) / (Math.cos(offset.angle) + Math.sin(offset.angle));
+  const { pxDisplayHeight, pxHeight, pxWidth } = getWorkarea(model);
+  const addOnInfo = getAddOnInfo(model);
+  const { borderless, 'enable-diode': enableDiode } = useDocumentStore.getState();
+  let maxCenterX = pxWidth;
+  let maxCenterY = pxDisplayHeight ?? pxHeight;
+
+  if (enableDiode && addOnInfo.hybridLaser) {
+    maxCenterX -= constant.diode.safeDistance.X * dpmm;
+    maxCenterY -= constant.diode.safeDistance.Y * dpmm;
+  } else if (borderless && addOnInfo.openBottom) {
+    maxCenterX -= constant.borderless.safeDistance.X * dpmm;
+  }
+
+  return {
+    height: side,
+    maxCenterX,
+    maxCenterY,
+    minCenterX: offset.x * dpmm,
+    minCenterY: offset.y * dpmm,
+    width: side,
+  };
+};
+
+const updateConfig = (): void => {
+  const { isPreviewMode, pendingPreviewMode, previewMode, supportedPreviewModes } = useCameraPreviewStore.getState();
+  const mode = pendingPreviewMode ?? previewMode;
+  // before preview starts the device is unknown; the workarea has been checked to match it
+  const model = (isPreviewMode && previewModeController.currentDevice?.model) || workareaManager.model;
+
+  if ((mode !== PreviewMode.REGION && mode !== PreviewMode.PRECISE_REGION) || fullAreaOnlyModels.has(model)) {
+    config = null;
+    hide();
+
+    return;
+  }
+
+  const isCameraOblique = supportedPreviewModes.includes(PreviewMode.PRECISE_REGION);
+
+  config = gridPreviewModels.includes(model)
+    ? getGridConfig(model, getRegionPreviewGrid(model, { isCameraOblique, mode }))
+    : getBeamConfig(model);
+};
+
+// supportedPreviewModes is watched because entering pre-preview updates it without
+// touching the other fields; isPreviewMode because live calibration replaces the
+// ideal fallback in getBeamConfig once preview starts.
+useCameraPreviewStore.subscribe(
+  (state) => [state.previewMode, state.pendingPreviewMode, state.isPreviewMode, state.supportedPreviewModes],
+  updateConfig,
+);
+// workarea/model switches don't touch the cameraPreview store; recompute on canvas change.
+eventEmitterFactory.createEventEmitter('canvas').on('canvas-change', updateConfig);
+
+/** Show / move the indicator for a hover at (x, y) in canvas px; hides itself when not applicable. */
+const update = (x: number, y: number): void => {
+  if (!config) {
+    hide();
+
+    return;
+  }
+
+  const elem = getIndicatorElement();
+
+  if (!elem) return;
+
+  const { height, maxCenterX, maxCenterY, minCenterX, minCenterY, width } = config;
+  const centerX = Math.min(Math.max(x, minCenterX), maxCenterX);
+  const centerY = Math.min(Math.max(y, minCenterY), maxCenterY);
+
+  elem.setAttribute('x', (centerX - width / 2).toFixed(1));
+  elem.setAttribute('y', (centerY - height / 2).toFixed(1));
+  elem.setAttribute('width', width.toFixed(1));
+  elem.setAttribute('height', height.toFixed(1));
+  elem.removeAttribute('display');
+};
+
+export default { hide, update };

--- a/packages/core/src/web/app/components/beambox/TopBar/SelectMachineButton.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/TopBar/SelectMachineButton.spec.tsx
@@ -23,6 +23,14 @@ jest.mock('@core/app/contexts/CanvasContext', () => ({
   }),
 }));
 
+const mockGetMouseMode = jest.fn();
+const mockSetMouseMode = jest.fn();
+
+jest.mock('@core/app/stores/canvas/utils/mouseMode', () => ({
+  getMouseMode: () => mockGetMouseMode(),
+  setMouseMode: (mode: string) => mockSetMouseMode(mode),
+}));
+
 const mockGetDevice = jest.fn();
 
 jest.mock(
@@ -86,6 +94,20 @@ describe('test SelectMachineButton', () => {
     fireEvent.click(container.querySelector('div[class*="button"]'));
     expect(mockGetDevice).toHaveBeenCalledTimes(1);
     expect(mockEndPreviewMode).toHaveBeenCalledTimes(0);
+  });
+
+  test('when in pre preview mode', async () => {
+    mockGetMouseMode.mockReturnValue('pre_preview');
+
+    const { container } = render(
+      <CanvasContext value={{ selectedDevice: null } as any}>
+        <SelectMachineButton />
+      </CanvasContext>,
+    );
+
+    await act(() => fireEvent.click(container.querySelector('div[class*="button"]')));
+    expect(mockEndPreviewMode).toHaveBeenCalledTimes(0);
+    expect(mockSetMouseMode).toHaveBeenCalledWith('select');
   });
 
   test('when is preview mode', async () => {

--- a/packages/core/src/web/app/components/beambox/TopBar/SelectMachineButton.tsx
+++ b/packages/core/src/web/app/components/beambox/TopBar/SelectMachineButton.tsx
@@ -33,8 +33,6 @@ function SelectMachineButton(): React.JSX.Element {
       if (previewModeController.isPreviewMode) {
         previewModeController.end();
       } else if (getMouseMode() === 'pre_preview') {
-        // supportedPreviewModes were computed for the previous device; drop back to
-        // select so the next preview click recomputes them.
         setMouseMode('select');
       }
     }

--- a/packages/core/src/web/app/components/beambox/TopBar/SelectMachineButton.tsx
+++ b/packages/core/src/web/app/components/beambox/TopBar/SelectMachineButton.tsx
@@ -3,6 +3,7 @@ import React, { use, useCallback, useMemo } from 'react';
 import previewModeController from '@core/app/actions/beambox/preview-mode-controller';
 import { CanvasContext } from '@core/app/contexts/CanvasContext';
 import TopBarIcons from '@core/app/icons/top-bar/TopBarIcons';
+import { getMouseMode, setMouseMode } from '@core/app/stores/canvas/utils/mouseMode';
 import { useIsMobile } from '@core/app/stores/screenStore';
 import getDevice from '@core/helpers/device/get-device';
 import useI18n from '@core/helpers/useI18n';
@@ -28,8 +29,14 @@ function SelectMachineButton(): React.JSX.Element {
   const handleClick = useCallback(async () => {
     const { device } = await getDevice(true);
 
-    if (previewModeController.isPreviewMode && device && device.uuid !== selectedDevice?.uuid) {
-      previewModeController.end();
+    if (device && device.uuid !== selectedDevice?.uuid) {
+      if (previewModeController.isPreviewMode) {
+        previewModeController.end();
+      } else if (getMouseMode() === 'pre_preview') {
+        // supportedPreviewModes were computed for the previous device; drop back to
+        // select so the next preview click recomputes them.
+        setMouseMode('select');
+      }
     }
   }, [selectedDevice]);
 

--- a/packages/core/src/web/app/constants/fisheyeCameraConstants.ts
+++ b/packages/core/src/web/app/constants/fisheyeCameraConstants.ts
@@ -1,5 +1,6 @@
 import { match } from 'ts-pattern';
 
+import { PreviewMode } from '@core/app/constants/cameraConstants';
 import type { PerspectiveGrid, WideAngleRegion } from '@core/interfaces/FisheyePreview';
 
 type Points = Array<[number, number]>;
@@ -139,6 +140,19 @@ export const bm2FullAreaPerspectiveGrid: PerspectiveGrid = {
   x: [0, 360, 10],
   y: [0, 240, 10],
 } as const;
+
+/**
+ * Perspective grid (= single-shot capture footprint) used by region preview,
+ * mirroring RegionPreviewMixin's constructor and Bb2Hx2PreviewManager.switchPreviewMode.
+ */
+export const getRegionPreviewGrid = (
+  model: string,
+  { isCameraOblique = false, mode = PreviewMode.REGION }: { isCameraOblique?: boolean; mode?: PreviewMode } = {},
+): PerspectiveGrid => {
+  if (model === 'fbm2') return bm2PerspectiveGrid;
+
+  return isCameraOblique && mode === PreviewMode.REGION ? bb2PerspectiveGridWide : bb2PerspectiveGrid;
+};
 
 export const getRegionalPoints = (
   region: WideAngleRegion,

--- a/packages/core/src/web/app/stores/canvas/utils/mouseMode.ts
+++ b/packages/core/src/web/app/stores/canvas/utils/mouseMode.ts
@@ -1,5 +1,6 @@
 import { match } from 'ts-pattern';
 
+import previewRegionIndicator from '@core/app/actions/canvas/preview-region-indicator';
 import curveSelectUrl from '@core/app/icons/left-panel/curve-select.svg?url';
 import { clear as clearPathActions, finishPath } from '@core/app/svgedit/operations/pathActions';
 import textActions from '@core/app/svgedit/text/textactions';
@@ -61,5 +62,7 @@ useCanvasStore.subscribe(
   (state) => state.mouseMode,
   (mouseMode) => {
     setCursorAccordingToMouseMode(mouseMode);
+
+    if (mouseMode !== 'preview' && mouseMode !== 'pre_preview') previewRegionIndicator.hide();
   },
 );

--- a/packages/core/src/web/app/svgedit/interaction/mouse/index.ts
+++ b/packages/core/src/web/app/svgedit/interaction/mouse/index.ts
@@ -8,6 +8,7 @@ import { boundaryDrawer } from '@core/app/actions/canvas/boundaryDrawer';
 import canvasEvents from '@core/app/actions/canvas/canvasEvents';
 import curveEngravingModeController from '@core/app/actions/canvas/curveEngravingModeController';
 import presprayArea from '@core/app/actions/canvas/prespray-area';
+import previewRegionIndicator from '@core/app/actions/canvas/preview-region-indicator';
 import rotaryAxis from '@core/app/actions/canvas/rotary-axis';
 import ObjectPanelController from '@core/app/components/beambox/RightPanel/contexts/ObjectPanelController';
 import * as TutorialController from '@core/app/components/tutorials/tutorialController';
@@ -216,6 +217,7 @@ const mouseDown = async (evt: MouseEvent) => {
     case 'pre_preview':
       svgCanvas.unsafeAccess.setStarted(true);
       setRubberBoxStart(startMouseX, startMouseY);
+      previewRegionIndicator.hide();
 
       return;
     case 'select':
@@ -690,6 +692,10 @@ const mouseMove = (evt: MouseEvent) => {
   if (!started) {
     if (svgCanvas.isAutoAlign && currentMode === 'path') {
       findAndDrawAlignPoints(realX, realY);
+    }
+
+    if (currentMode === 'preview' || currentMode === 'pre_preview') {
+      previewRegionIndicator.update(realX, realY);
     }
 
     //

--- a/packages/core/src/web/helpers/device/camera/previewMode.ts
+++ b/packages/core/src/web/helpers/device/camera/previewMode.ts
@@ -12,7 +12,6 @@ import { setMouseMode } from '@core/app/stores/canvas/utils/mouseMode';
 import showResizeAlert from '@core/helpers/device/fit-device-workarea-alert';
 import getDevice from '@core/helpers/device/get-device';
 import deviceMaster from '@core/helpers/device-master';
-import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import versionChecker from '@core/helpers/version-checker';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
@@ -68,38 +67,6 @@ export const getSupportedPreviewModes = (
   return modes;
 };
 
-/**
- * Query the device for its camera capabilities and refresh supportedPreviewModes in the
- * store. The device must be the currently selected one in deviceMaster, since the camera
- * and setting queries target the current connection.
- */
-export const updateSupportedPreviewModes = async (
-  device: IDeviceInfo,
-): Promise<{ canPreview?: boolean; hasWideAngleCamera: boolean }> => {
-  const { canPreview, hasWideAngleCamera } = await getWideAngleCameraData(device);
-  const isCameraOblique = await checkCameraOblique(device);
-
-  setCameraPreviewState({
-    supportedPreviewModes: getSupportedPreviewModes(device, { hasWideAngleCamera, isCameraOblique }),
-  });
-
-  return { canPreview, hasWideAngleCamera };
-};
-
-// While waiting in pre-preview, the supported modes were computed for the previously
-// selected device; re-evaluate them when the user switches to another device.
-eventEmitterFactory.createEventEmitter('top-bar').on('SET_SELECTED_DEVICE', async (device: IDeviceInfo | null) => {
-  if (!device || useCanvasStore.getState().mouseMode !== 'pre_preview') return;
-
-  try {
-    const res = await deviceMaster.select(device);
-
-    if (res.success) await updateSupportedPreviewModes(device);
-  } catch (err) {
-    console.warn('Failed to update supported preview modes after device switch', err);
-  }
-});
-
 export const handlePreviewClick = async ({ showModal = false }: { showModal?: boolean } = {}): Promise<boolean> => {
   if (tutorialController.getNextStepRequirement() === tutorialConstants.TO_PREVIEW_MODE) {
     tutorialController.handleNextStep();
@@ -125,7 +92,12 @@ export const handlePreviewClick = async ({ showModal = false }: { showModal?: bo
 
   if (!isWorkareaMatched && !(await showResizeAlert(device!))) return false;
 
-  const { canPreview, hasWideAngleCamera } = await updateSupportedPreviewModes(device);
+  const { canPreview, hasWideAngleCamera } = await getWideAngleCameraData(device);
+  const isCameraOblique = await checkCameraOblique(device);
+
+  setCameraPreviewState({
+    supportedPreviewModes: getSupportedPreviewModes(device, { hasWideAngleCamera, isCameraOblique }),
+  });
 
   if (device.model === 'ado1' || device.model === 'fbm2' || (hasWideAngleCamera && canPreview)) {
     setupPreviewMode();

--- a/packages/core/src/web/helpers/device/camera/previewMode.ts
+++ b/packages/core/src/web/helpers/device/camera/previewMode.ts
@@ -12,6 +12,7 @@ import { setMouseMode } from '@core/app/stores/canvas/utils/mouseMode';
 import showResizeAlert from '@core/helpers/device/fit-device-workarea-alert';
 import getDevice from '@core/helpers/device/get-device';
 import deviceMaster from '@core/helpers/device-master';
+import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import versionChecker from '@core/helpers/version-checker';
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
@@ -67,6 +68,38 @@ export const getSupportedPreviewModes = (
   return modes;
 };
 
+/**
+ * Query the device for its camera capabilities and refresh supportedPreviewModes in the
+ * store. The device must be the currently selected one in deviceMaster, since the camera
+ * and setting queries target the current connection.
+ */
+export const updateSupportedPreviewModes = async (
+  device: IDeviceInfo,
+): Promise<{ canPreview?: boolean; hasWideAngleCamera: boolean }> => {
+  const { canPreview, hasWideAngleCamera } = await getWideAngleCameraData(device);
+  const isCameraOblique = await checkCameraOblique(device);
+
+  setCameraPreviewState({
+    supportedPreviewModes: getSupportedPreviewModes(device, { hasWideAngleCamera, isCameraOblique }),
+  });
+
+  return { canPreview, hasWideAngleCamera };
+};
+
+// While waiting in pre-preview, the supported modes were computed for the previously
+// selected device; re-evaluate them when the user switches to another device.
+eventEmitterFactory.createEventEmitter('top-bar').on('SET_SELECTED_DEVICE', async (device: IDeviceInfo | null) => {
+  if (!device || useCanvasStore.getState().mouseMode !== 'pre_preview') return;
+
+  try {
+    const res = await deviceMaster.select(device);
+
+    if (res.success) await updateSupportedPreviewModes(device);
+  } catch (err) {
+    console.warn('Failed to update supported preview modes after device switch', err);
+  }
+});
+
 export const handlePreviewClick = async ({ showModal = false }: { showModal?: boolean } = {}): Promise<boolean> => {
   if (tutorialController.getNextStepRequirement() === tutorialConstants.TO_PREVIEW_MODE) {
     tutorialController.handleNextStep();
@@ -92,12 +125,7 @@ export const handlePreviewClick = async ({ showModal = false }: { showModal?: bo
 
   if (!isWorkareaMatched && !(await showResizeAlert(device!))) return false;
 
-  const { canPreview, hasWideAngleCamera } = await getWideAngleCameraData(device);
-  const isCameraOblique = await checkCameraOblique(device);
-
-  setCameraPreviewState({
-    supportedPreviewModes: getSupportedPreviewModes(device, { hasWideAngleCamera, isCameraOblique }),
-  });
+  const { canPreview, hasWideAngleCamera } = await updateSupportedPreviewModes(device);
 
   if (device.model === 'ado1' || device.model === 'fbm2' || (hasWideAngleCamera && canPreview)) {
     setupPreviewMode();

--- a/packages/core/src/web/interfaces/PreviewManager.d.ts
+++ b/packages/core/src/web/interfaces/PreviewManager.d.ts
@@ -46,9 +46,13 @@ export interface PreviewManager {
    * preview point
    * @param x x in px
    * @param y y in px
-   * @param opts
+   * @param opts silent: suppress progress messages (e.g. when the caller shows its own)
    */
-  preview(x: number, y: number, opts?: { overlapFlag?: number; overlapRatio?: number }): Promise<boolean>;
+  preview(
+    x: number,
+    y: number,
+    opts?: { overlapFlag?: number; overlapRatio?: number; silent?: boolean },
+  ): Promise<boolean>;
 
   previewFullWorkarea?: () => Promise<boolean>;
 


### PR DESCRIPTION
https://app.clickup.com/t/5719332/86exxq2uz

## Summary

1. Show a dashed rectangle following the cursor in preview / pre-preview mouse modes, indicating the exact area the camera will capture for REGION / PRECISE_REGION previews
  i. Grid-based models (fbb2 / fhx2rf / fbm2): footprint from the perspective grid, clamped inside the workarea like the real capture
  ii. Legacy Beam Series: square footprint from camera calibration (live `getCameraOffset()` when previewing, ideal constants in pre-preview); center-clamped like `constrainPreviewXY`, so it may overhang edges as real captures do
  iii. Config (size + clamp bounds) is cached and recomputed via cameraPreview store subscription and `canvas-change`; mouse move only clamps and moves the rect
2.  Show the "capturing image" message (and success toast) for single-point region previews, matching the existing batch and full-area flows; batch capture passes `silent` so its `i/n` counter is not overwritten
3. Fix stale `supportedPreviewModes` when switching to a different device while in pre-preview: re-query camera capabilities on device switch and let the store coerce the current mode

## 摘要

1. 在預覽 / 預備預覽滑鼠模式下，顯示跟隨游標的虛線矩形，指示相機在「區域 / 精細區域」預覽時實際拍攝的範圍
  i. 網格機型（fbb2 / fhx2rf / fbm2）：依透視網格計算拍攝範圍，並如實際拍攝般限制在工作區域內
  ii. 舊款 Beam 系列：依相機校正資料計算方形拍攝範圍（預覽中使用即時 `getCameraOffset()`，預備預覽時使用理想常數）；如 `constrainPreviewXY` 般僅限制中心點，因此矩形可能超出邊緣（與實際拍攝一致）
  iii. 尺寸與範圍限制會快取，並透過 cameraPreview store 訂閱與 `canvas-change` 事件重新計算；滑鼠移動時僅更新位置
2. 單點區域預覽時顯示「擷取影像中」訊息與成功提示，與批次及全區域預覽一致；批次拍攝改傳 `silent` 以避免覆蓋 `i/n` 進度訊息
3. 修正預備預覽時切換至不同型號機器後 `supportedPreviewModes` 未更新的問題：切換機器時重新查詢相機能力，並由 store 修正目前模式

## Test plan

- [x] fbb2 / fhx2rf: hover in region & precise region preview — the rectangle tracks the cursor, matches where the captured image lands, and stops at workarea edges
- [x] Legacy Beam Series: single-click preview shows the capturing message and the indicator square matches the pasted image
- [x] Drag region preview still shows the `i/n` progress counter (no message flicker)
- [x] Switch device with a different model while the floating bar is shown — mode buttons and indicator update

🤖 Generated with [Claude Code](https://claude.com/claude-code)