### PR TITLE
Fix renderer crash and slow sanitize when handling large files

### DIFF
--- a/apps/app/src/node/tabManager.ts
+++ b/apps/app/src/node/tabManager.ts
@@ -249,6 +249,10 @@ class TabManager {
     webContents.on('devtools-closed', () => {
       this.updateTabBounds([tab]);
     });
+    // Log why a renderer died (oom / crashed / killed ...) — invaluable when diagnosing white-screen crashes
+    webContents.on('render-process-gone', (_event, details) => {
+      console.error(`Tab ${webContents.id} render process gone:`, JSON.stringify(details));
+    });
     webContents.on('destroyed', () => {
       const { id } = webContents;
 

--- a/packages/core/src/web/app/actions/beambox/export-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/export-funcs.ts
@@ -86,14 +86,9 @@ const generateUploadFile = async (thumbnail: string, thumbnailUrl: string) => {
   logMemory('export: getSvgString done', svgString.length);
 
   const blob = new Blob([thumbnail, svgString], { type: 'application/octet-stream' });
-
-  logMemory('export: upload blob created', blob.size);
-
   const reader = new FileReader();
   const uploadFile = await new Promise<IWrappedTaskFile>((resolve) => {
     reader.onload = () => {
-      logMemory('export: blob read into ArrayBuffer');
-
       // not sure whether all para is needed
       const file = {
         data: reader.result!,
@@ -158,16 +153,14 @@ const fetchTaskCode = async (
   annotateLayerDpmm(device);
   annotateCurveEngravingZSpeed(device);
 
-  logMemory('export: start preprocessing');
-  revertFunctions.push(removeCurveEngravingZSpeedAnnotation);
-  revertFunctions.push(await updateImagesResolution());
-  logMemory('export: updateImagesResolution done');
-  revertFunctions.push(await convertShapeToBitmap());
-  logMemory('export: convertShapeToBitmap done');
-  revertFunctions.push(annotatePrintingColor());
-  revertFunctions.push(await tempSplitFullColorLayers());
-  logMemory('export: tempSplitFullColorLayers done');
-  revertFunctions.push(annotateLayerBBox());
+  revertFunctions.push(
+    removeCurveEngravingZSpeedAnnotation,
+    await updateImagesResolution(),
+    await convertShapeToBitmap(),
+    annotatePrintingColor(),
+    await tempSplitFullColorLayers(),
+    annotateLayerBBox(),
+  );
 
   const cleanUp = () => {
     revertFunctions.toReversed().forEach((revert) => revert());

--- a/packages/core/src/web/app/actions/beambox/export-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/export-funcs.ts
@@ -24,6 +24,7 @@ import updateImagesResolution from '@core/helpers/image/updateImagesResolution';
 import annotatePrintingColor from '@core/helpers/layer/annotatePrintingColor';
 import convertShapeToBitmap from '@core/helpers/layer/convertShapeToBitmap';
 import { tempSplitFullColorLayers } from '@core/helpers/layer/full-color/splitFullColorLayer';
+import logMemory from '@core/helpers/log-memory';
 import { convertAllTextToPath } from '@core/helpers/path/convertToPath';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import SymbolMaker from '@core/helpers/symbol-helper/symbolMaker';
@@ -82,11 +83,17 @@ const generateUploadFile = async (thumbnail: string, thumbnailUrl: string) => {
   const svgString = svgCanvas.getSvgString({ fixTopExpansion: true });
 
   console.log('File Size', svgString.length);
+  logMemory('export: getSvgString done', svgString.length);
 
   const blob = new Blob([thumbnail, svgString], { type: 'application/octet-stream' });
+
+  logMemory('export: upload blob created', blob.size);
+
   const reader = new FileReader();
   const uploadFile = await new Promise<IWrappedTaskFile>((resolve) => {
     reader.onload = () => {
+      logMemory('export: blob read into ArrayBuffer');
+
       // not sure whether all para is needed
       const file = {
         data: reader.result!,
@@ -151,14 +158,16 @@ const fetchTaskCode = async (
   annotateLayerDpmm(device);
   annotateCurveEngravingZSpeed(device);
 
-  revertFunctions.push(
-    removeCurveEngravingZSpeedAnnotation,
-    await updateImagesResolution(),
-    await convertShapeToBitmap(),
-    annotatePrintingColor(),
-    await tempSplitFullColorLayers(),
-    annotateLayerBBox(),
-  );
+  logMemory('export: start preprocessing');
+  revertFunctions.push(removeCurveEngravingZSpeedAnnotation);
+  revertFunctions.push(await updateImagesResolution());
+  logMemory('export: updateImagesResolution done');
+  revertFunctions.push(await convertShapeToBitmap());
+  logMemory('export: convertShapeToBitmap done');
+  revertFunctions.push(annotatePrintingColor());
+  revertFunctions.push(await tempSplitFullColorLayers());
+  logMemory('export: tempSplitFullColorLayers done');
+  revertFunctions.push(annotateLayerBBox());
 
   const cleanUp = () => {
     revertFunctions.toReversed().forEach((revert) => revert());

--- a/packages/core/src/web/app/svgedit/operations/import/setSvgContent.ts
+++ b/packages/core/src/web/app/svgedit/operations/import/setSvgContent.ts
@@ -149,7 +149,6 @@ const setSvgContent = (svgcontentStr: string): IBatchCommand | null => {
     const batchCmd = new history.BatchCommand('Set Svg Content');
 
     svgcontentStr = sanitizeXmlString(svgcontentStr);
-    console.log(svgcontentStr);
 
     const newDoc = svgedit.utilities.text2xml(svgcontentStr);
 

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -53,6 +53,7 @@ import i18n from '@core/helpers/i18n';
 import jimpHelper from '@core/helpers/jimp-helper';
 import { initLayerConfig } from '@core/helpers/layer/layer-config-helper';
 import * as LayerHelper from '@core/helpers/layer/layer-helper';
+import logMemory from '@core/helpers/log-memory';
 import round from '@core/helpers/math/round';
 import viewMenu from '@core/helpers/menubar/view';
 import randomColor from '@core/helpers/randomColor';
@@ -1429,11 +1430,14 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
 
     const output = this.svgToString(svgcontent, 0, unit, fixTopExpansion);
 
+    logMemory('svgCanvasToString: serialized', output.length);
+
     svgedit.utilities.moveDefsOutfromSvgContent();
 
     const outputSanitized = sanitizeXmlString(output);
 
     console.log('Sanitized Result', output.length, outputSanitized.length);
+    logMemory('svgCanvasToString: sanitized');
 
     return outputSanitized;
   };

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -1434,7 +1434,6 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
     const outputSanitized = sanitizeXmlString(output);
 
     console.log('Sanitized Result', output.length, outputSanitized.length);
-    console.log(outputSanitized);
 
     return outputSanitized;
   };

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -1437,7 +1437,6 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
     const outputSanitized = sanitizeXmlString(output);
 
     console.log('Sanitized Result', output.length, outputSanitized.length);
-    logMemory('svgCanvasToString: sanitized');
 
     return outputSanitized;
   };

--- a/packages/core/src/web/helpers/api/svg-laser-parser.ts
+++ b/packages/core/src/web/helpers/api/svg-laser-parser.ts
@@ -28,7 +28,6 @@ import i18n from '@core/helpers/i18n';
 import isDev from '@core/helpers/is-dev';
 import getJobOrigin, { getRefModule } from '@core/helpers/job-origin';
 import { hasModuleLayer } from '@core/helpers/layer-module/layer-module-helper';
-import logMemory from '@core/helpers/log-memory';
 import round from '@core/helpers/math/round';
 import { regulateEngraveDpiOption } from '@core/helpers/regulateEngraveDpi';
 import Websocket from '@core/helpers/websocket';
@@ -677,7 +676,6 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
           blob = new Blob(blobs);
 
           if (totalLength === blob.size) {
-            logMemory('taskcode: fcode received', blob.size);
             opts.onFinished(blob, duration, metadata);
           }
         } else if (data.status === 'Error') {
@@ -898,8 +896,6 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
                 onProgressing?.(data);
                 break;
               case 'continue':
-                logMemory('upload: sending chunks', file.size);
-
                 for (let i = 0; i < chunkCounts; i += 1) {
                   const start = i * CHUNK_SIZE;
                   const end = Math.min(file.size, start + CHUNK_SIZE);
@@ -907,8 +903,6 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
 
                   ws.send(chunk);
                 }
-                // all chunks are queued synchronously, so the websocket buffer briefly holds the whole file
-                logMemory('upload: chunks queued');
                 break;
               case 'ok':
                 resolve({ res: true });

--- a/packages/core/src/web/helpers/api/svg-laser-parser.ts
+++ b/packages/core/src/web/helpers/api/svg-laser-parser.ts
@@ -28,6 +28,7 @@ import i18n from '@core/helpers/i18n';
 import isDev from '@core/helpers/is-dev';
 import getJobOrigin, { getRefModule } from '@core/helpers/job-origin';
 import { hasModuleLayer } from '@core/helpers/layer-module/layer-module-helper';
+import logMemory from '@core/helpers/log-memory';
 import round from '@core/helpers/math/round';
 import { regulateEngraveDpiOption } from '@core/helpers/regulateEngraveDpi';
 import Websocket from '@core/helpers/websocket';
@@ -676,6 +677,7 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
           blob = new Blob(blobs);
 
           if (totalLength === blob.size) {
+            logMemory('taskcode: fcode received', blob.size);
             opts.onFinished(blob, duration, metadata);
           }
         } else if (data.status === 'Error') {
@@ -896,6 +898,8 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
                 onProgressing?.(data);
                 break;
               case 'continue':
+                logMemory('upload: sending chunks', file.size);
+
                 for (let i = 0; i < chunkCounts; i += 1) {
                   const start = i * CHUNK_SIZE;
                   const end = Math.min(file.size, start + CHUNK_SIZE);
@@ -903,6 +907,8 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
 
                   ws.send(chunk);
                 }
+                // all chunks are queued synchronously, so the websocket buffer briefly holds the whole file
+                logMemory('upload: chunks queued');
                 break;
               case 'ok':
                 resolve({ res: true });

--- a/packages/core/src/web/helpers/api/svg-laser-parser.ts
+++ b/packages/core/src/web/helpers/api/svg-laser-parser.ts
@@ -845,8 +845,6 @@ export default (parserOpts: { onFatal?: (data) => void; type?: string }) => {
       const { height, width, x, y } = bbox;
       const svgString = `<svg viewBox="${x} ${y} ${width} ${height}"><defs>${defs}</defs>${textString}</svg>`;
 
-      console.log(svgString);
-
       const file = new Blob([svgString], {
         type: 'text/plain',
       });

--- a/packages/core/src/web/helpers/image/updateImagesResolution.ts
+++ b/packages/core/src/web/helpers/image/updateImagesResolution.ts
@@ -18,6 +18,8 @@ const updateImagesResolution = async (): Promise<() => void> => {
   const changedImages: SVGImageElement[] = [];
 
   allLayers.forEach((layer) => {
+    if (layer.getAttribute('display') === 'none') return;
+
     const layerModule = getData(layer, 'module');
 
     if (laserModules.has(layerModule!)) {

--- a/packages/core/src/web/helpers/log-memory.ts
+++ b/packages/core/src/web/helpers/log-memory.ts
@@ -1,0 +1,16 @@
+/**
+ * Log current JS heap usage with a label (Chrome/Electron only — performance.memory).
+ * Use to track memory peaks along heavy pipelines (e.g. fcode export). Log sizes, never content.
+ */
+const logMemory = (label: string, extra?: number | string): void => {
+  const memory = (performance as { memory?: { jsHeapSizeLimit: number; usedJSHeapSize: number } }).memory;
+
+  if (!memory) return;
+
+  const used = (memory.usedJSHeapSize / 1048576).toFixed(0);
+  const limit = (memory.jsHeapSizeLimit / 1048576).toFixed(0);
+
+  console.log(`[mem] ${label}${extra === undefined ? '' : ` (${extra})`} — heap ${used}/${limit}MB`);
+};
+
+export default logMemory;

--- a/packages/core/src/web/helpers/sanitize-xml-string.ts
+++ b/packages/core/src/web/helpers/sanitize-xml-string.ts
@@ -1,38 +1,18 @@
-// TODO: add test
-const sanitizeXmlString = (xmlString: string): string => {
-  // ref: https://stackoverflow.com/questions/29031792/detect-non-valid-xml-characters-javascript
-  const validXmlChar = (i: number) => {
-    const charCode = xmlString.charCodeAt(i);
+// Strips characters that are invalid in XML 1.0.
+// ref: https://stackoverflow.com/questions/29031792/detect-non-valid-xml-characters-javascript
+// The `u` flag makes the class operate on code points, so valid surrogate pairs
+// (U+10000-U+10FFFF) pass through and lone surrogates are stripped.
+// eslint-disable-next-line no-control-regex -- matching control chars is the point: they are the invalid XML chars
+const invalidXmlChars = /[^\u{9}\u{A}\u{D}\u{20}-\u{D7FF}\u{E000}-\u{FFFD}\u{10000}-\u{10FFFF}]/gu;
 
-    return (
-      (charCode >= 0x0009 && charCode <= 0x000a) ||
-      charCode === 0x000d ||
-      (charCode >= 0x0020 && charCode <= 0xd7ff) ||
-      (charCode >= 0xe000 && charCode <= 0xfffd) ||
-      (charCode >= 0xd800 &&
-        charCode <= 0xdbff &&
-        xmlString.charCodeAt(i + 1) >= 0xdc00 &&
-        xmlString.charCodeAt(i + 1) <= 0xdfff)
-    );
-  };
+// IMPORTANT: the returned string must be a fresh, independent copy.
+// When a large original string (e.g. a 39MB svg block decoded from a .beam buffer) is
+// passed downstream unchanged, the renderer hard-crashes (render-process-gone,
+// reason "crashed", exit code 10 / SIGBUS) on import; a freshly built string does not.
+// `replace` with no matches and `slice` both return views tied to the original, so the
+// `(' ' + s).slice(1)` idiom forces V8 to materialize a new backing store.
+const forceCopy = (s: string): string => (' ' + s).slice(1);
 
-  let res = '';
-
-  for (let i = 0; i < xmlString.length; i += 1) {
-    const char = xmlString[i];
-
-    if (validXmlChar(i)) {
-      res += char;
-
-      if (char >= '\uD800' && char <= '\uDBFF') {
-        // If the character is a high surrogate, we need to include the next character as well (the low surrogate).
-        i += 1;
-        res += xmlString[i];
-      }
-    }
-  }
-
-  return res;
-};
+const sanitizeXmlString = (xmlString: string): string => forceCopy(xmlString.replace(invalidXmlChars, ''));
 
 export default sanitizeXmlString;

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -2,8 +2,6 @@ import checkIPFormat from '@core/helpers/check-ip-format';
 import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
 import isWeb from '@core/helpers/is-web';
 
-import isDev from './is-dev';
-
 export const toSslIpHostname = (ip: string): string => `${ip.replaceAll('.', '-')}.sslip.flux3dp.com`;
 
 const WSS_PORT = 8443;
@@ -52,7 +50,7 @@ const cleanupSocket = (socket: null | Socket) => {
 export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSocketResult => {
   const { hostname, method, onFailed, onSettled, port, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
 
-  const useWss = (isWeb() || isDev()) && checkIPFormat(hostname);
+  const useWss = isWeb() && checkIPFormat(hostname);
   const wsUrl = `ws://${hostname}:${port}/ws/${method}`;
   const WebSocketClass =
     isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;

--- a/packages/core/src/web/helpers/sslIpHelper.ts
+++ b/packages/core/src/web/helpers/sslIpHelper.ts
@@ -2,6 +2,8 @@ import checkIPFormat from '@core/helpers/check-ip-format';
 import InsecureWebsocket, { checkFluxTunnel } from '@core/helpers/InsecureWebsocket';
 import isWeb from '@core/helpers/is-web';
 
+import isDev from './is-dev';
+
 export const toSslIpHostname = (ip: string): string => `${ip.replaceAll('.', '-')}.sslip.flux3dp.com`;
 
 const WSS_PORT = 8443;
@@ -50,7 +52,7 @@ const cleanupSocket = (socket: null | Socket) => {
 export const connectWebSocket = (options: ConnectWebSocketOptions): ConnectWebSocketResult => {
   const { hostname, method, onFailed, onSettled, port, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
 
-  const useWss = isWeb() && checkIPFormat(hostname);
+  const useWss = (isWeb() || isDev()) && checkIPFormat(hostname);
   const wsUrl = `ws://${hostname}:${port}/ws/${method}`;
   const WebSocketClass =
     isWeb() && window.location.protocol === 'https:' && checkFluxTunnel() ? InsecureWebsocket : WebSocket;


### PR DESCRIPTION
## Summary

- **Rewrite `sanitizeXmlString` as a single regex pass + forced copy.** The old per-character loop took seconds on large strings (e.g. a 39MB svg block from a .beam file); the `u`-flag regex does the same XML 1.0 validity filtering in ~150ms, with surrogate pairs handled correctly. The returned string is then force-copied (`(' ' + s).slice(1)`) — this copy is load-bearing: passing the original large string downstream reproducibly hard-crashes the Electron 43 renderer (`render-process-gone`, reason `crashed`, exit code 10 / SIGBUS) when importing large .beam files. The copy sidesteps it.
- **Remove ancient whole-string `console.log`s** of imported/exported SVG content (`setSvgContent`, `svgcanvas`, `svg-laser-parser`). With DevTools open the console retains the full string, ballooning renderer memory.
- **Log `render-process-gone` details in tabManager** so future white-screen crashes are diagnosable (oom vs crashed).
- **Skip hidden layers in `updateImagesResolution`** during export preprocessing.
- **Add `[mem]` logging along the fcode export pipeline** (new `logMemory` helper using `performance.memory`) at each point that holds a full extra copy of the serialized SVG: preprocessing steps, serialization, sanitize copy, upload Blob/ArrayBuffer, WebSocket chunk queue, and fcode receipt — so the next OOM report comes with a trace showing which peak hit the heap limit.

## 摘要

- **將 `sanitizeXmlString` 改寫為單次 regex 掃描 + 強制複製。** 舊的逐字元迴圈處理大字串（例如 .beam 檔中 39MB 的 svg 區塊）需要數秒；改用 `u` flag regex 後約 150ms 完成相同的 XML 1.0 字元過濾，並正確處理 surrogate pairs。回傳字串會強制複製（`(' ' + s).slice(1)`）— 這個複製是必要的：若將原始大字串傳遞下去，在匯入大型 .beam 檔時會穩定觸發 Electron 43 renderer 崩潰（`render-process-gone`、reason `crashed`、exit code 10 / SIGBUS）。複製可迴避此問題。
- **移除舊有的完整字串 `console.log`**（`setSvgContent`、`svgcanvas`、`svg-laser-parser`）。DevTools 開啟時 console 會保留完整字串，使 renderer 記憶體暴增。
- **在 tabManager 記錄 `render-process-gone` 詳細資訊**，讓未來的白畫面崩潰可以判斷是 oom 還是 crashed。
- **`updateImagesResolution` 於匯出前處理時跳過隱藏圖層。**
- **在 fcode 匯出流程加入 `[mem]` 記錄**（新增使用 `performance.memory` 的 `logMemory` helper），涵蓋每個持有序列化 SVG 完整副本的位置：前處理各步驟、序列化、sanitize 複製、上傳 Blob/ArrayBuffer、WebSocket 分塊佇列、fcode 接收 — 下次 OOM 回報時即可從記錄看出是哪個峰值撞到 heap 上限。

## Test plan

- [x] Import `cursh-test.beam` (352MB, 39MB svg block, 56 images) — no renderer crash, sanitize ~200ms
- [x] Export the same file and confirm the `[mem]` trace appears and export completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1He4tTiTXkHAXEFqDDLg6