### PR TITLE
Unify layer state under layerManager

### DIFF
--- a/.agents/skills/layer-management/SKILL.md
+++ b/.agents/skills/layer-management/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: layer-management
+description: Layer system architecture — layerManager as the single mutation API, the passive layerStore, Layer DOM wrappers, and the resync/identifyLayers semantics. Use when reading or writing layer state, adding layer operations, debugging layer-panel/undo desyncs, or writing specs for code that imports layerManager.
+---
+
+# Layer Management System
+
+## Purpose
+
+Layers are `<g class="layer">` elements inside `#svgcontent`, each with a `<title>` child holding the
+layer name (names are unique and are the primary key everywhere). The DOM is the source of truth for
+layer *content*; an in-memory cache of `Layer` objects plus selection state lives in a Zustand store
+so React can subscribe. One rule keeps the two consistent:
+
+**layerManager is the ONLY writer of layer state. Never call `useLayerStore.setState` outside
+`svgedit/layer/` — an ESLint `no-restricted-syntax` rule in eslint.config.js enforces this**
+(specs and `__mocks__` are exempt; specs seed state with `useLayerStore.setState`).
+
+## File Locations
+
+- `packages/core/src/web/app/svgedit/layer/layerManager.ts` — the whole mutation API (singleton `layerManager`)
+- `packages/core/src/web/app/svgedit/layer/layer.ts` — `Layer` class wrapping one `<g class="layer">` group
+- `packages/core/src/web/app/stores/layer/layerStore.ts` — passive state container, NO actions
+- `packages/core/src/web/helpers/layer/layer-helper.ts` — high-level operations (clone/merge/move/lock, UI alerts, history batches)
+- `packages/core/src/web/helpers/layer/deleteLayer.ts` — delete flows + default-layer fallback
+- `packages/core/src/web/helpers/layer/layer-config-helper.ts` — per-layer `data-*` config read/write
+
+## State Shape (layerStore)
+
+| Field | Meaning |
+|---|---|
+| `layers: Layer[]` | all layers, bottom → top, mirrors DOM order |
+| `currentLayerName: null \| string` | layer receiving new elements |
+| `selectedLayers: string[]` | panel selection (never left empty by `setSelectedLayers`) |
+| `hasVector`, `hasGradient` | derived flags for the selected layers (gradient = Promark only) |
+
+## How to Access Layer State
+
+- **React component, reactive**: `useLayerStore((s) => s.selectedLayers)` — subscription only.
+- **Imperative read** (event handler, class method, helper): a `layerManager` getter
+  (`getSelectedLayers()`, `getCurrentLayerName()`, …). Prefer this in new code; a number of older
+  call sites (mostly ConfigPanel blocks) still read `useLayerStore.getState().selectedLayers`
+  directly, which is tolerated but not the pattern to copy — converting them is deferred only
+  because each converted component's specs then need `getSelectedLayers` in their inline
+  layerManager mock factory.
+- **Any write**: a `layerManager` method. No exceptions (ESLint-enforced).
+
+Rule of thumb: the hook exists to make React re-render; layerManager is the API. A component that
+never subscribes (e.g. a class component like LayerPanel) should not import the store at all.
+
+## Key layerManager Methods
+
+- `setSelectedLayers(names, currentLayer?)` — sets selection AND current layer (defaults to
+  `names[0]`; empty input falls back to `[currentLayerName]`), then re-runs `checkVector`/`checkGradient`.
+  Never pair it with a preceding `setCurrentLayer` call — that's redundant.
+- `identifyLayers()` — **fresh-document semantics**: rebuilds `Layer[]` from the DOM, adopts orphan
+  visible elements into a new `Layer N`, resets current layer to the top. Use after loading/replacing
+  a document (`setSvgContent` does this).
+- `resync()` — **same-document semantics**: rebuilds from the DOM but PRESERVES current layer and
+  selection when the names survive (dead current → first surviving selected → top layer; empty
+  selection → `[current]`). Use after undo/redo or any operation that mutated layer groups behind the
+  manager's back. Undo/redo already calls it centrally in `svgedit/history/utils/index.ts` — do NOT
+  add `cmd.onAfter = resync` sprinkles or re-call it after undoable commands.
+- `checkVector()` / `checkGradient(workarea?)` — recompute the derived flags; auto-run on selection
+  change, call manually only after mutating layer content in place (e.g. infill toggle).
+- `createLayer(name?, historyOptions?)` — creates group + title in the DOM, registers it, makes it
+  current. Prefer `layer-helper`'s `createLayer` wrapper when you need color/config/fullcolor init.
+- `removeLayerByName(name, historyOptions?)` — detaches the group AND unregisters it from the store,
+  so the name is immediately free for reuse (a stale registration once caused delete-then-recreate
+  to yield "Layer 1 1"). If it was current, the top remaining layer becomes current. The
+  `deleteLayerByName` helper in `helpers/layer/deleteLayer.ts` is a thin delegate to this.
+- `reset(svgContent, identifyLayers?)` — repoint at a new `#svgcontent` (document swap).
+
+`Layer` objects expose `getGroup()`, `setVisible`, `setName`, `setColor`, `setOpacity`,
+`setFullColor`, `removeGroup` — attribute-level operations on the `<g>`; the undo-relevant ones
+(`setVisible`, `setName`, `removeGroup`) emit history commands.
+
+## Choosing identifyLayers vs resync
+
+Ask: "is the user still working in this document?" Yes → `resync()` (selection must survive).
+No / document just loaded → `identifyLayers()`. Calling `identifyLayers()` before `resync()` is a
+bug, not belt-and-braces: identifyLayers resets current to top FIRST, and resync then faithfully
+preserves that wrong value.
+
+## Testing Gotchas
+
+- The central mock `src/__mocks__/@core/app/stores/layer/layerStore.ts` is state-only
+  (defaults: `selectedLayers: ['layer1']`, `currentLayerName: 'layer1'`). Seed with
+  `useLayerStore.setState({...})`. There are no action mocks on it.
+- Mock layerManager **inline per spec** with a factory containing only the members the code under
+  test calls. Do NOT create a global `__mocks__` for layerManager — many specs exercise the real one.
+- A spec whose component loads the REAL layerManager can crash with a `p-queue` ESM SyntaxError via
+  the chain layerManager → layer.ts → undoManager → currentFileManager → dialog-caller → … →
+  helpers/api/camera → p-queue. The fix is the inline layerManager mock above.
+
+## Known Legacy Touchpoint
+
+`cloneLayer` in layer-helper still uses `svgCanvas.getCurrentDrawing().copyElem` — the legacy
+`public/js/lib/svgeditor/draw.js` survives only as the element-ID allocator + copyElem (clipboard
+uses it too). Porting `svgedit.utilities.copyElem` to TS would remove it for both.

--- a/.agents/skills/layer-management/SKILL.md
+++ b/.agents/skills/layer-management/SKILL.md
@@ -38,12 +38,13 @@ so React can subscribe. One rule keeps the two consistent:
 
 - **React component, reactive**: `useLayerStore((s) => s.selectedLayers)` — subscription only.
 - **Imperative read** (event handler, class method, helper): a `layerManager` getter
-  (`getSelectedLayers()`, `getCurrentLayerName()`, …). Prefer this in new code; a number of older
-  call sites (mostly ConfigPanel blocks) still read `useLayerStore.getState().selectedLayers`
-  directly, which is tolerated but not the pattern to copy — converting them is deferred only
-  because each converted component's specs then need `getSelectedLayers` in their inline
-  layerManager mock factory.
+  (`getSelectedLayers()`, `getCurrentLayerName()`, …). `useLayerStore.getState()` is not used
+  outside `svgedit/layer/` (specs excepted, where `setState` seeds the mock).
 - **Any write**: a `layerManager` method. No exceptions (ESLint-enforced).
+
+In specs, a component's inline layerManager mock can keep `getSelectedLayers` consistent with
+store-mock seeding by delegating:
+`getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers`.
 
 Rule of thumb: the hook exists to make React re-render; layerManager is the API. A component that
 never subscribes (e.g. a class component like LayerPanel) should not import the store at all.

--- a/.agents/skills/layer-management/SKILL.md
+++ b/.agents/skills/layer-management/SKILL.md
@@ -31,7 +31,7 @@ so React can subscribe. One rule keeps the two consistent:
 |---|---|
 | `layers: Layer[]` | all layers, bottom → top, mirrors DOM order |
 | `currentLayerName: null \| string` | layer receiving new elements |
-| `selectedLayers: string[]` | panel selection (never left empty by `setSelectedLayers`) |
+| `selectedLayers: string[]` | panel selection (`setSelectedLayers` leaves it empty only when no layer exists) |
 | `hasVector`, `hasGradient` | derived flags for the selected layers (gradient = Promark only) |
 
 ## How to Access Layer State
@@ -68,8 +68,11 @@ never subscribes (e.g. a class component like LayerPanel) should not import the 
   current. Prefer `layer-helper`'s `createLayer` wrapper when you need color/config/fullcolor init.
 - `removeLayerByName(name, historyOptions?)` — detaches the group AND unregisters it from the store,
   so the name is immediately free for reuse (a stale registration once caused delete-then-recreate
-  to yield "Layer 1 1"). If it was current, the top remaining layer becomes current. The
-  `deleteLayerByName` helper in `helpers/layer/deleteLayer.ts` is a thin delegate to this.
+  to yield "Layer 1 1"). If it was current, the top remaining layer becomes current, and the name
+  is dropped from the selection (falling back to current) — callers need no selection cleanup. It
+  does NOT recreate a default layer when the last layer is removed; delete flows should go through
+  `deleteLayers` in `helpers/layer/deleteLayer.ts`, which does (the `deleteLayerByName` helper
+  there is a thin delegate without that guard).
 - `reset(svgContent, identifyLayers?)` — repoint at a new `#svgcontent` (document swap).
 
 `Layer` objects expose `getGroup()`, `setVisible`, `setName`, `setColor`, `setOpacity`,

--- a/.agents/skills/layer-management/SKILL.md
+++ b/.agents/skills/layer-management/SKILL.md
@@ -13,8 +13,10 @@ layer *content*; an in-memory cache of `Layer` objects plus selection state live
 so React can subscribe. One rule keeps the two consistent:
 
 **layerManager is the ONLY writer of layer state. Never call `useLayerStore.setState` outside
-`svgedit/layer/` — an ESLint `no-restricted-syntax` rule in eslint.config.js enforces this**
-(specs and `__mocks__` are exempt; specs seed state with `useLayerStore.setState`).
+`svgedit/layer/` — ESLint `no-restricted-syntax` rules in eslint.config.js enforce this**
+(specs and `__mocks__` are exempt; specs seed state with `useLayerStore.setState`). To keep the
+rule un-bypassable, `layerStore.ts` has no default export and importing `useLayerStore` under an
+alias is also lint-banned — always `import { useLayerStore } from '@core/app/stores/layer/layerStore'`.
 
 ## File Locations
 
@@ -42,9 +44,12 @@ so React can subscribe. One rule keeps the two consistent:
   outside `svgedit/layer/` (specs excepted, where `setState` seeds the mock).
 - **Any write**: a `layerManager` method. No exceptions (ESLint-enforced).
 
-In specs, a component's inline layerManager mock can keep `getSelectedLayers` consistent with
-store-mock seeding by delegating:
-`getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers`.
+In specs, seed each read path where it lives: a component that only reads imperatively gets an
+inline layerManager mock seeded directly (`const mockGetSelectedLayers = jest.fn();` →
+`getSelectedLayers: () => mockGetSelectedLayers()` → `mockGetSelectedLayers.mockReturnValue([...])`),
+with no `useLayerStore` seeding at all; seed the store mock only when the component subscribes via
+the hook. Only a component that genuinely uses both paths needs the layerManager mock to delegate
+to the store mock's `getState()` so one seed feeds both.
 
 Rule of thumb: the hook exists to make React re-render; layerManager is the API. A component that
 never subscribes (e.g. a class component like LayerPanel) should not import the store at all.

--- a/.agents/skills/unit-test/SKILL.md
+++ b/.agents/skills/unit-test/SKILL.md
@@ -93,7 +93,7 @@ Location: `packages/core/src/__mocks__/`
 | `@core/app/stores/storageStore` | full in-memory store with `useStorageStore`, `getStorage`, `setStorage` |
 | `@core/app/stores/documentStore` | full in-memory store |
 | `@core/app/stores/globalPreferenceStore` | full in-memory store |
-| `@core/app/stores/layer/layerStore` | full in-memory store |
+| `@core/app/stores/layer/layerStore` | state-only in-memory store (no actions; seed with `useLayerStore.setState({...})` — layer mutations live on `layerManager`, mock that inline per spec) |
 | `@core/app/pages/Settings/useSettingStore` | in-memory settings store |
 | `@core/app/contexts/CanvasContext` | stub context provider |
 | `@core/app/widgets/UnitInput` | renders real `<input>` with `onChange` wired to `Number(e.target.value)` |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -170,6 +170,21 @@ module.exports = [
     rules: { 'import/order': 'off' },
   },
   {
+    // layer state boundary: only layerManager (svgedit/layer/) may write to useLayerStore
+    files: [SRC_GLOB_TS, SRC_GLOB_TSX],
+    ignores: ['**/svgedit/layer/**', '**/__mocks__/**', ...SRC_GLOB_TESTS],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          message:
+            'Layer state is written only by layerManager (@core/app/svgedit/layer/layerManager) — call its methods instead of useLayerStore.setState.',
+          selector: "CallExpression[callee.object.name='useLayerStore'][callee.property.name='setState']",
+        },
+      ],
+    },
+  },
+  {
     files: ['**/webpack.*.js', 'eslint.config.js', './eslint/**/*.js'],
     rules: {
       'format/prettier': [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -181,6 +181,10 @@ module.exports = [
             'Layer state is written only by layerManager (@core/app/svgedit/layer/layerManager) — call its methods instead of useLayerStore.setState.',
           selector: "CallExpression[callee.object.name='useLayerStore'][callee.property.name='setState']",
         },
+        {
+          message: 'Import useLayerStore by its own name — aliasing it hides writes from the layer state boundary.',
+          selector: "ImportSpecifier[imported.name='useLayerStore'][local.name!='useLayerStore']",
+        },
       ],
     },
   },

--- a/packages/core/src/__mocks__/@core/app/stores/layer/layerStore.ts
+++ b/packages/core/src/__mocks__/@core/app/stores/layer/layerStore.ts
@@ -17,5 +17,3 @@ useLayerStore.setState = (newState: Partial<LayerStoreState>) => {
   Object.assign(state, newState);
 };
 useLayerStore.subscribe = jest.fn();
-
-export default useLayerStore;

--- a/packages/core/src/__mocks__/@core/app/stores/layer/layerStore.ts
+++ b/packages/core/src/__mocks__/@core/app/stores/layer/layerStore.ts
@@ -1,47 +1,21 @@
-import type { LayerStoreActions, LayerStoreState } from '@core/app/stores/layer/layerStore';
+import type { LayerStoreState } from '@core/app/stores/layer/layerStore';
 
-export const mockCheckGradient = jest.fn();
-export const mockCheckVector = jest.fn();
-export const mockForceUpdate = jest.fn();
-export const mockSetSelectedLayers = jest.fn();
-
-const state = {
+const state: LayerStoreState = {
+  currentLayerName: 'layer1',
   hasGradient: false,
   hasVector: false,
+  layers: [],
   selectedLayers: ['layer1'],
 };
 
-const actions = {
-  checkGradient: () => {
-    const res = mockCheckGradient();
-
-    state.hasGradient = res ?? false;
-  },
-  checkVector: () => {
-    const res = mockCheckVector();
-
-    state.hasVector = res ?? false;
-  },
-  forceUpdate: () => {
-    mockForceUpdate();
-  },
-  setSelectedLayers: (selectedLayers: string[]) => {
-    mockSetSelectedLayers(selectedLayers);
-    state.selectedLayers = selectedLayers;
-  },
+export const useLayerStore = (selector?: (state: LayerStoreState) => Partial<LayerStoreState>) => {
+  return selector ? selector({ ...state }) : { ...state };
 };
 
-export const useLayerStore = (
-  selector?: (state: LayerStoreActions & LayerStoreState) => Partial<LayerStoreActions & LayerStoreState>,
-) => {
-  const allStates = { ...state, ...actions };
-
-  return selector ? selector(allStates) : allStates;
-};
-
-useLayerStore.getState = () => ({ ...state, ...actions });
-useLayerStore.setState = (newState: Partial<LayerStoreActions & LayerStoreState>) => {
+useLayerStore.getState = () => ({ ...state });
+useLayerStore.setState = (newState: Partial<LayerStoreState>) => {
   Object.assign(state, newState);
 };
+useLayerStore.subscribe = jest.fn();
 
 export default useLayerStore;

--- a/packages/core/src/web/app/actions/beambox/svg-editor.ts
+++ b/packages/core/src/web/app/actions/beambox/svg-editor.ts
@@ -78,7 +78,7 @@ import {
   setCursorAccordingToMouseMode,
   setMouseMode,
 } from '@core/app/stores/canvas/utils/mouseMode';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { getBBox } from '@core/app/svgedit/utils/getBBox';
 import { showPanel } from '@core/app/widgets/dockable/utils';
 import { getRotationAngle } from '@core/app/svgedit/transform/rotation';
@@ -642,7 +642,7 @@ const svgEditor = (window['svgEditor'] = (function () {
       clearResumeConfig({ isChange: false });
       workareaManager.resetView();
       RightPanelController.setPanelType(isMobile() ? PanelType.None : PanelType.Layer);
-      useLayerStore.getState().forceUpdate();
+      layerManager.resync();
       updateContextPanel();
       svgedit.transformlist.resetListMap();
     };
@@ -662,7 +662,7 @@ const svgEditor = (window['svgEditor'] = (function () {
       });
     })();
 
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
 
     var centerCanvas = function () {
       // this centers the canvas vertically in the workarea (horizontal handled in CSS)
@@ -1021,7 +1021,7 @@ const svgEditor = (window['svgEditor'] = (function () {
           case 'json':
             Progress.popById('loading_image');
             await importPresets(file);
-            useLayerStore.getState().forceUpdate();
+            layerManager.resync();
             break;
           case 'unknown':
             Progress.popById('loading_image');

--- a/packages/core/src/web/app/components/beambox/RightPanel/AddLayerButton.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/AddLayerButton.spec.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import AddLayerButton from './AddLayerButton';
-import { mockSetSelectedLayers } from '@mocks/@core/app/stores/layer/layerStore';
 
 const mockHasLayer = jest.fn();
+const mockSetSelectedLayers = jest.fn();
 
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   hasLayer: (...args) => mockHasLayer(...args),
+  setSelectedLayers: (...args) => mockSetSelectedLayers(...args),
 }));
 
 const mockCreateLayer = jest.fn();

--- a/packages/core/src/web/app/components/beambox/RightPanel/AddLayerButton.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/AddLayerButton.tsx
@@ -5,7 +5,6 @@ import Icon from '@ant-design/icons';
 import TutorialController from '@core/app/components/tutorials/tutorialController';
 import TutorialConstants from '@core/app/constants/tutorial-constants';
 import LayerPanelIcons from '@core/app/icons/layer-panel/LayerPanelIcons';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import { createLayer } from '@core/helpers/layer/layer-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -30,7 +29,7 @@ function AddLayerButton(): React.JSX.Element {
       TutorialController.handleNextStep();
     }
 
-    useLayerStore.getState().setSelectedLayers([uniqName]);
+    layerManager.setSelectedLayers([uniqName]);
   };
 
   return (

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedPowerPanel.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedPowerPanel.tsx
@@ -4,9 +4,9 @@ import { ConfigProvider, InputNumber, Modal, Slider } from 'antd';
 
 import { ConfigModalBlock } from '@core/app/constants/antd-config';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeDataLayer } from '@core/helpers/layer/layer-config-helper';
 import { getLayerByName } from '@core/helpers/layer/layer-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -43,7 +43,7 @@ const AdvancedPowerPanel = ({ onClose }: Props): React.JSX.Element => {
     const newState = { ...state };
     const batchCmd = new history.BatchCommand('Change power advanced setting');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       const layer = getLayerByName(layerName)!;
 
       if (

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedSettingModal.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedSettingModal.spec.tsx
@@ -83,12 +83,13 @@ jest.mock('@core/app/stores/configPanel', () => ({
   useConfigPanelStore: mockUseConfigPanelStore,
 }));
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import AdvancedSettingModal from './AdvancedSettingModal';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 
 describe('test AdvancedSettingModal', () => {
   beforeEach(() => {
@@ -111,7 +112,7 @@ describe('test AdvancedSettingModal', () => {
       wobbleDiameter: { hasMultiValue: false, value: -0.2 },
       wobbleStep: { hasMultiValue: false, value: -0.05 },
     });
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
   });
 
   it('should render correctly', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedSettingModal.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedSettingModal.spec.tsx
@@ -83,6 +83,10 @@ jest.mock('@core/app/stores/configPanel', () => ({
   useConfigPanelStore: mockUseConfigPanelStore,
 }));
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import AdvancedSettingModal from './AdvancedSettingModal';
 import useLayerStore from '@core/app/stores/layer/layerStore';
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedSettingModal.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AdvancedSettingModal.tsx
@@ -4,9 +4,9 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Modal, Switch, Tooltip } from 'antd';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import isDev from '@core/helpers/is-dev';
 import { writeDataLayer } from '@core/helpers/layer/layer-config-helper';
@@ -56,7 +56,7 @@ const AdvancedSettingModal = ({ onClose }: Props): React.JSX.Element => {
 
     const batchCmd = new history.BatchCommand('Change advanced setting');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       const layer = getLayerByName(layerName)!;
 
       keys.forEach((key) => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AutoFocus.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AutoFocus.spec.tsx
@@ -40,6 +40,10 @@ jest.mock('@core/app/stores/configPanel', () => ({
   useConfigPanelStore: (...args) => mockUseConfigPanelStore(...args),
 }));
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import AutoFocus from './AutoFocus';
 import useLayerStore from '@core/app/stores/layer/layerStore';
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AutoFocus.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AutoFocus.spec.tsx
@@ -40,12 +40,13 @@ jest.mock('@core/app/stores/configPanel', () => ({
   useConfigPanelStore: (...args) => mockUseConfigPanelStore(...args),
 }));
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import AutoFocus from './AutoFocus';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 
 describe('test AutoFocus', () => {
   beforeEach(() => {
@@ -56,7 +57,7 @@ describe('test AutoFocus', () => {
       repeat: { hasMultiValue: false, value: 1 },
       zStep: { hasMultiValue: false, value: 0 },
     });
-    useLayerStore.setState({ selectedLayers: mockSelectedLayers });
+    mockGetSelectedLayers.mockReturnValue(mockSelectedLayers);
   });
 
   it('should render correctly when height is less than 0', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AutoFocus.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/AutoFocus.tsx
@@ -4,9 +4,9 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 import useI18n from '@core/helpers/useI18n';
 
@@ -29,7 +29,7 @@ const AutoFocus = ({ type = 'default' }: { type?: 'default' | 'modal' | 'panel-i
 
     const batchCmd = new history.BatchCommand('Change auto focus toggle');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => writeData(layerName, 'height', value, { batchCmd }));
+    layerManager.getSelectedLayers().forEach((layerName) => writeData(layerName, 'height', value, { batchCmd }));
     batchCmd.onAfter = initState;
     undoManager.addCommandToHistory(batchCmd);
   };

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/BlendKWithCmyBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/BlendKWithCmyBlock.tsx
@@ -4,9 +4,9 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 
 import styles from './Block.module.scss';
@@ -24,7 +24,7 @@ const BlendKWithCmyBlock = ({ type = 'default' }: { type?: 'default' | 'modal' |
 
     const batchCmd = new history.BatchCommand('Change blend K with CMY');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       writeData(layerName, 'blendKWithCmy', newValue, { batchCmd });
     });
     batchCmd.onAfter = initState;

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorAdvancedSetting/ColorAdvancedSettingButton.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorAdvancedSetting/ColorAdvancedSettingButton.spec.tsx
@@ -2,23 +2,23 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
-
 const mockShowColorAdvancedSetting = jest.fn();
 
 jest.mock('./utils', () => ({
   showColorAdvancedSetting: (...args) => mockShowColorAdvancedSetting(...args),
 }));
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import ColorAdvancedSettingButton from './ColorAdvancedSettingButton';
 
 describe('ColorAdvancedSettingButton', () => {
   beforeEach(() => {
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
   });
 
   it('should renders correctly', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorAdvancedSetting/ColorAdvancedSettingButton.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorAdvancedSetting/ColorAdvancedSettingButton.spec.tsx
@@ -10,6 +10,10 @@ jest.mock('./utils', () => ({
   showColorAdvancedSetting: (...args) => mockShowColorAdvancedSetting(...args),
 }));
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import ColorAdvancedSettingButton from './ColorAdvancedSettingButton';
 
 describe('ColorAdvancedSettingButton', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorAdvancedSetting/ColorAdvancedSettingButton.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorAdvancedSetting/ColorAdvancedSettingButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import ConfigPanelIcons from '@core/app/icons/config-panel/ConfigPanelIcons';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 
 import styles from '../Block.module.scss';
 
@@ -11,10 +11,7 @@ const ColorAdvancedSettingButton = () => {
   return (
     <>
       <div className={styles.panel}>
-        <span
-          className={styles.title}
-          onClick={() => showColorAdvancedSetting(useLayerStore.getState().selectedLayers)}
-        >
+        <span className={styles.title} onClick={() => showColorAdvancedSetting(layerManager.getSelectedLayers())}>
           Color Advanced Setting
           <span className={styles.icon}>
             <ConfigPanelIcons.ColorAdjustment />

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorRatioModal.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ColorRatioModal.tsx
@@ -5,7 +5,7 @@ import { Col, ConfigProvider, Modal, Row } from 'antd';
 import { ColorRatioModalBlock } from '@core/app/constants/antd-config';
 import { PrintingColors } from '@core/app/constants/color-constants';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeDataLayer } from '@core/helpers/layer/layer-config-helper';
 import { getLayerByName } from '@core/helpers/layer/layer-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -41,7 +41,7 @@ const ColorRationModal = ({ fullColor, onClose }: Props): React.JSX.Element => {
       ? ['cRatio', 'mRatio', 'yRatio', 'kRatio']
       : ['printingStrength'];
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       const layer = getLayerByName(layerName)!;
 
       keys.forEach((key) => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ConfigPanel.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ConfigPanel.tsx
@@ -20,7 +20,7 @@ import { getWorkarea } from '@core/app/constants/workarea-constants';
 import LayerPanelIcons from '@core/app/icons/layer-panel/LayerPanelIcons';
 import { useCanvasStore } from '@core/app/stores/canvas/canvasStore';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import Select from '@core/app/widgets/AntdSelect';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ConfigPanel.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ConfigPanel.tsx
@@ -131,7 +131,7 @@ const ConfigPanel = ({ UIType = 'default' }: Props): React.JSX.Element => {
     if (UIType === 'modal' && selectedLayers.length > 1) {
       const currentLayerName = layerManager.getCurrentLayerName();
 
-      useLayerStore.getState().setSelectedLayers([currentLayerName]);
+      layerManager.setSelectedLayers([currentLayerName]);
     }
   }, [selectedLayers, UIType]);
 
@@ -408,7 +408,7 @@ const ConfigPanel = ({ UIType = 'default' }: Props): React.JSX.Element => {
           if (changedKeys.includes('power')) clearMinPower(layer, current.power.value, batchCmd);
         });
 
-        if (fullColorToggled) useLayerStore.getState().forceUpdate();
+        if (fullColorToggled) layerManager.resync();
 
         batchCmd.onAfter = initState;
         svgCanvas.addCommandToHistory(batchCmd);

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/CurveEngravingZHighSpeed.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/CurveEngravingZHighSpeed.spec.tsx
@@ -17,7 +17,7 @@ const mockInitState = jest.fn();
 jest.mock('./initState', () => mockInitState);
 
 import CurveEngravingZHighSpeed from './CurveEngravingZHighSpeed';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockWriteData = jest.fn();
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/CurveEngravingZHighSpeed.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/CurveEngravingZHighSpeed.tsx
@@ -5,7 +5,7 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/Diode.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/Diode.spec.tsx
@@ -29,7 +29,7 @@ const mockInitState = jest.fn();
 jest.mock('./initState', () => mockInitState);
 
 import Diode from './Diode';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockSelectedLayers = ['layer1', 'layer2'];
 const mockUseConfigPanelStore = jest.fn();

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/Diode.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/Diode.tsx
@@ -4,7 +4,7 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DottingTimeBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DottingTimeBlock.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import MockNumberBlock from '@mocks/@core/app/components/beambox/RightPanel/ConfigPanel/NumberBlock';
 
 jest.mock('./NumberBlock', () => MockNumberBlock);

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DottingTimeBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DottingTimeBlock.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import React, { memo } from 'react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import useI18n from '@core/helpers/useI18n';
 
 import NumberBlock from './NumberBlock';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DpiBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/DpiBlock.tsx
@@ -8,7 +8,6 @@ import type { EngraveDpiValue } from '@core/app/constants/resolutions';
 import { defaultEngraveDpiOptions, dpiValueMap, valueDpiMap } from '@core/app/constants/resolutions';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -49,7 +48,7 @@ const DpiBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | 'panel-it
       const batchCmd = new history.BatchCommand('Change layers dpi');
       let shouldInitState = false;
 
-      useLayerStore.getState().selectedLayers.forEach((layerName) => {
+      layerManager.getSelectedLayers().forEach((layerName) => {
         const layer = layerManager.getLayerElementByName(layerName);
 
         if (!layer) return;

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/FocusBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/FocusBlock.tsx
@@ -8,6 +8,7 @@ import { useConfigPanelStore } from '@core/app/stores/configPanel';
 import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import isDev from '@core/helpers/is-dev';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -40,7 +41,7 @@ const FocusBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | 'panel-
 
     const batchCmd = new history.BatchCommand('Toggle focus adjustment');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => writeData(layerName, 'focus', value, { batchCmd }));
+    layerManager.getSelectedLayers().forEach((layerName) => writeData(layerName, 'focus', value, { batchCmd }));
     batchCmd.onAfter = initState;
     undoManager.addCommandToHistory(batchCmd);
   };

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/FocusBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/FocusBlock.tsx
@@ -5,7 +5,7 @@ import { Switch, Tooltip } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HalftoneBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HalftoneBlock.spec.tsx
@@ -20,7 +20,7 @@ const mockInitState = jest.fn();
 jest.mock('./initState', () => mockInitState);
 
 import HalftoneBlock from './HalftoneBlock';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockAddCommandToHistory = jest.fn();
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HalftoneBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HalftoneBlock.tsx
@@ -4,7 +4,7 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import Select from '@core/app/widgets/AntdSelect';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HighQualityBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HighQualityBlock.spec.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
-
 const mockChange = jest.fn();
 let mockData = { hasMultiValue: false, value: false };
 
@@ -47,8 +45,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import HighQualityBlock from './HighQualityBlock';
@@ -58,7 +58,7 @@ describe('test HighQualityBlock', () => {
     jest.clearAllMocks();
     batchCmd = { count: 0, onAfter: undefined };
     mockData = { hasMultiValue: false, value: false };
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
   });
 
   it('should render correctly', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HighQualityBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HighQualityBlock.spec.tsx
@@ -47,6 +47,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import HighQualityBlock from './HighQualityBlock';
 
 describe('test HighQualityBlock', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HighQualityBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/HighQualityBlock.tsx
@@ -6,9 +6,9 @@ import classNames from 'classnames';
 
 import ObjectPanelItem from '@core/app/components/beambox/RightPanel/ObjectPanelItem';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -32,7 +32,7 @@ const HighQualityBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | '
 
     const batchCmd = new history.BatchCommand('Toggle high quality');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       writeData(layerName, 'highQuality', newVal, { batchCmd });
     });
     batchCmd.onAfter = initState;

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/InkBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/InkBlock.spec.tsx
@@ -93,6 +93,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import InkBlock from './InkBlock';
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/InkBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/InkBlock.spec.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import { PrintingColors } from '@core/app/constants/color-constants';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 
 jest.mock('./ConfigSlider', () => ({ id, max, min, onChange, value }: any) => (
   <input
@@ -93,8 +92,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import InkBlock from './InkBlock';
@@ -116,7 +117,7 @@ jest.mock('@core/app/stores/globalPreferenceStore', () => ({
 describe('test InkBlock', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
     batchCmd = { count: 0, onAfter: undefined };
     mockUseConfigPanelStore.mockReturnValue({
       change: mockChange,

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/InkBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/InkBlock.tsx
@@ -12,8 +12,8 @@ import ConfigPanelIcons from '@core/app/icons/config-panel/ConfigPanelIcons';
 import ObjectPanelIcons from '@core/app/icons/object-panel/ObjectPanelIcons';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { CUSTOM_PRESET_CONSTANT, writeData } from '@core/helpers/layer/layer-config-helper';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -51,7 +51,7 @@ function InkBlock({ type = 'default' }: { type?: 'default' | 'modal' | 'panel-it
     if (type !== 'modal') {
       const batchCmd = new history.BatchCommand('Change ink');
 
-      useLayerStore.getState().selectedLayers.forEach((layerName) => {
+      layerManager.getSelectedLayers().forEach((layerName) => {
         writeData(layerName, 'ink', value, { batchCmd });
         writeData(layerName, 'configName', CUSTOM_PRESET_CONSTANT, { batchCmd });
       });

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/LaserDevOptions/OneWayEngraving.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/LaserDevOptions/OneWayEngraving.tsx
@@ -4,9 +4,9 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 
 import styles from '../Block.module.scss';
@@ -17,7 +17,7 @@ const OneWayEngraving = () => {
 
   const handleToggle = useCallback(
     (key: 'oneWayEngraving' | 'oneWayEngravingReverse', val: boolean) => {
-      const selectedLayers = useLayerStore.getState().selectedLayers;
+      const selectedLayers = layerManager.getSelectedLayers();
 
       change({ [key]: val });
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ModuleBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ModuleBlock.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockUseConfigPanelStore = jest.fn();
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ModuleBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/ModuleBlock.tsx
@@ -4,7 +4,7 @@ import { pipe } from 'remeda';
 
 import type { LayerModuleType } from '@core/app/constants/layer-module/layer-modules';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import Select from '@core/app/widgets/AntdSelect';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/MultipassBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/MultipassBlock.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { ObjectPanelContext } from '../contexts/ObjectPanelContext';
 
 jest.mock('./ConfigSlider', () => ({ id, max, min, onChange, value }: any) => (
@@ -101,8 +100,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import MultipassBlock from './MultipassBlock';
@@ -123,7 +124,7 @@ jest.mock('@core/app/stores/globalPreferenceStore', () => ({
 describe('test MultipassBlock when type is not panel-item', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
     mockCreateEventEmitter.mockReturnValueOnce({
       emit: mockEmit,
     });

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/MultipassBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/MultipassBlock.spec.tsx
@@ -101,6 +101,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import MultipassBlock from './MultipassBlock';
 
 const mockUseConfigPanelStore = jest.fn();

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/MultipassBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/MultipassBlock.tsx
@@ -6,9 +6,9 @@ import classNames from 'classnames';
 import configOptions from '@core/app/constants/config-options';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import { CUSTOM_PRESET_CONSTANT, writeData } from '@core/helpers/layer/layer-config-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -49,7 +49,7 @@ const MultipassBlock = ({ type = 'default' }: Props): React.JSX.Element => {
     if (type !== 'modal') {
       const batchCmd = new history.BatchCommand('Change multipass');
 
-      useLayerStore.getState().selectedLayers.forEach((layerName) => {
+      layerManager.getSelectedLayers().forEach((layerName) => {
         writeData(layerName, 'multipass', val, { batchCmd });
         writeData(layerName, 'configName', CUSTOM_PRESET_CONSTANT, { batchCmd });
       });

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NozzleBlock/NozzleMode.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NozzleBlock/NozzleMode.tsx
@@ -5,7 +5,7 @@ import { pick } from 'remeda';
 import { useShallow } from 'zustand/react/shallow';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import Select from '@core/app/widgets/AntdSelect';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NumberBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NumberBlock.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { setStorage } from '@mocks/@core/app/stores/storageStore';
 
 const mockGetData = jest.fn();
@@ -55,8 +54,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
 import NumberBlock from './NumberBlock';
@@ -71,7 +72,7 @@ jest.mock('@core/app/stores/configPanel', () => ({
 describe('test NumberBlock', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
     mockCreateEventEmitter.mockReturnValueOnce({
       emit: mockEmit,
     });

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NumberBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NumberBlock.spec.tsx
@@ -55,6 +55,10 @@ const mockInitState = jest.fn();
 
 jest.mock('./initState', () => mockInitState);
 
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+}));
+
 import NumberBlock from './NumberBlock';
 
 const mockUseConfigPanelStore = jest.fn();

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NumberBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/NumberBlock.tsx
@@ -6,10 +6,10 @@ import { Button, Popover } from 'antd-mobile';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { useStorageStore } from '@core/app/stores/storageStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import {
   CUSTOM_PRESET_CONSTANT,
@@ -114,7 +114,7 @@ const NumberBlock = ({
       if (type !== 'modal') {
         const batchCmd = noHistory ? undefined : new history.BatchCommand(`Change ${key}`);
 
-        useLayerStore.getState().selectedLayers.forEach((layerName) => {
+        layerManager.getSelectedLayers().forEach((layerName) => {
           const layer = getLayerByName(layerName)!;
 
           writeDataLayer(layer, key, newVal, { batchCmd });

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/PowerBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/PowerBlock.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 jest.mock('./AdvancedPowerPanel', () => ({ onClose }: any) => (
   <div id="AdvancedPowerPanel">

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/PowerBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/PowerBlock.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
 import ConfigPanelIcons from '@core/app/icons/config-panel/ConfigPanelIcons';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/RefreshIntervalBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/RefreshIntervalBlock.tsx
@@ -4,7 +4,7 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SCurveBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SCurveBlock.tsx
@@ -4,9 +4,9 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 
 import styles from './Block.module.scss';
@@ -23,7 +23,7 @@ const SCurveBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | 'panel
 
     const batchCmd = new history.BatchCommand('Change S-Curve enable');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       writeData(layerName, 'scEnable', newValue, { batchCmd });
     });
     batchCmd.onAfter = initState;
@@ -41,7 +41,7 @@ const SCurveBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | 'panel
 
     const batchCmd = new history.BatchCommand('Change S-Curve toggle');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       writeData(layerName, 'scA0', a0, { batchCmd });
       writeData(layerName, 'scAMax', aMax, { batchCmd });
       writeData(layerName, 'scJerk', jerk, { batchCmd });

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SaveConfigButton.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SaveConfigButton.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 import SaveConfigButton from './SaveConfigButton';
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SaveConfigButton.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SaveConfigButton.tsx
@@ -8,7 +8,7 @@ import alertConstants from '@core/app/constants/alert-constants';
 import { printingModules } from '@core/app/constants/layer-module/layer-modules';
 import ConfigPanelIcons from '@core/app/icons/config-panel/ConfigPanelIcons';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { getConfigKeys, writeData } from '@core/helpers/layer/layer-config-helper';
 import { getAllPresets, savePreset } from '@core/helpers/presets/preset-helper';
 import useI18n from '@core/helpers/useI18n';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.spec.tsx
@@ -10,6 +10,7 @@ const mockForceUpdate = jest.fn();
 
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   getCurrentLayerName: () => '',
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
   resync: () => mockForceUpdate(),
 }));
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.spec.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore from '@mocks/@core/app/stores/layer/layerStore';
-
 import SingleColorBlock from './SingleColorBlock';
 
 const mockForceUpdate = jest.fn();
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   getCurrentLayerName: () => '',
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
   resync: () => mockForceUpdate(),
 }));
 
@@ -68,7 +68,7 @@ jest.mock('@core/app/stores/configPanel', () => ({
 describe('test SingleColorBlock', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useLayerStore.setState({ selectedLayers: ['layer1', 'layer2'] });
+    mockGetSelectedLayers.mockReturnValue(['layer1', 'layer2']);
     mockUseConfigPanelStore.mockReturnValue({
       change: mockChange,
       fullcolor: { hasMultiValue: false, value: true },

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.spec.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import useLayerStore, { mockForceUpdate } from '@mocks/@core/app/stores/layer/layerStore';
+import useLayerStore from '@mocks/@core/app/stores/layer/layerStore';
 
 import SingleColorBlock from './SingleColorBlock';
+
+const mockForceUpdate = jest.fn();
+
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  getCurrentLayerName: () => '',
+  resync: () => mockForceUpdate(),
+}));
 
 const mockBatchCommand = jest.fn();
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.tsx
@@ -47,7 +47,7 @@ const SingleColorBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | '
       update({ color: config });
     }
 
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
     batchCmd.onAfter = initState;
     undoManager.addCommandToHistory(batchCmd);
   };

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SingleColorBlock.tsx
@@ -5,7 +5,6 @@ import { Switch, Tooltip } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -32,7 +31,7 @@ const SingleColorBlock = ({ type = 'default' }: { type?: 'default' | 'modal' | '
 
     const batchCmd = new history.BatchCommand('Toggle full color');
     let colorChanged = false;
-    const selectedLayers = useLayerStore.getState().selectedLayers;
+    const selectedLayers = layerManager.getSelectedLayers();
     const layers = selectedLayers.map((layerName) => getLayerByName(layerName)!);
 
     layers.forEach((layer) => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SpeedBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SpeedBlock.spec.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render } from '@testing-library/react';
 
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
 import { setStorage } from '@mocks/@core/app/stores/storageStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockIsDev = jest.fn();
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SpeedBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/SpeedBlock.tsx
@@ -18,7 +18,7 @@ import { useConfigPanelStore } from '@core/app/stores/configPanel';
 import { useCurveEngravingStore } from '@core/app/stores/curveEngravingStore';
 import { useDocumentStore } from '@core/app/stores/documentStore';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { useStorageStore } from '@core/app/stores/storageStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/TextureBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/TextureBlock.tsx
@@ -7,9 +7,9 @@ import { pick } from 'remeda';
 import { useShallow } from 'zustand/shallow';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 import useI18n from '@core/helpers/useI18n';
 
@@ -34,7 +34,7 @@ const TextureBlock = ({ type = 'default' }: Props): React.JSX.Element => {
 
     const batchCmd = new history.BatchCommand('Toggle texture');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       writeData(layerName, 'texture', newVal, { batchCmd });
     });
     batchCmd.onAfter = initState;
@@ -52,7 +52,7 @@ const TextureBlock = ({ type = 'default' }: Props): React.JSX.Element => {
 
     const batchCmd = new history.BatchCommand('Change texture mode');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       writeData(layerName, 'textureMode', newValue, { batchCmd });
     });
     batchCmd.onAfter = initState;

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/UVConfigs/CuringOptions.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/UVConfigs/CuringOptions.tsx
@@ -4,7 +4,7 @@ import { Switch } from 'antd';
 import classNames from 'classnames';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/WhiteInkCheckbox.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/WhiteInkCheckbox.tsx
@@ -5,8 +5,8 @@ import { Checkbox, Switch } from 'antd';
 
 import ConfigPanelIcons from '@core/app/icons/config-panel/ConfigPanelIcons';
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeData } from '@core/helpers/layer/layer-config-helper';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -48,7 +48,7 @@ const WhiteInkCheckbox = ({ type = 'default' }: Props): ReactNode => {
 
     const batchCmd = new history.BatchCommand('Change white ink toggle');
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => writeData(layerName, 'wInk', newVal, { batchCmd }));
+    layerManager.getSelectedLayers().forEach((layerName) => writeData(layerName, 'wInk', newVal, { batchCmd }));
     batchCmd.onAfter = initState;
     svgCanvas.addCommandToHistory(batchCmd);
   };

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/WhiteInkSettingsModal.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/WhiteInkSettingsModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Modal } from 'antd';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { writeDataLayer } from '@core/helpers/layer/layer-config-helper';
 import { getLayerByName } from '@core/helpers/layer/layer-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -37,7 +37,7 @@ const WhiteInkSettingsModal = ({ onClose }: Props): React.JSX.Element => {
   const handleSave = () => {
     const newState = { ...state };
 
-    useLayerStore.getState().selectedLayers.forEach((layerName) => {
+    layerManager.getSelectedLayers().forEach((layerName) => {
       const layer = getLayerByName(layerName)!;
 
       if (wInk.value !== ink.value || wInk.hasMultiValue !== ink.hasMultiValue) {

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/initState.spec.ts
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/initState.spec.ts
@@ -17,12 +17,13 @@ jest.mock('@core/helpers/layer/layer-config-helper', () => ({
 
 const mockGetCurrentLayerName = jest.fn();
 
+const mockGetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   getCurrentLayerName: (...args) => mockGetCurrentLayerName(...args),
-  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
+  getSelectedLayers: () => mockGetSelectedLayers(),
 }));
 
-import useLayerStore from '@mocks/@core/app/stores/layer/layerStore';
 import initState from './initState';
 
 describe('test initState', () => {
@@ -51,7 +52,7 @@ describe('test initState', () => {
   });
 
   test('initState without arg', () => {
-    useLayerStore.setState({ selectedLayers: ['layer3', 'layer4'] });
+    mockGetSelectedLayers.mockReturnValue(['layer3', 'layer4']);
     mockGetCurrentLayerName.mockReturnValue('layer3');
     mockGetLayersConfig.mockReturnValue('mock-layers-config');
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/initState.spec.ts
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/initState.spec.ts
@@ -19,6 +19,7 @@ const mockGetCurrentLayerName = jest.fn();
 
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   getCurrentLayerName: (...args) => mockGetCurrentLayerName(...args),
+  getSelectedLayers: () => require('@core/app/stores/layer/layerStore').default.getState().selectedLayers,
 }));
 
 import useLayerStore from '@mocks/@core/app/stores/layer/layerStore';

--- a/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/initState.ts
+++ b/packages/core/src/web/app/components/beambox/RightPanel/ConfigPanel/initState.ts
@@ -1,11 +1,10 @@
 import { pipe } from 'remeda';
 
 import { useConfigPanelStore } from '@core/app/stores/configPanel';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import { getLayerConfig, getLayersConfig } from '@core/helpers/layer/layer-config-helper';
 
-export const initState = (layers: string[] = useLayerStore.getState().selectedLayers) => {
+export const initState = (layers: string[] = layerManager.getSelectedLayers()) => {
   if (layers.length === 0) layers = [layerManager.getCurrentLayerName()!];
 
   const { update } = useConfigPanelStore.getState();

--- a/packages/core/src/web/app/components/beambox/RightPanel/DragImage.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/DragImage.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 
 import LayerPanelIcons from '@core/app/icons/layer-panel/LayerPanelIcons';
-import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import ColorPicker from '@core/app/widgets/ColorPicker';
 import { getData } from '@core/helpers/layer/layer-config-helper';
@@ -31,7 +30,7 @@ function DragImage({ draggingLayer = null }: Props): React.JSX.Element {
   const isVisible = layerObject.isVisible();
   const backLayers = [];
   // No need to rerender DragImage when selectedLayers change, so not using useLayerStore hook here
-  const layerCount = useLayerStore.getState().selectedLayers.length;
+  const layerCount = layerManager.getSelectedLayers().length;
 
   for (let i = layerCount - 1; i >= 1; i -= 1) {
     backLayers.push(<div className={styles.back} key={i} style={{ left: 10 * i, top: -10 * i }} />);

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel.tsx
@@ -7,7 +7,6 @@ import Alert from '@core/app/actions/alert-caller';
 import Dialog from '@core/app/actions/dialog-caller';
 import layoutConstants from '@core/app/constants/layout-constants';
 import LayerPanelIcons from '@core/app/icons/layer-panel/LayerPanelIcons';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { isMobile } from '@core/app/stores/screenStore';
 import HistoryCommandFactory from '@core/app/svgedit/history/HistoryCommandFactory';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -120,14 +119,14 @@ class LayerPanel extends React.PureComponent<Props, State> {
   };
 
   unLockLayers = (layerName: string): void => {
-    const { selectedLayers, setSelectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
 
     if (selectedLayers.includes(layerName)) {
       setLayersLock(selectedLayers, false);
       this.forceUpdate();
     } else {
       setLayersLock([layerName], false);
-      setSelectedLayers([layerName]);
+      layerManager.setSelectedLayers([layerName]);
     }
   };
 
@@ -154,30 +153,29 @@ class LayerPanel extends React.PureComponent<Props, State> {
 
         svgCanvas.renameCurrentLayer(newName);
         cloneLayerConfig(oldName, newName);
-        useLayerStore.getState().setSelectedLayers([newName]);
+        layerManager.setSelectedLayers([newName]);
       },
     });
   };
 
   selectOnlyLayer = (layerName: string): void => {
     selectionManager.clearSelection();
-    useLayerStore.getState().setSelectedLayers([layerName]);
+    layerManager.setSelectedLayers([layerName]);
   };
 
   toggleLayerSelected = (layerName: string): void => {
-    const { selectedLayers, setSelectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
     const newSelectedLayers = [...selectedLayers];
     const index = newSelectedLayers.findIndex((name: string) => name === layerName);
 
     if (index >= 0) {
       if (newSelectedLayers.length > 1) {
         newSelectedLayers.splice(index, 1);
-        setSelectedLayers(newSelectedLayers);
+        layerManager.setSelectedLayers(newSelectedLayers);
       }
     } else {
       newSelectedLayers.push(layerName);
-      layerManager.setCurrentLayer(layerName);
-      setSelectedLayers(newSelectedLayers, layerName);
+      layerManager.setSelectedLayers(newSelectedLayers, layerName);
     }
   };
 
@@ -205,7 +203,7 @@ class LayerPanel extends React.PureComponent<Props, State> {
       return;
     }
 
-    const { selectedLayers, setSelectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
     const newSelectedLayers = [...selectedLayers];
     const isLayerSelected = newSelectedLayers.includes(layerName);
 
@@ -223,11 +221,11 @@ class LayerPanel extends React.PureComponent<Props, State> {
       newSelectedLayers.push(layerName);
     }
 
-    setSelectedLayers(newSelectedLayers, layerName);
+    layerManager.setSelectedLayers(newSelectedLayers, layerName);
   };
 
   setLayerColor = (layerName: string, newColor: string): void => {
-    const { forceUpdate, selectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
     const targets = selectedLayers.includes(layerName) ? selectedLayers : [layerName];
     const cmd = changeLayersColor(targets, newColor);
 
@@ -235,7 +233,7 @@ class LayerPanel extends React.PureComponent<Props, State> {
       svgCanvas.addCommandToHistory(cmd);
     }
 
-    forceUpdate();
+    layerManager.resync();
   };
 
   setLayerVisibility = (layerName: string): void => {
@@ -244,7 +242,7 @@ class LayerPanel extends React.PureComponent<Props, State> {
     if (!layerObject) return;
 
     const isVis = layerObject.isVisible();
-    const { selectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
     const batchCmd = HistoryCommandFactory.createBatchCommand('Set Layers Visibility');
 
     if (selectedLayers.includes(layerName)) {
@@ -267,10 +265,10 @@ class LayerPanel extends React.PureComponent<Props, State> {
 
     e?.dataTransfer?.setDragImage(dragImage, 0, 0);
 
-    const { selectedLayers, setSelectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
 
     if (!selectedLayers.includes(layerName)) {
-      setSelectedLayers([layerName]);
+      layerManager.setSelectedLayers([layerName]);
     }
 
     this.setState({
@@ -280,7 +278,7 @@ class LayerPanel extends React.PureComponent<Props, State> {
   };
 
   onLayerCenterDragEnter = (layerName?: string): void => {
-    const { selectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
 
     if (layerName && selectedLayers.includes(layerName)) {
       this.setState({ draggingDestIndex: undefined });
@@ -297,7 +295,7 @@ class LayerPanel extends React.PureComponent<Props, State> {
 
   onLayerDragEnd = (): void => {
     const { draggingDestIndex } = this.state;
-    const { selectedLayers } = useLayerStore.getState();
+    const selectedLayers = layerManager.getSelectedLayers();
 
     if (draggingDestIndex !== null && draggingDestIndex !== undefined) {
       moveLayersToPosition(selectedLayers, draggingDestIndex);
@@ -427,7 +425,7 @@ class LayerPanel extends React.PureComponent<Props, State> {
         this.selectOnlyLayer(layerName);
       }
     } else if (e.button === 2) {
-      const { selectedLayers } = useLayerStore.getState();
+      const selectedLayers = layerManager.getSelectedLayers();
 
       if (!selectedLayers.includes(layerName)) {
         this.selectOnlyLayer(layerName);

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.spec.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
-import { mockForceUpdate, mockSetSelectedLayers } from '@mocks/@core/app/stores/layer/layerStore';
 import { useScreenStore } from '@core/app/stores/screenStore';
 import i18n from '@core/helpers/i18n';
 import useLayerStore from '@core/app/stores/layer/layerStore';
@@ -63,11 +62,16 @@ jest.mock(
       mockToggleFullColorLayer(...args),
 );
 
+const mockForceUpdate = jest.fn();
+const mockSetSelectedLayers = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   getAllLayerNames: () => mockGetAllLayerNames(),
   getCurrentLayerName: (...args) => mockGetCurrentLayerName(...args),
   getLayerElementByName: (...args) => mockGetLayerElementByName(...args),
   getLayerName: (...args) => mockGetLayerName(...args),
+  resync: () => mockForceUpdate(),
+  setSelectedLayers: (...args) => mockSetSelectedLayers(...args),
 }));
 
 jest.mock('@core/helpers/system-helper', () => ({
@@ -347,7 +351,7 @@ describe('test LayerContextMenu', () => {
     mockGetLayerName.mockReturnValue('layer1');
     mockGetLayerElementByName.mockReturnValue(mockElem);
     mockGetData.mockReturnValueOnce(LayerModule.PRINTER).mockReturnValueOnce(false);
-    useLayerStore.getState().setSelectedLayers(['layer1']);
+    useLayerStore.setState({ selectedLayers: ['layer1'] });
 
     const { baseElement } = renderDesktop();
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.spec.tsx
@@ -5,7 +5,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
 import { useScreenStore } from '@core/app/stores/screenStore';
 import i18n from '@core/helpers/i18n';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockClearSelection = jest.fn();
 
@@ -262,7 +262,7 @@ describe('test LayerContextMenu', () => {
     expect(mockTogglePresprayArea).not.toHaveBeenCalled();
     fireEvent.click(screen.getByText(t.del));
     expect(mockDeleteLayers).toHaveBeenCalledWith(['layer1', 'layer2']);
-    expect(mockSetSelectedLayers).toHaveBeenCalledWith([]);
+    expect(mockSetSelectedLayers).not.toHaveBeenCalled();
     expect(mockTogglePresprayArea).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.tsx
@@ -5,8 +5,6 @@ import { Button, Switch } from 'antd';
 import type { MenuProps } from 'antd';
 import { Popover } from 'antd-mobile';
 import classNames from 'classnames';
-import { pick } from 'remeda';
-import { useShallow } from 'zustand/shallow';
 
 import alertCaller from '@core/app/actions/alert-caller';
 import { modelsWithModules } from '@core/app/actions/beambox/constant';
@@ -49,9 +47,7 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
   const LANG = lang.beambox.right_panel.layer_panel;
   const LANG2 = lang.alert;
   const workarea = useWorkarea();
-  const { forceUpdate, selectedLayers, setSelectedLayers } = useLayerStore(
-    useShallow(pick(['forceUpdate', 'selectedLayers', 'setSelectedLayers'])),
-  );
+  const selectedLayers = useLayerStore((state) => state.selectedLayers);
   const isMobile = useIsMobile();
   const { activeKey, updateActiveKey } = use(ObjectPanelContext);
   const [color, setColor] = useState(colorConstants.printingLayerColor[0]);
@@ -75,19 +71,19 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
   const handleCloneLayers = () => {
     const newLayers = cloneLayers(selectedLayers);
 
-    setSelectedLayers(newLayers);
+    layerManager.setSelectedLayers(newLayers);
   };
 
   const handleDeleteLayers = () => {
     deleteLayers(selectedLayers);
-    setSelectedLayers([]);
+    layerManager.setSelectedLayers([]);
     presprayArea.togglePresprayArea();
   };
 
   const toggleLayerLocked = () => {
     selectionManager.clearSelection();
     setLayersLock(selectedLayers, !isLocked);
-    forceUpdate();
+    layerManager.resync();
   };
 
   const handleMergeDown = async () => {
@@ -131,7 +127,7 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
     const elem = layerManager.getLayerElementByName(baseLayer!);
 
     updateLayerColor(elem as SVGGElement);
-    setSelectedLayers([baseLayer]);
+    layerManager.setSelectedLayers([baseLayer]);
   };
 
   const isSelectingPrinterLayer =
@@ -166,7 +162,7 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
     const layer = selectedLayers[0];
 
     await splitFullColorLayer(layer);
-    setSelectedLayers([]);
+    layerManager.setSelectedLayers([]);
   };
 
   const handleLayerFullColor = (newColor?: string) => {
@@ -189,7 +185,7 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
       undoManager.addCommandToHistory(cmd);
     }
 
-    forceUpdate();
+    layerManager.resync();
   };
 
   const isMultiSelecting = selectedLayers.length > 1;

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.tsx
@@ -15,7 +15,7 @@ import type { PrintingColors } from '@core/app/constants/color-constants';
 import { printingModules } from '@core/app/constants/layer-module/layer-modules';
 import LayerPanelIcons from '@core/app/icons/layer-panel/LayerPanelIcons';
 import ObjectPanelIcons from '@core/app/icons/object-panel/ObjectPanelIcons';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -76,7 +76,6 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
 
   const handleDeleteLayers = () => {
     deleteLayers(selectedLayers);
-    layerManager.setSelectedLayers([]);
     presprayArea.togglePresprayArea();
   };
 

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import { useScreenStore } from '@core/app/stores/screenStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 
 const mockGetSupportedModules = jest.fn();
 
@@ -44,10 +44,10 @@ jest.mock('@core/helpers/layer/layer-helper', () => ({
   setLayerLock: jest.fn(),
 }));
 
-const mockDeleteLayerByName = jest.fn();
+const mockDeleteLayers = jest.fn();
 
 jest.mock('@core/helpers/layer/deleteLayer', () => ({
-  deleteLayerByName: (...args) => mockDeleteLayerByName(...args),
+  deleteLayers: (...args) => mockDeleteLayers(...args),
 }));
 
 jest.mock(

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
@@ -15,7 +15,7 @@ import layerManager from '@core/app/svgedit/layer/layerManager';
 import ColorPicker from '@core/app/widgets/ColorPicker';
 import { useSupportedModules } from '@core/helpers/hooks/useSupportedModules';
 import useWorkarea from '@core/helpers/hooks/useWorkarea';
-import { deleteLayerByName } from '@core/helpers/layer/deleteLayer';
+import { deleteLayers } from '@core/helpers/layer/deleteLayer';
 import { getData } from '@core/helpers/layer/layer-config-helper';
 import { setLayerLock } from '@core/helpers/layer/layer-helper';
 
@@ -235,10 +235,7 @@ const LayerList = ({
               {
                 color: 'danger',
                 key: 'delete',
-                onClick: () => {
-                  deleteLayerByName(layerName);
-                  layerManager.setSelectedLayers([]);
-                },
+                onClick: () => deleteLayers([layerName]),
                 text: <ObjectPanelIcons.Trash />,
               },
             ]

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
@@ -3,9 +3,7 @@ import React, { useEffect, useRef } from 'react';
 import { SwipeAction } from 'antd-mobile';
 import type { Action, SwipeActionRef } from 'antd-mobile/es/components/swipe-action';
 import classNames from 'classnames';
-import { pick } from 'remeda';
 import { match } from 'ts-pattern';
-import { useShallow } from 'zustand/shallow';
 
 import type { LayerModuleType } from '@core/app/constants/layer-module/layer-modules';
 import { LayerModule, printingModules } from '@core/app/constants/layer-module/layer-modules';
@@ -58,9 +56,7 @@ const LayerList = ({
   setLayerVisibility,
   unLockLayers,
 }: Props): React.JSX.Element => {
-  const { forceUpdate, selectedLayers, setSelectedLayers } = useLayerStore(
-    useShallow(pick(['forceUpdate', 'selectedLayers', 'setSelectedLayers'])),
-  );
+  const selectedLayers = useLayerStore((state) => state.selectedLayers);
 
   const items: React.ReactNode[] = [];
   const currentLayerName = layerManager.getCurrentLayerName();
@@ -74,12 +70,6 @@ const LayerList = ({
       ref.current.close();
     }
   }, [ref, draggingDestIndex, selectedLayers]);
-
-  const isAnyLayerMissing = layerManager.getAllLayers().some((layer) => !layer.getGroup().parentNode);
-
-  if (isAnyLayerMissing) {
-    layerManager.identifyLayers();
-  }
 
   const allLayerNames = layerManager.getAllLayerNames();
 
@@ -234,7 +224,7 @@ const LayerList = ({
                 onClick: () => {
                   setLayerLock(layerName, !isLocked);
                   // let SwipeAction close before force update
-                  setTimeout(forceUpdate);
+                  setTimeout(layerManager.resync);
                 },
                 text: isLocked ? <LayerPanelIcons.Unlock /> : <LayerPanelIcons.Lock />,
               },
@@ -247,7 +237,7 @@ const LayerList = ({
                 key: 'delete',
                 onClick: () => {
                   deleteLayerByName(layerName);
-                  setSelectedLayers([]);
+                  layerManager.setSelectedLayers([]);
                 },
                 text: <ObjectPanelIcons.Trash />,
               },
@@ -258,7 +248,7 @@ const LayerList = ({
           <SwipeAction
             key={layerName}
             leftActions={leftActions}
-            onActionsReveal={() => setSelectedLayers([layerName])}
+            onActionsReveal={() => layerManager.setSelectedLayers([layerName])}
             ref={isSelected && layerName === selectedLayers[0] ? ref : undefined}
             rightActions={rightActions}
           >

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
@@ -9,7 +9,7 @@ import type { LayerModuleType } from '@core/app/constants/layer-module/layer-mod
 import { LayerModule, printingModules } from '@core/app/constants/layer-module/layer-modules';
 import LayerPanelIcons from '@core/app/icons/layer-panel/LayerPanelIcons';
 import ObjectPanelIcons from '@core/app/icons/object-panel/ObjectPanelIcons';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import ColorPicker from '@core/app/widgets/ColorPicker';

--- a/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/ImageOptions/GradientBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/ImageOptions/GradientBlock.tsx
@@ -3,8 +3,8 @@ import React, { memo, useCallback } from 'react';
 import { Switch } from 'antd';
 
 import ObjectPanelItem from '@core/app/components/beambox/RightPanel/ObjectPanelItem';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import useI18n from '@core/helpers/useI18n';
 
 import styles from './ImageOptions.module.scss';
@@ -29,7 +29,7 @@ const GradientBlock = ({ changeAttribute, generateImageData, isGradient }: Props
         'data-threshold': threshold,
         'xlink:href': pngBase64,
       });
-      useLayerStore.getState().checkGradient();
+      layerManager.checkGradient();
     },
     [changeAttribute, generateImageData],
   );

--- a/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/InFillBlock.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/InFillBlock.spec.tsx
@@ -22,6 +22,12 @@ jest.mock('@core/helpers/svg-editor-helper', () => ({
   },
 }));
 
+const mockCheckVector = jest.fn();
+
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  checkVector: () => mockCheckVector(),
+}));
+
 import InFillBlock from './InFillBlock';
 
 describe('should render correctly', () => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/InFillBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/InFillBlock.tsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 
 import { iconButtonTheme } from '@core/app/constants/antd-config';
 import OptionPanelIcons from '@core/app/icons/option-panel/OptionPanelIcons';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import useDidUpdateEffect from '@core/helpers/hooks/useDidUpdateEffect';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import useI18n from '@core/helpers/useI18n';
@@ -76,7 +76,7 @@ const InFillBlock = ({ elems, id = 'infill', label }: Props): React.ReactNode =>
       isAllFilled: !isAnyFilled,
       isAnyFilled: !isAnyFilled,
     }));
-    useLayerStore.getState().checkVector();
+    layerManager.checkVector();
   };
 
   const isPartiallyFilled = elems[0].tagName === 'g' && isAnyFilled && !isAllFilled;

--- a/packages/core/src/web/app/components/beambox/RightPanel/SelLayerBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/SelLayerBlock.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import React, { memo, useEffect, useState } from 'react';
 
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { useSelectedElementStore } from '@core/app/stores/selectedElementStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import Select from '@core/app/widgets/AntdSelect';

--- a/packages/core/src/web/app/components/beambox/RightPanel/SelLayerBlock.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/SelLayerBlock.tsx
@@ -17,7 +17,7 @@ function SelLayerBlock(): ReactNode {
   const [promptMoveLayerOnce, setPromptMoveLayerOnce] = useState(false);
   const [displayValue, setDisplayValue] = useState(defaultOption);
   const selectedElement = useSelectedElementStore((state) => state.selectedElement);
-  const selectedLayers = useLayerStore.getState().selectedLayers;
+  const selectedLayers = useLayerStore((state) => state.selectedLayers);
   // TODO: should put allLayerNames in a store to register change listener
   const layerNames = layerManager.getAllLayerNames();
 

--- a/packages/core/src/web/app/components/beambox/SvgEditor/Workarea.tsx
+++ b/packages/core/src/web/app/components/beambox/SvgEditor/Workarea.tsx
@@ -4,7 +4,7 @@ import type { MenuProps } from 'antd';
 import { useShallow } from 'zustand/shallow';
 
 import svgEditor from '@core/app/actions/beambox/svg-editor';
-import useLayerStore from '@core/app/stores/layer/layerStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import { useSelectedElementStore } from '@core/app/stores/selectedElementStore';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import { cloneSelectedElements, pasteElements } from '@core/app/svgedit/operations/clipboard';

--- a/packages/core/src/web/app/components/boxgen/ExportButton.spec.tsx
+++ b/packages/core/src/web/app/components/boxgen/ExportButton.spec.tsx
@@ -40,9 +40,12 @@ jest.mock(
 const mockGetAllLayers = jest.fn();
 const mockGetLayerByName = jest.fn();
 
+const mockResync = jest.fn();
+
 jest.mock('@core/app/svgedit/layer/layerManager', () => ({
   getAllLayers: (...args: unknown[]) => mockGetAllLayers(...args),
   getLayerByName: (...args: unknown[]) => mockGetLayerByName(...args),
+  resync: () => mockResync(),
 }));
 
 const mockDisassembleUse = jest.fn();
@@ -65,14 +68,6 @@ const mockCreateBatchCommand = jest.fn().mockImplementation(() => mockBatchComma
 
 jest.mock('@core/app/svgedit/history/HistoryCommandFactory', () => ({
   createBatchCommand: (...args: unknown[]) => mockCreateBatchCommand(...args),
-}));
-
-const mockForceUpdateLayerStore = jest.fn();
-
-jest.mock('@core/app/stores/layer/layerStore', () => ({
-  getState: () => ({
-    forceUpdate: () => mockForceUpdateLayerStore(),
-  }),
 }));
 
 const mockGetObjectLayer = jest.fn();

--- a/packages/core/src/web/app/components/boxgen/ExportButton.tsx
+++ b/packages/core/src/web/app/components/boxgen/ExportButton.tsx
@@ -5,7 +5,6 @@ import { DownloadOutlined } from '@ant-design/icons';
 import { Button, Form, InputNumber, Modal, Pagination, Switch } from 'antd';
 
 import { useBoxgenStore } from '@core/app/stores/boxgenStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import HistoryCommandFactory from '@core/app/svgedit/history/HistoryCommandFactory';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -108,7 +107,7 @@ const ExportDialog = ({ onClose, setVisible, visible }: ExportDialogProps): Reac
 
       layerObject?.setVisible(false, { addToHistory: false });
     });
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
     undoManager.addCommandToHistory(batchCmd);
     setConfirmLoading(false);
     setVisible(false);

--- a/packages/core/src/web/app/components/dialogs/KeyChainGenerator/exportToCanvas.ts
+++ b/packages/core/src/web/app/components/dialogs/KeyChainGenerator/exportToCanvas.ts
@@ -3,9 +3,9 @@ import { PaperOffset } from 'paperjs-offset';
 
 import fontFuncs, { convertTextToPathByFontkit, getFontObj } from '@core/app/actions/beambox/font-funcs';
 import NS from '@core/app/constants/namespaces';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import { moveElements } from '@core/app/svgedit/operations/move';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import i18n from '@core/helpers/i18n';
@@ -187,7 +187,7 @@ const exportBaseLayer = async (shape: KeyChainShape, batchCmd: IBatchCommand, si
   const { layers: tLayers } = i18n.lang.keychain_generator;
   const { name } = createLayer(tLayers.keychain, { hexCode: KEYCHAIN_COLORS.exploded.base, parentCmd: batchCmd });
 
-  useLayerStore.getState().setSelectedLayers([name]);
+  layerManager.setSelectedLayers([name]);
 
   const paths = [pathItemToSvgPath(shape.resultBasePath)];
 
@@ -251,7 +251,7 @@ const exportEngravingLayer = async (
     parentCmd: batchCmd,
   });
 
-  useLayerStore.getState().setSelectedLayers([name]);
+  layerManager.setSelectedLayers([name]);
 
   const paths = await convertSvgElementsToPath(shape.decorations.engraving, shape.decorations.refPaths);
 
@@ -283,7 +283,7 @@ const exportEmbossLayers = async (shape: KeyChainShape, batchCmd: IBatchCommand,
     parentCmd: batchCmd,
   });
 
-  useLayerStore.getState().setSelectedLayers([posName]);
+  layerManager.setSelectedLayers([posName]);
 
   const insetSource = combinedInnerPath.clone() as paper.Path;
 
@@ -302,7 +302,7 @@ const exportEmbossLayers = async (shape: KeyChainShape, batchCmd: IBatchCommand,
     parentCmd: batchCmd,
   });
 
-  useLayerStore.getState().setSelectedLayers([aloneName]);
+  layerManager.setSelectedLayers([aloneName]);
 
   const shiftedBounds = new paper.Rectangle(
     shape.bounds.x,

--- a/packages/core/src/web/app/components/dialogs/MaterialTestGeneratorPanel/index.tsx
+++ b/packages/core/src/web/app/components/dialogs/MaterialTestGeneratorPanel/index.tsx
@@ -6,7 +6,6 @@ import constant, { promarkModels } from '@core/app/actions/beambox/constant';
 import svgEditor from '@core/app/actions/beambox/svg-editor';
 import { LaserType } from '@core/app/constants/promark-constants';
 import { useDocumentStore } from '@core/app/stores/documentStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { useStorageStore } from '@core/app/stores/storageStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
@@ -261,7 +260,7 @@ const MaterialTestGeneratorPanel = ({ onClose }: Props): React.JSX.Element => {
     undoManager.addCommandToHistory(batchCmd.current);
 
     svgEditor.updateContextPanel();
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
 
     onClose();
   };

--- a/packages/core/src/web/app/components/dialogs/PrintAndCut/utils/generateCutLayer.ts
+++ b/packages/core/src/web/app/components/dialogs/PrintAndCut/utils/generateCutLayer.ts
@@ -1,5 +1,4 @@
 import { LayerModule } from '@core/app/constants/layer-module/layer-modules';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -192,8 +191,7 @@ export const generateAlignedCutLayer = (): void => {
     layer.setVisible(false, { parentCmd: batchCmd });
   });
 
-  layerManager.identifyLayers();
-  useLayerStore.getState().forceUpdate();
+  layerManager.resync();
   selectionManager.clearSelection();
 
   if (!batchCmd.isEmpty()) undoManager.addCommandToHistory(batchCmd);

--- a/packages/core/src/web/app/components/dialogs/PrintAndCut/utils/generateCutLayer.ts
+++ b/packages/core/src/web/app/components/dialogs/PrintAndCut/utils/generateCutLayer.ts
@@ -107,10 +107,6 @@ export const generateAlignedCutLayer = (): void => {
     deleteLayerByName(getLayerName(layer), { parentCmd: batchCmd });
   });
 
-  // removeGroup only detaches the dom node, so layerManager still maps the old
-  // name; without this resync createLayer sees it as taken and appends " (1)"
-  if (previousCutLayers.length > 0) layerManager.identifyLayers();
-
   const originalLayers = layerManager.getAllLayers();
   const insertedElements: SVGGraphicsElement[] = [];
   // layer-mode cut geometry serialized into the saved config, so a resumed run

--- a/packages/core/src/web/app/components/dialogs/PuzzleGenerator/geometry/svgExport.ts
+++ b/packages/core/src/web/app/components/dialogs/PuzzleGenerator/geometry/svgExport.ts
@@ -1,7 +1,6 @@
 import { dpmm } from '@core/app/actions/beambox/constant';
 import svgEditor from '@core/app/actions/beambox/svg-editor';
 import presprayArea from '@core/app/actions/canvas/prespray-area';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -441,7 +440,7 @@ export const exportToCanvas = async (
 
   // Refresh layer panel to show new layers
   svgEditor.updateContextPanel();
-  useLayerStore.getState().forceUpdate();
+  layerManager.resync();
 
   if (!batchCmd.isEmpty()) undoManager.addCommandToHistory(batchCmd);
 };

--- a/packages/core/src/web/app/components/pass-through/sliceWorkarea.ts
+++ b/packages/core/src/web/app/components/pass-through/sliceWorkarea.ts
@@ -254,12 +254,8 @@ const sliceWorkarea = async (
   generateGuideMark();
   changeDocumentStoreValue('pass-through', false, { parentCmd: batchCmd });
 
-  const onAfter = () => {
-    layerManager.identifyLayers();
-    layerManager.setSelectedLayers([]);
-  };
-
-  onAfter();
+  layerManager.identifyLayers();
+  layerManager.setSelectedLayers([]);
 
   if (parentCmd) {
     parentCmd.addSubCommand(batchCmd);
@@ -267,7 +263,6 @@ const sliceWorkarea = async (
     svgCanvas.undoMgr.addCommandToHistory(batchCmd);
   }
 
-  batchCmd.onAfter = onAfter;
   progressCaller.popById(progressId);
 };
 

--- a/packages/core/src/web/app/components/pass-through/sliceWorkarea.ts
+++ b/packages/core/src/web/app/components/pass-through/sliceWorkarea.ts
@@ -4,7 +4,6 @@ import type { AddOnInfo } from '@core/app/constants/addOn';
 import NS from '@core/app/constants/namespaces';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
 import { changeDocumentStoreValue, useDocumentStore } from '@core/app/stores/documentStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import { handlePastedRef } from '@core/app/svgedit/operations/clipboard';
@@ -257,7 +256,7 @@ const sliceWorkarea = async (
 
   const onAfter = () => {
     layerManager.identifyLayers();
-    useLayerStore.getState().setSelectedLayers([]);
+    layerManager.setSelectedLayers([]);
   };
 
   onAfter();

--- a/packages/core/src/web/app/stores/layer/layerStore.ts
+++ b/packages/core/src/web/app/stores/layer/layerStore.ts
@@ -29,5 +29,3 @@ export const useLayerStore = create(
     selectedLayers: [],
   })),
 );
-
-export default useLayerStore;

--- a/packages/core/src/web/app/stores/layer/layerStore.ts
+++ b/packages/core/src/web/app/stores/layer/layerStore.ts
@@ -1,91 +1,33 @@
-import { pipe } from 'remeda';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
-import { promarkModels } from '@core/app/actions/beambox/constant';
-import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
-import layerManager from '@core/app/svgedit/layer/layerManager';
-import doLayersContainsVector from '@core/helpers/layer/check-vector';
-
-import { useDocumentStore } from '../documentStore';
+import type { Layer } from '@core/app/svgedit/layer/layer';
 
 export interface LayerStoreState {
+  /** Name of the layer receiving new elements; mirrors the DOM */
+  currentLayerName: null | string;
   hasGradient: boolean;
   hasVector: boolean;
+  /** All layers, bottom to top */
+  layers: Layer[];
   selectedLayers: string[];
 }
 
-export interface LayerStoreActions {
-  checkGradient: (workarea?: WorkAreaModel) => void;
-  checkVector: () => void;
-  forceUpdate: () => void;
-  setSelectedLayers: (selectedLayers: string[], currentLayer?: string) => void;
-}
-
+/**
+ * Passive state container for layer data.
+ *
+ * All writes go through layerManager (@core/app/svgedit/layer/layerManager) — never call
+ * useLayerStore.setState from anywhere else. React components subscribe with selectors;
+ * imperative reads via useLayerStore.getState() are fine.
+ */
 export const useLayerStore = create(
-  subscribeWithSelector<LayerStoreActions & LayerStoreState>((set, get) => ({
-    checkGradient: (workarea: WorkAreaModel = useDocumentStore.getState().workarea) => {
-      const { selectedLayers } = get();
-      const isPromark = promarkModels.has(workarea);
-
-      if (isPromark) {
-        const newVal = selectedLayers.some((layerName: string) =>
-          pipe(
-            layerName,
-            layerManager.getLayerElementByName,
-            (layer) => layer?.querySelector('image[data-shading="true"]'),
-            Boolean,
-          ),
-        );
-
-        set({ hasGradient: newVal });
-      }
-    },
-    // Computed state checks, expensive, should be called only when necessary
-    checkVector: () => {
-      const { selectedLayers } = get();
-      const newVal = doLayersContainsVector(selectedLayers);
-
-      set({ hasVector: newVal });
-    },
-    forceUpdate: () => {
-      set((state) => ({ selectedLayers: [...state.selectedLayers] }));
-      get().checkVector();
-      get().checkGradient(useDocumentStore.getState().workarea);
-    },
+  subscribeWithSelector<LayerStoreState>(() => ({
+    currentLayerName: null,
     hasGradient: false,
     hasVector: false,
+    layers: [],
     selectedLayers: [],
-
-    setSelectedLayers: (newLayers: string[], currentLayer?: string) => {
-      const { selectedLayers } = get();
-      const oldCurrentLayer = layerManager.getCurrentLayerName();
-
-      if (newLayers.length === 0) newLayers = [layerManager.getCurrentLayerName()];
-
-      const newCurrentLayer = currentLayer || newLayers[0];
-
-      if (newCurrentLayer && newCurrentLayer !== oldCurrentLayer) {
-        layerManager.setCurrentLayer(newCurrentLayer);
-      }
-
-      // Lazy update - only update if actually different
-      if (newLayers.length === selectedLayers.length && newLayers.every((name, i) => name === selectedLayers[i])) {
-        return;
-      }
-
-      set({ selectedLayers: newLayers });
-
-      // Auto-check states when selected layers change
-      get().checkVector();
-      get().checkGradient();
-    },
   })),
-);
-
-useDocumentStore.subscribe(
-  (state) => state.workarea,
-  (workarea) => useLayerStore.getState().checkGradient(workarea),
 );
 
 export default useLayerStore;

--- a/packages/core/src/web/app/svgedit/history/utils/index.ts
+++ b/packages/core/src/web/app/svgedit/history/utils/index.ts
@@ -1,5 +1,5 @@
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import currentFileManager from '@core/app/svgedit/currentFileManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import shortcuts, { isFocusingOnInputs } from '@core/helpers/shortcuts';
 
 import undoManager from '../undoManager';
@@ -26,7 +26,7 @@ export const undo = ({ checkFocus = true, checkShortCutsScope = true }: Options 
   const res = undoManager.undo();
 
   if (res) {
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
     currentFileManager.setHasUnsavedChanges(true);
   }
 };
@@ -48,7 +48,7 @@ export const redo = ({ checkFocus = true, checkShortCutsScope = true }: Options 
   const res = undoManager.redo();
 
   if (res) {
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
     currentFileManager.setHasUnsavedChanges(true);
   }
 };

--- a/packages/core/src/web/app/svgedit/interaction/mouse/index.ts
+++ b/packages/core/src/web/app/svgedit/interaction/mouse/index.ts
@@ -16,7 +16,6 @@ import { MouseButtons } from '@core/app/constants/mouse-constants';
 import TutorialConstants from '@core/app/constants/tutorial-constants';
 import { getMouseMode, setCursor, setMouseMode } from '@core/app/stores/canvas/utils/mouseMode';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import { setupPreviewMode } from '@core/helpers/device/camera/previewMode';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
@@ -296,8 +295,7 @@ const mouseDown = async (evt: MouseEvent) => {
             const currentLayer = layerManager.getCurrentLayerElement();
 
             if (targetLayer && !selectedElements.includes(targetLayer.elem) && targetLayer.elem !== currentLayer) {
-              layerManager.setCurrentLayer(targetLayer.title);
-              useLayerStore.getState().setSelectedLayers([targetLayer.title]);
+              layerManager.setSelectedLayers([targetLayer.title]);
             }
           }
         }
@@ -1111,7 +1109,7 @@ const mouseUp = async (evt: MouseEvent, blocked = false) => {
           selectionManager.tempGroupSelectedElements();
           svgEditor.updateContextPanel();
         } else if (tempLayer) {
-          useLayerStore.getState().setSelectedLayers([tempLayer]);
+          layerManager.setSelectedLayers([tempLayer]);
         }
       }
 
@@ -1122,8 +1120,7 @@ const mouseUp = async (evt: MouseEvent, blocked = false) => {
         const currentLayer = layerManager.getCurrentLayerElement();
 
         if (targetLayer && !selectedElements.includes(targetLayer.elem) && targetLayer.elem !== currentLayer) {
-          layerManager.setCurrentLayer(targetLayer.title);
-          useLayerStore.getState().setSelectedLayers([targetLayer.title]);
+          layerManager.setSelectedLayers([targetLayer.title]);
         }
       }
     // eslint-disable-next-line no-fallthrough

--- a/packages/core/src/web/app/svgedit/layer/layerManager.spec.ts
+++ b/packages/core/src/web/app/svgedit/layer/layerManager.spec.ts
@@ -4,6 +4,8 @@ jest.mock('../history/undoManager', () => ({
   addCommandToHistory: mockAddCommandToHistory,
 }));
 
+jest.mock('@core/helpers/layer/check-vector', () => () => false);
+
 // Mock history functionality
 jest.mock('../history/history', () => ({
   BatchCommand: jest.fn().mockImplementation((text: string) => ({
@@ -269,6 +271,21 @@ describe('LayerManager', () => {
     it('should return null for a non-existent layer', () => {
       expect(layerManager.removeLayerByName('nope')).toBeNull();
     });
+
+    it('should drop the removed layer from the selection', () => {
+      layerManager.createLayer('Layer 1');
+      layerManager.createLayer('Layer 2');
+      layerManager.setSelectedLayers(['Layer 1', 'Layer 2']);
+
+      layerManager.removeLayerByName('Layer 2');
+
+      expect(layerManager.getSelectedLayers()).toEqual(['Layer 1']);
+      expect(layerManager.getCurrentLayerName()).toBe('Layer 1');
+
+      layerManager.removeLayerByName('Layer 1');
+
+      expect(layerManager.getSelectedLayers()).toEqual([]);
+    });
   });
 
   describe('layer management', () => {
@@ -401,6 +418,27 @@ describe('LayerManager', () => {
       // Since the mock groups aren't properly recognized, they won't be in the layer map
       expect(layerManager.hasLayer('Existing Layer 1')).toBe(false);
       expect(layerManager.hasLayer('Existing Layer 2')).toBe(false);
+    });
+
+    it('should rename duplicate layer names', () => {
+      // Real DOM elements: MockSVGElement groups are not recognized by the layer walk
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+      ['Layer 1', 'Layer 1'].forEach((name) => {
+        const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+
+        title.textContent = name;
+        group.appendChild(title);
+        svg.appendChild(group);
+      });
+
+      const manager = new LayerManager(svg as SVGSVGElement);
+
+      manager.identifyLayers();
+
+      expect(manager.getAllLayerNames()).toEqual(['Layer 1', 'Layer 1 1']);
+      expect(svg.children[1].querySelector('title')?.textContent).toBe('Layer 1 1');
     });
 
     it('should create default layer for orphaned elements', () => {

--- a/packages/core/src/web/app/svgedit/layer/layerManager.spec.ts
+++ b/packages/core/src/web/app/svgedit/layer/layerManager.spec.ts
@@ -242,6 +242,35 @@ describe('LayerManager', () => {
     });
   });
 
+  describe('layer removal', () => {
+    it('should free the name for reuse after removal', () => {
+      layerManager.createLayer('Layer 1');
+      layerManager.removeLayerByName('Layer 1');
+
+      expect(layerManager.getNumLayers()).toBe(0);
+      expect(layerManager.hasLayer('Layer 1')).toBe(false);
+
+      const layer = layerManager.createLayer('Layer 1');
+
+      expect(layer?.getName()).toBe('Layer 1');
+    });
+
+    it('should move current to the top remaining layer when the current layer is removed', () => {
+      layerManager.createLayer('Layer 1');
+      layerManager.createLayer('Layer 2');
+
+      expect(layerManager.getCurrentLayerName()).toBe('Layer 2');
+
+      layerManager.removeLayerByName('Layer 2');
+
+      expect(layerManager.getCurrentLayerName()).toBe('Layer 1');
+    });
+
+    it('should return null for a non-existent layer', () => {
+      expect(layerManager.removeLayerByName('nope')).toBeNull();
+    });
+  });
+
   describe('layer management', () => {
     beforeEach(() => {
       layerManager.createLayer('Layer 1');

--- a/packages/core/src/web/app/svgedit/layer/layerManager.ts
+++ b/packages/core/src/web/app/svgedit/layer/layerManager.ts
@@ -7,7 +7,6 @@
  */
 
 import { promarkModels } from '@core/app/actions/beambox/constant';
-import { CanvasElements } from '@core/app/constants/canvasElements';
 import NS from '@core/app/constants/namespaces';
 import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { useDocumentStore } from '@core/app/stores/documentStore';
@@ -15,7 +14,7 @@ import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import doLayersContainsVector from '@core/helpers/layer/check-vector';
 import type { HistoryActionOptions, ICommand } from '@core/interfaces/IHistory';
 
-import { BatchCommand, InsertElementCommand, MoveElementCommand, RemoveElementCommand } from '../history/history';
+import { InsertElementCommand } from '../history/history';
 import { handleHistoryActionOptions } from '../history/utils/handleHistoryActionOptions';
 
 import { Layer } from './layer';
@@ -171,59 +170,6 @@ export class LayerManager {
   };
 
   /**
-   * Merge current layer with the previous layer
-   */
-  public mergeLayer = (options: HistoryActionOptions): void => {
-    const currentLayer = this.getCurrentLayer();
-
-    if (!currentLayer) return;
-
-    const currentGroup = currentLayer.getGroup();
-
-    if (!currentGroup) return;
-
-    const prevGroup = currentGroup.previousElementSibling as SVGGElement;
-
-    if (!prevGroup) return;
-
-    const batchCmd = new BatchCommand('Merge Layer');
-
-    const layerNextSibling = currentGroup.nextSibling;
-
-    // Move all children from current layer to previous layer
-    const children = Array.from(currentGroup.childNodes);
-
-    for (const child of children) {
-      if (child instanceof Element && CanvasElements.defElems.includes(child.localName)) {
-        continue;
-      }
-
-      const oldNextSibling = child.nextSibling;
-
-      prevGroup.appendChild(child);
-      batchCmd.addSubCommand(new MoveElementCommand(child as SVGElement, oldNextSibling, currentGroup));
-    }
-
-    batchCmd.addSubCommand(new RemoveElementCommand(currentGroup, layerNextSibling, this.svgContent));
-
-    // Remove current layer's group
-    currentLayer.removeGroup();
-
-    // Remove the current layer and set the previous layer as the new current layer
-    const { layers } = this.getState();
-    const index = layers.indexOf(currentLayer);
-
-    if (index > 0) {
-      useLayerStore.setState({
-        currentLayerName: layers[index - 1].getName(),
-        layers: layers.filter((layer) => layer !== currentLayer),
-      });
-    }
-
-    handleHistoryActionOptions(batchCmd, options);
-  };
-
-  /**
    * Remove a layer: detach its group from the DOM (emitting a history command per options) and
    * unregister it from the store, so its name is immediately free for reuse. If it was the current
    * layer, the top-most remaining layer becomes current; the removed name is also dropped from
@@ -365,8 +311,13 @@ export class LayerManager {
           }
 
           if (name) {
-            layerNames.push(name);
-            layers.push(new Layer(name, element as SVGGElement, null, color || undefined));
+            // Duplicate names would make by-name lookups ambiguous; rename later occurrences
+            const finalName = layerNames.includes(name) ? this.getNewLayerName(layerNames, name) : name;
+
+            if (finalName !== name) element.querySelector('title')!.textContent = finalName;
+
+            layerNames.push(finalName);
+            layers.push(new Layer(finalName, element as SVGGElement, null, color || undefined));
           } else {
             // Group without name is an orphan
             orphans.push(element);

--- a/packages/core/src/web/app/svgedit/layer/layerManager.ts
+++ b/packages/core/src/web/app/svgedit/layer/layerManager.ts
@@ -13,7 +13,7 @@ import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { useDocumentStore } from '@core/app/stores/documentStore';
 import { useLayerStore } from '@core/app/stores/layer/layerStore';
 import doLayersContainsVector from '@core/helpers/layer/check-vector';
-import type { HistoryActionOptions } from '@core/interfaces/IHistory';
+import type { HistoryActionOptions, ICommand } from '@core/interfaces/IHistory';
 
 import { BatchCommand, InsertElementCommand, MoveElementCommand, RemoveElementCommand } from '../history/history';
 import { handleHistoryActionOptions } from '../history/utils/handleHistoryActionOptions';
@@ -221,6 +221,29 @@ export class LayerManager {
     }
 
     handleHistoryActionOptions(batchCmd, options);
+  };
+
+  /**
+   * Remove a layer: detach its group from the DOM (emitting a history command per options) and
+   * unregister it from the store, so its name is immediately free for reuse. If it was the current
+   * layer, the top-most remaining layer becomes current.
+   */
+  public removeLayerByName = (name: string, options?: HistoryActionOptions): ICommand | null => {
+    const layer = this.getLayerByName(name);
+
+    if (!layer) return null;
+
+    const cmd = layer.removeGroup(options);
+    const layers = this.getState().layers.filter((l) => l !== layer);
+
+    useLayerStore.setState({
+      layers,
+      ...(this.getState().currentLayerName === name && {
+        currentLayerName: layers.at(-1)?.getName() ?? null,
+      }),
+    });
+
+    return cmd;
   };
 
   /**

--- a/packages/core/src/web/app/svgedit/layer/layerManager.ts
+++ b/packages/core/src/web/app/svgedit/layer/layerManager.ts
@@ -1,12 +1,18 @@
 /**
  * SVG Layer Manager for Beam Studio
  *
- * This class manages multiple layers in an SVG drawing, extracted from the original
- * draw.js functionality. It handles layer creation, deletion, ordering, and properties.
+ * The single mutation API for layer state. All layer reads/writes from imperative code go
+ * through this class; the backing state lives in useLayerStore (a passive Zustand store) so
+ * React components can subscribe to it with selectors. Never write to useLayerStore directly.
  */
 
+import { promarkModels } from '@core/app/actions/beambox/constant';
 import { CanvasElements } from '@core/app/constants/canvasElements';
 import NS from '@core/app/constants/namespaces';
+import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
+import { useDocumentStore } from '@core/app/stores/documentStore';
+import { useLayerStore } from '@core/app/stores/layer/layerStore';
+import doLayersContainsVector from '@core/helpers/layer/check-vector';
 import type { HistoryActionOptions } from '@core/interfaces/IHistory';
 
 import { BatchCommand, InsertElementCommand, MoveElementCommand, RemoveElementCommand } from '../history/history';
@@ -36,12 +42,34 @@ const VISIBLE_ELEMENTS = [
 ];
 
 /**
+ * Decide what the current layer and selection become after the layer list is rebuilt from the
+ * DOM (undo/redo, external DOM mutation). Unlike identifyLayers, a resync happens on a document
+ * the user is still working in, so selection should survive when it can.
+ *
+ * @param prevCurrentLayerName - current layer before the resync (may no longer exist)
+ * @param prevSelectedLayers - selected layer names before the resync (may contain dead names)
+ * @param layerNames - the rebuilt layer names, ordered bottom to top; never empty
+ */
+const resolveSelectionAfterResync = (
+  prevCurrentLayerName: null | string,
+  prevSelectedLayers: string[],
+  layerNames: string[],
+): { currentLayerName: null | string; selectedLayers: string[] } => {
+  const selectedLayers = prevSelectedLayers.filter((name) => layerNames.includes(name));
+  const currentLayerName =
+    prevCurrentLayerName && layerNames.includes(prevCurrentLayerName)
+      ? prevCurrentLayerName
+      : (selectedLayers[0] ?? layerNames.at(-1)!);
+
+  if (selectedLayers.length === 0) selectedLayers.push(currentLayerName);
+
+  return { currentLayerName, selectedLayers };
+};
+
+/**
  * LayerManager class for managing SVG layers in the drawing canvas
  */
 export class LayerManager {
-  private allLayers: Layer[] = [];
-  private layerMap: Map<string, Layer> = new Map();
-  private currentLayer: Layer | null = null;
   private svgContent: SVGSVGElement;
 
   /**
@@ -50,54 +78,59 @@ export class LayerManager {
    */
   constructor(svgContent: SVGSVGElement) {
     this.svgContent = svgContent;
+    this.clear();
   }
+
+  private getState = () => useLayerStore.getState();
 
   /**
    * Returns the number of layers in the current drawing
    */
   public getNumLayers = (): number => {
-    return this.allLayers.length;
+    return this.getState().layers.length;
   };
 
   /**
    * Check if layer with given name already exists
    */
   public hasLayer = (name: string): boolean => {
-    return this.layerMap.has(name);
+    return this.getState().layers.some((layer) => layer.getName() === name);
   };
 
   /**
    * Returns the name of the ith layer. If the index is out of range, an empty string is returned.
    */
   public getLayerName = (i: number): string => {
-    return i >= 0 && i < this.getNumLayers() ? this.allLayers[i].getName() : '';
+    return this.getState().layers[i]?.getName() ?? '';
   };
 
   /**
    * Get all layer names
    */
   public getAllLayerNames = (): string[] => {
-    return this.allLayers.map((layer) => layer.getName());
+    return this.getState().layers.map((layer) => layer.getName());
   };
 
   /**
-   * Returns the SVGGElement representing the current layer
+   * Returns the currently selected layer
    */
   public getCurrentLayer = (): Layer | null => {
-    return this.currentLayer ?? null;
+    const { currentLayerName, layers } = this.getState();
+
+    if (!currentLayerName) return null;
+
+    return layers.find((layer) => layer.getName() === currentLayerName) ?? null;
   };
 
   /**
    * Get a layer by name
    */
   public getLayerByName = (name: string): Layer | null => {
-    const layer = this.layerMap.get(name);
-
-    return layer ?? null;
+    return this.getState().layers.find((layer) => layer.getName() === name) ?? null;
   };
 
   public getLayerElementByName = (name: string): null | SVGGElement => {
-    const layer = this.layerMap.get(name);
+    const layer = this.getLayerByName(name);
 
     return layer ? layer.getGroup() : null;
   };
@@ -106,28 +139,32 @@ export class LayerManager {
    * Returns the name of the currently selected layer
    */
   public getCurrentLayerName = (): string => {
-    return this.currentLayer ? this.currentLayer.getName() : '';
+    return this.getState().currentLayerName ?? '';
   };
 
   public getCurrentLayerElement = (): null | SVGGElement => {
-    return this.currentLayer ? this.currentLayer.getGroup() : null;
+    return this.getCurrentLayer()?.getGroup() ?? null;
+  };
+
+  /**
+   * Get the selected layer names. React components should subscribe via useLayerStore instead.
+   */
+  public getSelectedLayers = (): string[] => {
+    return this.getState().selectedLayers;
   };
 
   /**
    * Set the current layer's name
    */
   public setCurrentLayerName = (name: string): null | string => {
-    let finalName: null | string = null;
+    const currentLayer = this.getCurrentLayer();
 
-    if (this.currentLayer) {
-      const oldName = this.currentLayer.getName();
+    if (!currentLayer) return null;
 
-      finalName = this.currentLayer.setName(name);
+    const finalName = currentLayer.setName(name);
 
-      if (finalName) {
-        this.layerMap.delete(oldName);
-        this.layerMap.set(finalName, this.currentLayer);
-      }
+    if (finalName) {
+      useLayerStore.setState({ currentLayerName: finalName, layers: [...this.getState().layers] });
     }
 
     return finalName;
@@ -137,9 +174,11 @@ export class LayerManager {
    * Merge current layer with the previous layer
    */
   public mergeLayer = (options: HistoryActionOptions): void => {
-    if (!this.currentLayer) return;
+    const currentLayer = this.getCurrentLayer();
 
-    const currentGroup = this.currentLayer.getGroup();
+    if (!currentLayer) return;
+
+    const currentGroup = currentLayer.getGroup();
 
     if (!currentGroup) return;
 
@@ -168,17 +207,17 @@ export class LayerManager {
     batchCmd.addSubCommand(new RemoveElementCommand(currentGroup, layerNextSibling, this.svgContent));
 
     // Remove current layer's group
-    this.currentLayer.removeGroup();
+    currentLayer.removeGroup();
 
     // Remove the current layer and set the previous layer as the new current layer
-    const index = this.allLayers.indexOf(this.currentLayer);
+    const { layers } = this.getState();
+    const index = layers.indexOf(currentLayer);
 
     if (index > 0) {
-      const name = this.currentLayer.getName();
-
-      this.currentLayer = this.allLayers[index - 1];
-      this.allLayers.splice(index, 1);
-      this.layerMap.delete(name);
+      useLayerStore.setState({
+        currentLayerName: layers[index - 1].getName(),
+        layers: layers.filter((layer) => layer !== currentLayer),
+      });
     }
 
     handleHistoryActionOptions(batchCmd, options);
@@ -188,15 +227,60 @@ export class LayerManager {
    * Sets the current layer. Returns true if successful, false otherwise.
    */
   public setCurrentLayer = (name: string): boolean => {
-    const layer = this.layerMap.get(name);
+    if (!this.hasLayer(name)) return false;
 
-    if (layer) {
-      this.currentLayer = layer;
+    useLayerStore.setState({ currentLayerName: name });
 
-      return true;
+    return true;
+  };
+
+  /**
+   * Set the selected layers (and the current layer, which defaults to the first selected one).
+   * Recomputes the hasVector / hasGradient flags when the selection actually changes.
+   */
+  public setSelectedLayers = (selectedLayers: string[], currentLayer?: string): void => {
+    const state = this.getState();
+    const newLayers = selectedLayers.length === 0 ? [this.getCurrentLayerName()] : selectedLayers;
+    const newCurrentLayer = currentLayer || newLayers[0];
+
+    if (newCurrentLayer && newCurrentLayer !== state.currentLayerName) {
+      this.setCurrentLayer(newCurrentLayer);
     }
 
-    return false;
+    // Lazy update - only update if actually different
+    if (
+      newLayers.length === state.selectedLayers.length &&
+      newLayers.every((name, i) => name === state.selectedLayers[i])
+    ) {
+      return;
+    }
+
+    useLayerStore.setState({ selectedLayers: newLayers });
+    this.checkVector();
+    this.checkGradient();
+  };
+
+  /**
+   * Recompute whether the selected layers contain vector elements. Expensive; called
+   * automatically when the selection changes.
+   */
+  public checkVector = (): void => {
+    const layers = this.getState().selectedLayers.map(this.getLayerElementByName);
+
+    useLayerStore.setState({ hasVector: doLayersContainsVector(layers) });
+  };
+
+  /**
+   * Recompute whether the selected layers contain gradient images (Promark models only).
+   */
+  public checkGradient = (workarea: WorkAreaModel = useDocumentStore.getState().workarea): void => {
+    if (!promarkModels.has(workarea)) return;
+
+    const hasGradient = this.getState().selectedLayers.some((layerName) =>
+      Boolean(this.getLayerElementByName(layerName)?.querySelector('image[data-shading="true"]')),
+    );
+
+    useLayerStore.setState({ hasGradient });
   };
 
   /**
@@ -229,16 +313,14 @@ export class LayerManager {
   }
 
   /**
-   * Updates layer system and sets the current layer to the top-most layer
+   * Rebuild the Layer list from the DOM, adopting orphan elements into a new layer.
+   * Always returns at least one layer.
    */
-  public identifyLayers = (): void => {
-    this.allLayers = [];
-    this.layerMap.clear();
-
+  private buildLayersFromDom(): Layer[] {
+    const layers: Layer[] = [];
     const numChildren = this.svgContent.childNodes.length;
     const orphans: SVGElement[] = [];
     const layerNames: string[] = [];
-    let layer: Layer | null = null;
 
     // Loop through all children of SVG element
     for (let i = 0; i < numChildren; i++) {
@@ -258,9 +340,7 @@ export class LayerManager {
 
           if (name) {
             layerNames.push(name);
-            layer = new Layer(name, element as SVGGElement, null, color || undefined);
-            this.allLayers.push(layer);
-            this.layerMap.set(name, layer);
+            layers.push(new Layer(name, element as SVGGElement, null, color || undefined));
           } else {
             // Group without name is an orphan
             orphans.push(element);
@@ -273,16 +353,39 @@ export class LayerManager {
     }
 
     // If orphans or no layers found, create a new layer and add all orphans to it
-    if (orphans.length > 0 || this.allLayers.length === 0) {
+    if (orphans.length > 0 || layers.length === 0) {
       const newName = this.getNewLayerName(layerNames);
+      const layer = new Layer(newName, null, this.svgContent);
 
-      layer = new Layer(newName, null, this.svgContent);
       layer.appendChildren(orphans);
-      this.allLayers.push(layer);
-      this.layerMap.set(newName, layer);
+      layers.push(layer);
     }
 
-    this.currentLayer = layer;
+    return layers;
+  }
+
+  /**
+   * Updates layer system and sets the current layer to the top-most layer
+   */
+  public identifyLayers = (): void => {
+    const layers = this.buildLayersFromDom();
+
+    useLayerStore.setState({ currentLayerName: layers.at(-1)?.getName() ?? null, layers });
+  };
+
+  /**
+   * Rebuild the layer list from the DOM while keeping the current layer and selection alive
+   * where possible. Use after undo/redo or any operation that mutated layer groups behind the
+   * manager's back; identifyLayers is for freshly loaded documents instead.
+   */
+  public resync = (): void => {
+    const { currentLayerName, selectedLayers } = this.getState();
+    const layers = this.buildLayersFromDom();
+    const layerNames = layers.map((layer) => layer.getName());
+
+    useLayerStore.setState({ layers, ...resolveSelectionAfterResync(currentLayerName, selectedLayers, layerNames) });
+    this.checkVector();
+    this.checkGradient();
   };
 
   /**
@@ -290,8 +393,8 @@ export class LayerManager {
    */
   public createLayer = (name?: string, options?: HistoryActionOptions): Layer | null => {
     // Check for duplicate name or generate new one
-    if (!name || name === '' || this.layerMap.has(name)) {
-      name = this.getNewLayerName(Array.from(this.layerMap.keys()), name || 'Layer');
+    if (!name || name === '' || this.hasLayer(name)) {
+      name = this.getNewLayerName(this.getAllLayerNames(), name || 'Layer');
     }
 
     // Create new layer and add to DOM as last layer
@@ -305,9 +408,7 @@ export class LayerManager {
     // Add to history
     handleHistoryActionOptions(cmd, options);
 
-    this.allLayers.push(layer);
-    this.layerMap.set(name, layer);
-    this.currentLayer = layer;
+    useLayerStore.setState({ currentLayerName: name, layers: [...this.getState().layers, layer] });
 
     return layer;
   };
@@ -316,7 +417,7 @@ export class LayerManager {
    * Returns the layer color
    */
   public getLayerColor(layerName: string): false | string {
-    const layer = this.layerMap.get(layerName);
+    const layer = this.getLayerByName(layerName);
 
     if (!layer) return false;
 
@@ -335,7 +436,7 @@ export class LayerManager {
    * Returns the opacity of the given layer
    */
   public getLayerOpacity = (layerName: string): null | number => {
-    const layer = this.layerMap.get(layerName);
+    const layer = this.getLayerByName(layerName);
 
     if (!layer) return null;
 
@@ -348,59 +449,62 @@ export class LayerManager {
   public setLayerOpacity = (layerName: string, opacity: number): void => {
     if (opacity < 0.0 || opacity > 1.0) return;
 
-    const layer = this.layerMap.get(layerName);
-
-    if (layer) layer.setOpacity(opacity);
+    this.getLayerByName(layerName)?.setOpacity(opacity);
   };
 
   /**
    * Get all layers
    */
   public getAllLayers = (): Layer[] => {
-    return [...this.allLayers];
+    return [...this.getState().layers];
   };
 
   /**
    * Get layer by index
    */
   public getLayerByIndex = (index: number): Layer | null => {
-    return this.allLayers[index] || null;
+    return this.getState().layers[index] || null;
   };
 
   /**
    * Move layer to new position
    */
   public moveLayer = (fromIndex: number, toIndex: number): boolean => {
+    const { layers } = this.getState();
+
     if (
       fromIndex < 0 ||
-      fromIndex >= this.allLayers.length ||
+      fromIndex >= layers.length ||
       toIndex < 0 ||
-      toIndex >= this.allLayers.length ||
+      toIndex >= layers.length ||
       fromIndex === toIndex
     ) {
       return false;
     }
 
-    const layer = this.allLayers[fromIndex];
+    const layer = layers[fromIndex];
     const group = layer.getGroup();
 
     if (!group) return false;
 
+    const newLayers = [...layers];
+
     // Remove from array
-    this.allLayers.splice(fromIndex, 1);
+    newLayers.splice(fromIndex, 1);
 
     // Insert at new position
-    this.allLayers.splice(toIndex, 0, layer);
+    newLayers.splice(toIndex, 0, layer);
 
     // Update DOM order
-    const targetLayer = this.allLayers[toIndex + 1];
-    const targetGroup = targetLayer?.getGroup();
+    const targetGroup = newLayers[toIndex + 1]?.getGroup();
 
     if (targetGroup) {
       this.svgContent.insertBefore(group, targetGroup);
     } else {
       this.svgContent.appendChild(group);
     }
+
+    useLayerStore.setState({ layers: newLayers });
 
     return true;
   };
@@ -409,9 +513,7 @@ export class LayerManager {
    * Clear all layers
    */
   public clear = (): void => {
-    this.allLayers = [];
-    this.layerMap.clear();
-    this.currentLayer = null;
+    useLayerStore.setState({ currentLayerName: null, layers: [] });
   };
 
   public reset = (svgContent: SVGSVGElement, identifyLayers = false): void => {
@@ -423,5 +525,11 @@ export class LayerManager {
 }
 
 export const layerManager = new LayerManager(document.createElementNS(NS.SVG, 'svg'));
+
+// Recompute the Promark gradient flag when the workarea changes
+useDocumentStore.subscribe(
+  (state) => state.workarea,
+  (workarea) => layerManager.checkGradient(workarea),
+);
 
 export default layerManager;

--- a/packages/core/src/web/app/svgedit/layer/layerManager.ts
+++ b/packages/core/src/web/app/svgedit/layer/layerManager.ts
@@ -226,7 +226,8 @@ export class LayerManager {
   /**
    * Remove a layer: detach its group from the DOM (emitting a history command per options) and
    * unregister it from the store, so its name is immediately free for reuse. If it was the current
-   * layer, the top-most remaining layer becomes current.
+   * layer, the top-most remaining layer becomes current; the removed name is also dropped from
+   * the selection (falling back to the current layer), so callers need no selection cleanup.
    */
   public removeLayerByName = (name: string, options?: HistoryActionOptions): ICommand | null => {
     const layer = this.getLayerByName(name);
@@ -234,14 +235,16 @@ export class LayerManager {
     if (!layer) return null;
 
     const cmd = layer.removeGroup(options);
-    const layers = this.getState().layers.filter((l) => l !== layer);
+    const state = this.getState();
+    const layers = state.layers.filter((l) => l !== layer);
 
     useLayerStore.setState({
       layers,
-      ...(this.getState().currentLayerName === name && {
+      ...(state.currentLayerName === name && {
         currentLayerName: layers.at(-1)?.getName() ?? null,
       }),
     });
+    this.setSelectedLayers(state.selectedLayers.filter((selectedName) => selectedName !== name));
 
     return cmd;
   };
@@ -263,7 +266,7 @@ export class LayerManager {
    */
   public setSelectedLayers = (selectedLayers: string[], currentLayer?: string): void => {
     const state = this.getState();
-    const newLayers = selectedLayers.length === 0 ? [this.getCurrentLayerName()] : selectedLayers;
+    const newLayers = selectedLayers.length === 0 && state.currentLayerName ? [state.currentLayerName] : selectedLayers;
     const newCurrentLayer = currentLayer || newLayers[0];
 
     if (newCurrentLayer && newCurrentLayer !== state.currentLayerName) {

--- a/packages/core/src/web/app/svgedit/operations/delete.ts
+++ b/packages/core/src/web/app/svgedit/operations/delete.ts
@@ -1,5 +1,5 @@
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import selectionManager from '@core/app/svgedit/selection';
 import selector from '@core/app/svgedit/selector';
 import findDefs from '@core/app/svgedit/utils/findDef';
@@ -103,8 +103,8 @@ export const deleteElements = (elems: Element[], isSub = false): IBatchCommand =
 
   svgCanvas.call('changed', deletedElems);
   selectionManager.clearSelection();
-  useLayerStore.getState().checkVector();
-  useLayerStore.getState().checkGradient();
+  layerManager.checkVector();
+  layerManager.checkGradient();
 
   return batchCmd;
 };

--- a/packages/core/src/web/app/svgedit/operations/disassembleUse.ts
+++ b/packages/core/src/web/app/svgedit/operations/disassembleUse.ts
@@ -4,7 +4,7 @@ import progressCaller from '@core/app/actions/progress-caller';
 import alertConstants from '@core/app/constants/alert-constants';
 import NS from '@core/app/constants/namespaces';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
-import { useLayerStore } from '@core/app/stores/layer/layerStore';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import i18n from '@core/helpers/i18n';
 import { getData } from '@core/helpers/layer/layer-config-helper';
@@ -123,7 +123,7 @@ export const disassembleUse = async (
 
     const { elem: layer, title: layerTitle } = getObjectLayer(elem)!;
 
-    useLayerStore.getState().setSelectedLayers([layerTitle]);
+    layerManager.setSelectedLayers([layerTitle]);
 
     const color = (useGlobalPreferenceStore.getState().use_layer_color ? getData(layer, 'color') : '#000') ?? '#000';
     const drawing = svgCanvas.getCurrentDrawing();

--- a/packages/core/src/web/app/svgedit/operations/import/importBvg.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/importBvg.ts
@@ -9,7 +9,6 @@ import { fullColorHeadModules, LayerModule } from '@core/app/constants/layer-mod
 import type { EngraveDpiOption } from '@core/app/constants/resolutions';
 import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { changeMultipleDocumentStoreValues, useDocumentStore } from '@core/app/stores/documentStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import currentFileManager from '@core/app/svgedit/currentFileManager';
 import history from '@core/app/svgedit/history/history';
 import changeWorkarea from '@core/app/svgedit/operations/changeWorkarea';
@@ -179,7 +178,7 @@ export const importBvgString = async (str: string, opts: HistoryActionOptions = 
       rotaryAxis.toggleDisplay();
     };
 
-    useLayerStore.getState().forceUpdate();
+    layerManager.resync();
   }
 
   const { lang } = i18n;
@@ -253,7 +252,7 @@ export const importBvgString = async (str: string, opts: HistoryActionOptions = 
     // Change modules not supported to default module of the new workarea
     toggleModuleAfterWorkareaChange();
     presprayArea.togglePresprayArea();
-    useLayerStore.getState().setSelectedLayers([]);
+    layerManager.setSelectedLayers([]);
 
     if (!parentCmd) {
       workareaManager.setWorkarea(workarea);

--- a/packages/core/src/web/app/svgedit/operations/import/importDxf.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/importDxf.ts
@@ -3,7 +3,6 @@ import dialogCaller from '@core/app/actions/dialog-caller';
 import progressCaller from '@core/app/actions/progress-caller';
 import alertConstants from '@core/app/constants/alert-constants';
 import NS from '@core/app/constants/namespaces';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import HistoryCommandFactory from '@core/app/svgedit/history/HistoryCommandFactory';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -206,7 +205,7 @@ const importDxf = async (file: Blob, { silent = false }: { silent?: boolean } = 
   await Promise.all(promises);
 
   removeDefaultLayerIfEmpty({ parentCmd: batchCmd });
-  useLayerStore.getState().setSelectedLayers(layerNames);
+  layerManager.setSelectedLayers(layerNames);
   undoManager.addCommandToHistory(batchCmd);
 
   return true;

--- a/packages/core/src/web/app/svgedit/operations/import/importSvg/index.tsx
+++ b/packages/core/src/web/app/svgedit/operations/import/importSvg/index.tsx
@@ -9,7 +9,6 @@ import progressCaller from '@core/app/actions/progress-caller';
 import alertConstants from '@core/app/constants/alert-constants';
 import type { LayerModuleType } from '@core/app/constants/layer-module/layer-modules';
 import { useDocumentStore } from '@core/app/stores/documentStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
 import layerManager from '@core/app/svgedit/layer/layerManager';
@@ -200,7 +199,7 @@ function finalizeImport(
     elements.forEach((elem) => elem.setAttribute('data-np', '1'));
   }
 
-  useLayerStore.getState().setSelectedLayers([layerManager.getCurrentLayerName()!]);
+  layerManager.setSelectedLayers([layerManager.getCurrentLayerName()!]);
 
   let minX = Infinity;
   let minY = Infinity;

--- a/packages/core/src/web/app/svgedit/selection/SelectionManager.ts
+++ b/packages/core/src/web/app/svgedit/selection/SelectionManager.ts
@@ -1,6 +1,5 @@
 import type { ISVGEditor } from '@core/app/actions/beambox/svg-editor';
 import NS from '@core/app/constants/namespaces';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import * as LayerHelper from '@core/helpers/layer/layer-helper';
 import type { IBatchCommand } from '@core/interfaces/IHistory';
@@ -261,11 +260,10 @@ export class SelectionManager {
       )
       .filter(Boolean) as string[];
 
-    // set the newest added layer as currentLayer
-    layerManager.setCurrentLayer(layers[0]);
+    // the newest added layer (layers[0]) becomes the current layer;
     // the uniq process is performed `here` to avoid duplicate layer in layer panel,
     // and remain the selected layers contains information if there are multiple elements in same layer
-    useLayerStore.getState().setSelectedLayers([...new Set(layers)]);
+    layerManager.setSelectedLayers([...new Set(layers)]);
 
     this.selectedLayers = layers;
 
@@ -293,8 +291,7 @@ export class SelectionManager {
     }
 
     // set the current layer from the remaining layers
-    layerManager.setCurrentLayer(this.selectedLayers[0]);
-    useLayerStore.getState().setSelectedLayers([...new Set(this.selectedLayers)]);
+    layerManager.setSelectedLayers([...new Set(this.selectedLayers)]);
 
     if (elem.nextSibling && (elem.nextSibling as Element).getAttribute('data-imageborder') === 'true') {
       elem.nextSibling.remove();

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -453,25 +453,12 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
           var isApply = eventType === EventTypes.AFTER_APPLY;
 
           if (cmdType === MoveElementCommand.type()) {
-            var parent = isApply ? cmd.newParent : cmd.oldParent;
-
-            if (parent === svgcontent) {
-              layerManager.identifyLayers();
-            }
-
-            let shouldUpdateLayerStore = false;
-
+            // Layer state rebuild is handled by the central layerManager.resync() after undo/redo
             elems.forEach((elem) => {
-              if (elem.classList.contains('layer')) {
-                shouldUpdateLayerStore = true;
-              } else {
+              if (!elem.classList.contains('layer')) {
                 updateElementColor(elem);
               }
             });
-
-            if (shouldUpdateLayerStore) {
-              layerManager.resync();
-            }
           } else if (cmdType === InsertElementCommand.type() || cmdType === RemoveElementCommand.type()) {
             if (cmdType === InsertElementCommand.type()) {
               if (isApply) {
@@ -489,11 +476,6 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
               }
             }
           } else if (cmdType === ChangeElementCommand.type()) {
-            // if we are changing layer names, re-identify all layers
-            if (cmd.elem.tagName === 'title' && cmd.elem.parentNode?.parentNode === svgcontent) {
-              layerManager.identifyLayers();
-            }
-
             var values = isApply ? cmd.newValues : cmd.oldValues;
             const changedValues = Object.keys(values);
 
@@ -527,8 +509,6 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
                 'Split Full Color Layer',
               ].includes(cmd.text)
             ) {
-              layerManager.identifyLayers();
-              layerManager.setSelectedLayers([]);
               presprayArea.togglePresprayArea();
             }
 

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -44,7 +44,6 @@ import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { getMouseMode, setMouseMode } from '@core/app/stores/canvas/utils/mouseMode';
 import { useDocumentStore } from '@core/app/stores/documentStore';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import { getAutoFeeder, getPassThrough } from '@core/helpers/addOn';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import { getAttributes } from '@core/helpers/element/attribute';
@@ -329,9 +328,9 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
     $(shape).mouseover(canvas.handleGenerateSensorArea).mouseleave(canvas.handleGenerateSensorArea);
 
     if (shape.tagName === 'image') {
-      useLayerStore.getState().checkGradient();
+      layerManager.checkGradient();
     } else {
-      useLayerStore.getState().checkVector();
+      layerManager.checkVector();
     }
 
     return shape;
@@ -471,7 +470,7 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
             });
 
             if (shouldUpdateLayerStore) {
-              useLayerStore.getState().forceUpdate();
+              layerManager.resync();
             }
           } else if (cmdType === InsertElementCommand.type() || cmdType === RemoveElementCommand.type()) {
             if (cmdType === InsertElementCommand.type()) {
@@ -529,7 +528,7 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
               ].includes(cmd.text)
             ) {
               layerManager.identifyLayers();
-              useLayerStore.getState().setSelectedLayers([]);
+              layerManager.setSelectedLayers([]);
               presprayArea.togglePresprayArea();
             }
 
@@ -2028,7 +2027,7 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
     initLayerConfig(defaultLayer);
 
     // force update selected layers
-    useLayerStore.getState().setSelectedLayers([defaultLayerName]);
+    layerManager.setSelectedLayers([defaultLayerName]);
     presprayArea.togglePresprayArea();
 
     // clear the undo stack

--- a/packages/core/src/web/helpers/layer-module/change-module.spec.ts
+++ b/packages/core/src/web/helpers/layer-module/change-module.spec.ts
@@ -77,8 +77,13 @@ jest.mock('@core/helpers/presets/preset-helper', () => ({
   getPresetsList: mockGetPresetsList,
 }));
 
+const mockForceUpdate = jest.fn();
+
+jest.mock('@core/app/svgedit/layer/layerManager', () => ({
+  resync: () => mockForceUpdate(),
+}));
+
 import { changeLayersModule } from './change-module';
-import { mockForceUpdate } from '@mocks/@core/app/stores/layer/layerStore';
 
 const mockLayer = {} as unknown as Element;
 
@@ -124,7 +129,7 @@ describe('test changeLayersModule', () => {
 
     batchCmd.onAfter();
     expect(mockInitState).toHaveBeenCalledTimes(2);
-    expect(mockForceUpdate).toHaveBeenCalledTimes(2);
+    expect(mockForceUpdate).toHaveBeenCalledTimes(1);
     expect(mockTogglePresprayArea).toHaveBeenCalledTimes(2);
   });
 
@@ -157,7 +162,7 @@ describe('test changeLayersModule', () => {
 
     batchCmd.onAfter();
     expect(mockInitState).toHaveBeenCalledTimes(2);
-    expect(mockForceUpdate).toHaveBeenCalledTimes(2);
+    expect(mockForceUpdate).toHaveBeenCalledTimes(1);
     expect(mockTogglePresprayArea).toHaveBeenCalledTimes(2);
   });
 
@@ -191,7 +196,7 @@ describe('test changeLayersModule', () => {
 
     batchCmd.onAfter();
     expect(mockInitState).toHaveBeenCalledTimes(2);
-    expect(mockForceUpdate).toHaveBeenCalledTimes(2);
+    expect(mockForceUpdate).toHaveBeenCalledTimes(1);
     expect(mockTogglePresprayArea).toHaveBeenCalledTimes(2);
   });
 
@@ -224,7 +229,7 @@ describe('test changeLayersModule', () => {
 
     batchCmd.onAfter();
     expect(mockInitState).toHaveBeenCalledTimes(2);
-    expect(mockForceUpdate).toHaveBeenCalledTimes(2);
+    expect(mockForceUpdate).toHaveBeenCalledTimes(1);
     expect(mockTogglePresprayArea).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/web/helpers/layer-module/change-module.ts
+++ b/packages/core/src/web/helpers/layer-module/change-module.ts
@@ -5,9 +5,9 @@ import alertConstants from '@core/app/constants/alert-constants';
 import type { LayerModuleType } from '@core/app/constants/layer-module/layer-modules';
 import { fullColorModules, LayerModule, printingModules } from '@core/app/constants/layer-module/layer-modules';
 import { useDocumentStore } from '@core/app/stores/documentStore';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
+import layerManager from '@core/app/svgedit/layer/layerManager';
 import alertConfig from '@core/helpers/api/alert-config';
 import i18n from '@core/helpers/i18n';
 import toggleFullColorLayer from '@core/helpers/layer/full-color/toggleFullColorLayer';
@@ -127,13 +127,12 @@ export const changeLayersModule = async (
   });
 
   initLayerConfigState();
-  useLayerStore.getState().forceUpdate();
+  layerManager.resync();
   presprayArea.togglePresprayArea();
 
   if (addToHistory) {
     batchCmd.onAfter = () => {
       initLayerConfigState();
-      useLayerStore.getState().forceUpdate();
       presprayArea.togglePresprayArea();
     };
     undoManager.addCommandToHistory(batchCmd);

--- a/packages/core/src/web/helpers/layer/check-vector.ts
+++ b/packages/core/src/web/helpers/layer/check-vector.ts
@@ -1,5 +1,3 @@
-import layerManager from '@core/app/svgedit/layer/layerManager';
-
 const doElementContainVector = (elem: Element) => {
   const vectors = elem.querySelectorAll('path, rect, ellipse, polygon, line, text');
   let res = false;
@@ -19,8 +17,7 @@ const doElementContainVector = (elem: Element) => {
 };
 
 // TODO: add unit test
-const doLayersContainsVector = (layerNames: string[]): boolean => {
-  const layers = layerNames.map((layerName: string) => layerManager.getLayerElementByName(layerName));
+const doLayersContainsVector = (layers: Array<Element | null>): boolean => {
   let res = false;
 
   for (let i = 0; i < layers.length; i += 1) {

--- a/packages/core/src/web/helpers/layer/deleteLayer.ts
+++ b/packages/core/src/web/helpers/layer/deleteLayer.ts
@@ -42,7 +42,8 @@ export const deleteLayers = (layerNames: string[]): void => {
     undoManager.addCommandToHistory(batchCmd);
   }
 
-  layerManager.resync();
+  // Collapse selection to the current layer (covers the recreated default layer)
+  layerManager.setSelectedLayers([]);
 };
 
 export const removeDefaultLayerIfEmpty = ({ parentCmd }: { parentCmd?: IBatchCommand } = {}): ICommand | null => {
@@ -55,14 +56,7 @@ export const removeDefaultLayerIfEmpty = ({ parentCmd }: { parentCmd?: IBatchCom
     const isEmpty = childNodes.every((node) => CanvasElements.defElems.includes((node as Element).tagName));
 
     if (isEmpty) {
-      console.log('default layer is empty. delete it!');
-
-      const cmd = deleteLayerByName(defaultLayerName, { parentCmd });
-
-      layerManager.resync();
-      layerManager.setSelectedLayers([]);
-
-      return cmd;
+      return deleteLayerByName(defaultLayerName, { parentCmd });
     }
   }
 

--- a/packages/core/src/web/helpers/layer/deleteLayer.ts
+++ b/packages/core/src/web/helpers/layer/deleteLayer.ts
@@ -1,8 +1,6 @@
 import { CanvasElements } from '@core/app/constants/canvasElements';
-import useLayerStore from '@core/app/stores/layer/layerStore';
-import { BatchCommand, InsertElementCommand } from '@core/app/svgedit/history/history';
+import { BatchCommand } from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
-import Layer from '@core/app/svgedit/layer/layer';
 import layerManager from '@core/app/svgedit/layer/layerManager';
 import selectionManager from '@core/app/svgedit/selection';
 import type { IBatchCommand, ICommand } from '@core/interfaces/IHistory';
@@ -38,24 +36,19 @@ export const deleteLayers = (layerNames: string[]): void => {
   const layerCounts = document.querySelectorAll('g.layer').length;
 
   if (!layerCounts) {
-    const svgcontent = document.getElementById('svgcontent')! as unknown as SVGSVGElement;
-    // TODO: should use layerManager to create layer?
-    const newLayer = new Layer(
-      i18n.lang.beambox.right_panel.layer_panel.layer1,
-      null,
-      svgcontent,
-      '#333333',
-    ).getGroup() as Element;
+    const newLayer = layerManager.createLayer(i18n.lang.beambox.right_panel.layer_panel.layer1, {
+      parentCmd: batchCmd,
+    })!;
 
-    batchCmd.addSubCommand(new InsertElementCommand(newLayer));
-    initLayerConfig(newLayer);
+    newLayer.setColor('#333333');
+    initLayerConfig(newLayer.getGroup());
   }
 
   if (!batchCmd.isEmpty()) {
     undoManager.addCommandToHistory(batchCmd);
   }
 
-  layerManager.identifyLayers();
+  layerManager.resync();
 };
 
 export const removeDefaultLayerIfEmpty = ({ parentCmd }: { parentCmd?: IBatchCommand } = {}): ICommand | null => {
@@ -72,8 +65,8 @@ export const removeDefaultLayerIfEmpty = ({ parentCmd }: { parentCmd?: IBatchCom
 
       const cmd = deleteLayerByName(defaultLayerName, { parentCmd });
 
-      layerManager.identifyLayers();
-      useLayerStore.getState().setSelectedLayers([]);
+      layerManager.resync();
+      layerManager.setSelectedLayers([]);
 
       return cmd;
     }

--- a/packages/core/src/web/helpers/layer/deleteLayer.ts
+++ b/packages/core/src/web/helpers/layer/deleteLayer.ts
@@ -15,13 +15,7 @@ export const deleteLayerByName = (
   layerName: string,
   opts: { addToHistory?: boolean; parentCmd?: IBatchCommand } = {},
 ): ICommand | null => {
-  const layer = layerManager.getLayerByName(layerName);
-
-  if (!layer) return null;
-
-  const cmd = layer.removeGroup(opts);
-
-  return cmd;
+  return layerManager.removeLayerByName(layerName, opts);
 };
 
 export const deleteLayers = (layerNames: string[]): void => {

--- a/packages/core/src/web/helpers/layer/layer-helper.ts
+++ b/packages/core/src/web/helpers/layer/layer-helper.ts
@@ -5,7 +5,6 @@ import alertConstants from '@core/app/constants/alert-constants';
 import { CanvasElements } from '@core/app/constants/canvasElements';
 import type { LayerModuleType } from '@core/app/constants/layer-module/layer-modules';
 import { printingModules } from '@core/app/constants/layer-module/layer-modules';
-import useLayerStore from '@core/app/stores/layer/layerStore';
 import history from '@core/app/svgedit/history/history';
 import HistoryCommandFactory from '@core/app/svgedit/history/HistoryCommandFactory';
 import undoManager from '@core/app/svgedit/history/undoManager';
@@ -230,7 +229,6 @@ export const setLayerLock = (
   if (parentCmd) {
     parentCmd.addSubCommand(cmd);
   } else {
-    cmd.onAfter = () => useLayerStore.getState().forceUpdate();
     undoManager.addCommandToHistory(cmd);
   }
 
@@ -245,7 +243,6 @@ export const setLayersLock = (layerNames: string[], isLocked: boolean): IBatchCo
   }
 
   if (!batchCmd.isEmpty()) {
-    batchCmd.onAfter = () => useLayerStore.getState().forceUpdate();
     undoManager.addCommandToHistory(batchCmd);
   }
 
@@ -430,7 +427,6 @@ const insertLayerBefore = (layerName: string, anchorLayerName: string) => {
 
 export const moveLayersToPosition = (layerNames: string[], newPosition: number): void => {
   const batchCmd = new history.BatchCommand('Move Layer(s)');
-  const currentLayerName = layerManager.getCurrentLayerName()!;
 
   layerNames = sortLayerNamesByPosition(layerNames);
 
@@ -455,8 +451,8 @@ export const moveLayersToPosition = (layerNames: string[], newPosition: number):
   }
 
   if (!batchCmd.isEmpty()) {
-    layerManager.identifyLayers();
-    layerManager.setCurrentLayer(currentLayerName);
+    // resync preserves the current layer and selection across the reorder
+    layerManager.resync();
     undoManager.addCommandToHistory(batchCmd);
   }
 };
@@ -486,8 +482,7 @@ export const moveToOtherLayer = (destLayer: string, callback: () => void, showAl
     }
 
     moveSelectedToLayer(destLayer);
-    layerManager.setCurrentLayer(destLayer);
-    useLayerStore.getState().setSelectedLayers([destLayer]);
+    layerManager.setSelectedLayers([destLayer]);
     callback?.();
   };
   const selectedElements = selectionManager.getSelectedElements();


### PR DESCRIPTION
## Summary

Layer selection state was duplicated between `layerManager` (`currentLayer`) and `layerStore` (`selectedLayers`), kept in sync by convention — the `forceUpdate()` notification hack and LayerList's render-time `identifyLayers()` repair were the symptoms. This PR makes the split explicit and enforceable:

- **`layerStore` is now a passive state container** (`layers`, `currentLayerName`, `selectedLayers`, `hasVector`, `hasGradient`) with no actions. React components subscribe with selectors; nothing else.
- **`layerManager` is the single mutation API** and the only writer of the store — enforced by a new ESLint `no-restricted-syntax` rule banning `useLayerStore.setState` outside `svgedit/layer/`. `setSelectedLayers`, `checkVector`, `checkGradient` moved onto it; selection + current layer update atomically.
- **New `resync()`** rebuilds the layer list from the DOM while preserving current layer/selection (used centrally after undo/redo). This replaces `forceUpdate()` (~20 call sites), the LayerList render hack, `cmd.onAfter` sprinkles, and the redundant `setCurrentLayer`-before-`setSelectedLayers` pairs. `identifyLayers()` keeps fresh-document semantics (current → top).
- **Bug fix (second commit):** deleting a layer only detached its DOM group and left it registered, so deleting the last "Layer 1" recreated it as "Layer 1 1". New `layerManager.removeLayerByName` detaches + unregisters in one step; all deletion flows route through it, and generateCutLayer's workaround for the same bug is removed.
- **Read sweep (third commit):** the remaining imperative `useLayerStore.getState().selectedLayers` reads (~23 sites, mostly ConfigPanel blocks) now go through `layerManager.getSelectedLayers()`, so components follow one convention — subscribe via the hook, read/write via layerManager. SelLayerBlock's render-time `getState()` read (which could show a stale layer count) becomes a proper hook subscription.
- `check-vector` takes elements instead of names (breaks an import cycle); central layerStore mock is state-only; affected specs mock layerManager inline; new `layer-management` skill documents the architecture.
- **Review fixes (commits 4–5, from `/code-review`):**
  - `removeLayerByName` now maintains `selectedLayers` itself (drops the removed name, falls back to the current layer), and the mobile swipe-delete routes through `deleteLayers` — fixes a confirmed crash where deleting the last layer on mobile left the document with zero layers.
  - Deleted the remaining `identifyLayers`-during-undo sprinkles (`svgcanvas` `handleHistoryEvent`, `sliceWorkarea`'s `batchCmd.onAfter`): they reset the current layer to top *before* the central `resync()`, which then faithfully preserved the wrong value. All undo/redo flows through `history/utils`, so the central resync is the single rebuild point.
  - `buildLayersFromDom` renames duplicate layer titles on load, keeping by-name lookups unambiguous.
  - Boundary hardening: `layerStore` no longer has a default export, and a second lint selector bans importing `useLayerStore` under an alias — both rename bypasses of the setState rule are closed.
  - Dead `layerManager.mergeLayer` deleted; redundant post-delete `resync`/`setSelectedLayers` chasers removed; specs for imperative-only components seed the layerManager mock directly instead of delegating through the layerStore mock.

Deliberately deferred: porting `svgedit.utilities.copyElem` to TS (removes the last `getCurrentDrawing()` call in layer code; also benefits clipboard) — an independent follow-up.

## 摘要

圖層選取狀態原本重複存在於 `layerManager`（`currentLayer`）與 `layerStore`（`selectedLayers`），僅靠慣例同步 — `forceUpdate()` 通知 hack 與 LayerList render 時的 `identifyLayers()` 修復即為其症狀。本 PR 將職責明確劃分並加以強制：

- **`layerStore` 改為純狀態容器**（`layers`、`currentLayerName`、`selectedLayers`、`hasVector`、`hasGradient`），不再有 action；React 元件僅透過 selector 訂閱。
- **`layerManager` 成為唯一的寫入 API**：新增 ESLint 規則禁止在 `svgedit/layer/` 之外呼叫 `useLayerStore.setState`。`setSelectedLayers`、`checkVector`、`checkGradient` 移入 manager，選取與 current layer 以原子方式更新。
- **新增 `resync()`**：自 DOM 重建圖層清單並保留 current layer / 選取狀態（undo/redo 後集中呼叫），取代 `forceUpdate()`（約 20 處）、LayerList render hack、`cmd.onAfter` 散落呼叫，以及多餘的 `setCurrentLayer` 前置呼叫。`identifyLayers()` 維持「新文件」語意（current 重設為最上層）。
- **修正錯誤（第二個 commit）**：刪除圖層時僅移除 DOM group、store 仍保留註冊，導致刪除唯一的「Layer 1」後自動建立的新圖層變成「Layer 1 1」。新增 `layerManager.removeLayerByName` 一次完成移除與註銷，所有刪除流程統一經過它，並移除 generateCutLayer 針對同一問題的 workaround。
- **讀取端整理（第三個 commit）**：剩餘的命令式 `useLayerStore.getState().selectedLayers` 讀取（約 23 處，多在 ConfigPanel blocks）改為 `layerManager.getSelectedLayers()`，元件統一遵循同一慣例 — 訂閱用 hook、讀寫走 layerManager。SelLayerBlock 在 render 時的 `getState()` 讀取（可能顯示過期的圖層數）改為正式的 hook 訂閱。
- `check-vector` 改收 element 陣列（解除循環相依）；集中式 layerStore mock 改為純狀態；受影響的 spec 改以 inline 方式 mock layerManager；新增 `layer-management` skill 文件。
- **Code review 修正（第 4–5 個 commit，來自 `/code-review`）：**
  - `removeLayerByName` 現在自行維護 `selectedLayers`（移除被刪除的名稱、退回 current layer），行動版滑動刪除改走 `deleteLayers` — 修正行動版刪除最後一個圖層後文件剩零圖層的崩潰。
  - 刪除殘留的 undo 期間 `identifyLayers` 呼叫（`svgcanvas` `handleHistoryEvent`、`sliceWorkarea` 的 `batchCmd.onAfter`）：它們在集中式 `resync()` 之前就把 current layer 重設為最上層，resync 反而如實保留了錯誤的值。所有 undo/redo 都經過 `history/utils`，集中式 resync 是唯一的重建點。
  - `buildLayersFromDom` 載入時將重複的圖層名稱重新命名，確保以名稱查詢不會混淆。
  - 邊界強化：`layerStore` 移除 default export，並新增 lint 規則禁止以別名 import `useLayerStore` — 封鎖 setState 規則的兩種改名繞道。
  - 刪除無人呼叫的 `layerManager.mergeLayer`；移除刪除流程後多餘的 `resync`/`setSelectedLayers` 補呼叫；僅命令式讀取的元件其 spec 直接 seed layerManager mock，不再繞經 layerStore mock。

刻意延後處理：將 `svgedit.utilities.copyElem` 移植為 TS（移除圖層程式碼中最後一個 `getCurrentDrawing()` 呼叫，也有利於剪貼簿功能）— 為獨立的後續工作。

## Test plan

- Full core suite green: 392 suites / 2131 tests
- New regression tests: `resolveSelectionAfterResync` behavior via layerManager spec (incl. delete-then-recreate name reuse, current-layer promotion, selection maintenance on removal, duplicate-title renaming)
- Manual smoke: layer create/rename/clone/merge/delete/reorder with undo/redo each; multi-select across layers; imports; Print & Cut regenerate; Promark gradient flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

