### PR TITLE
Ship and silently install the VC++ redistributable for Swiftray on Windows

### DIFF
--- a/.github/workflows/app.cd.x64.yml
+++ b/.github/workflows/app.cd.x64.yml
@@ -116,6 +116,9 @@ jobs:
           mv ./swiftray ./backend
           rm ./swiftray.zip
 
+          # VC++ 2015-2022 runtime required by Swiftray, installed by win-install.nsh
+          curl.exe -L https://aka.ms/vs/17/release/vc_redist.x64.exe --output ./backend/VC_redist.x64.exe
+
           cp -R ./util/win64 ./utils
 
           bash ./build/clearup-develop-files.sh

--- a/apps/app/win-install.nsh
+++ b/apps/app/win-install.nsh
@@ -3,7 +3,14 @@
   ; VC++ 2015-2022 runtime (v14.x) required by Swiftray. Bundled installer is a no-op
   ; when an equal or newer runtime is present (exit 1638), so just always run it.
   ${If} ${FileExists} "$INSTDIR\resources\backend\VC_redist.x64.exe"
-    ExecWait '"$INSTDIR\resources\backend\VC_redist.x64.exe" /install /passive /norestart' $R5
+    ; electron-builder sets "SetDetailsPrint none" for the whole section, so both the
+    ; status line and the log are silent by default. textonly keeps our message on the
+    ; status line; listonly stops ExecWait's own line from overwriting it there.
+    SetDetailsPrint textonly
+    DetailPrint "Installing Microsoft Visual C++ Redistributable..."
+    SetDetailsPrint listonly
+    ExecWait '"$INSTDIR\resources\backend\VC_redist.x64.exe" /install /quiet /norestart' $R5
+    SetDetailsPrint none
     ${If} $R5 == 0
     ${ElseIf} $R5 == 1638 ; newer runtime already installed
     ${ElseIf} $R5 == 3010 ; installed, reboot pending

--- a/apps/app/win-install.nsh
+++ b/apps/app/win-install.nsh
@@ -1,31 +1,14 @@
 
 !macro customInstall
-  ${If} ${RunningX64}
-    StrCpy $R1 "SOFTWARE\Classes\Installer\Dependencies\{d992c12e-cab2-426f-bde3-fb8c53950b0d}"
-    StrCpy $R2 "$INSTDIR\resources\backend\VC_redist.x64.exe /passive"
-    StrCpy $R3 "$INSTDIR\resources\backend\UsbDriver\dpinst_x64.exe /SW"
-  ${Else}
-    StrCpy $R1 "SOFTWARE\Classes\Installer\Dependencies\{e2803110-78b3-4664-a479-3611a381656a}"
-    StrCpy $R2 "$INSTDIR\resources\backend\VC_redist.x32.exe /passive"
-    StrCpy $R3 "$INSTDIR\resources\backend\UsbDriver\dpinst_x32.exe /SW"
-  ${EndIf}
-
-  ReadRegDword $R4 HKLM $R1 "DisplayName"
-
-  ${If} $R4 == ""
-    ExecWait $R2 $R5
-    ${If} $R5 == 1638
-    ${ElseIf} $R5 > 0
-      MessageBox MB_OK "Visual C++ Redistributable install failed. Maybe you have to install manually. (Return $R5)"
+  ; VC++ 2015-2022 runtime (v14.x) required by Swiftray. Bundled installer is a no-op
+  ; when an equal or newer runtime is present (exit 1638), so just always run it.
+  ${If} ${FileExists} "$INSTDIR\resources\backend\VC_redist.x64.exe"
+    ExecWait '"$INSTDIR\resources\backend\VC_redist.x64.exe" /install /passive /norestart' $R5
+    ${If} $R5 == 0
+    ${ElseIf} $R5 == 1638 ; newer runtime already installed
+    ${ElseIf} $R5 == 3010 ; installed, reboot pending
     ${Else}
+      MessageBox MB_OK "Visual C++ Redistributable install failed. Maybe you have to install manually. (Return $R5)"
     ${EndIf}
-  ${Else}
-  ${EndIf}
-
-  ExecWait $R3 $R5
-  ${If} $R5 == 1638
-  ${ElseIf} $R5 > 0
-      MessageBox MB_OK "FLUX USB Link Cable driver install failed. Maybe you have to install manually. (Return $R5)"
-  ${Else}
   ${EndIf}
 !macroend


### PR DESCRIPTION
## Summary

Swiftray needs the Microsoft Visual C++ 2015–2022 runtime, and Windows users without it hit a failure when Swiftray starts.

`win-install.nsh` already referenced `resources/backend/VC_redist.x64.exe`, but nothing in the repo or CI ever produced that file — `apps/app/backend/` is gitignored and assembled during the Windows CD. NSIS set the error flag on the missing `ExecWait`, left `$R5` empty, and the `$R5 > 0` check read the empty string as `0`, so the failure was completely silent.

**Changes**

- Fetch the evergreen VC++ 2015–2022 x64 redistributable into `backend/` during the Windows CD, next to the existing swiftray download. One redistributable covers everything built with MSVC 2015 through 2022 — they share one binary-compatible 14.x runtime — so there is nothing to pin or track.
- Install with `/quiet` rather than `/passive` so users see one installer window instead of two.
- Label the step on the installer's status line, since `ExecWait` blocks with no visible progress once the child window is gone.
- Treat `3010` (installed, reboot pending) as success rather than an error.
- Drop the `dpinst` USB driver block: it installed the FLUX Delta USB Link Cable driver (added 2017), whose `UsbDriver/` payload never migrated to the monorepo. USB machine setup is IP-over-USB now (`ConnectUsb.tsx` hands off to `connect-machine-ip?usb=1`), and DPInst itself is deprecated in favour of `pnputil`.

**Testing**

Verified on a Windows machine: the redistributable installs, no second installer window appears, and the status line shows the step. Worth watching on the first CD run that `curl.exe -L` follows the `aka.ms` redirect to a real ~25MB binary rather than saving an HTML stub — the `${FileExists}` guard would otherwise skip silently.

## 摘要

Swiftray 需要 Microsoft Visual C++ 2015–2022 執行階段，沒有安裝的 Windows 使用者在 Swiftray 啟動時會失敗。

`win-install.nsh` 原本就有引用 `resources/backend/VC_redist.x64.exe`，但 repo 和 CI 都沒有產生這個檔案（`apps/app/backend/` 被 gitignore，由 Windows CD 組出來）。NSIS 對不存在的 `ExecWait` 設了 error flag，`$R5` 維持空字串，而 `$R5 > 0` 把空字串當成 `0`，所以整個失敗是無聲的。

**變更**

- 在 Windows CD 中把常青版的 VC++ 2015–2022 x64 redistributable 下載到 `backend/`，位置就在既有的 swiftray 下載旁邊。單一 redistributable 就涵蓋 MSVC 2015 到 2022 建置的所有東西（共用同一套二進位相容的 14.x runtime），所以不需要固定版本或追蹤。
- 用 `/quiet` 而非 `/passive`，使用者只會看到一個安裝視窗。
- 把 `3010`（已安裝，待重開機）視為成功而非錯誤。
- 移除 `dpinst` USB 驅動程式區塊：它安裝的是 FLUX Delta USB Link Cable 驅動程式（2017 年加入），其 `UsbDriver/` 檔案從未遷移到 monorepo。現在 USB 連線走的是 IP-over-USB（`ConnectUsb.tsx` 導向 `connect-machine-ip?usb=1`），而 DPInst 本身也已被 `pnputil` 取代。

**測試**

已在 Windows 機器上驗證：redistributable 安裝成功、不會出現第二個安裝視窗、狀態列會顯示該步驟。第一次 CD 執行時值得確認 `curl.exe -L` 有跟隨 `aka.ms` 轉址並取得約 25MB 的真實二進位檔，而不是存成 HTML stub——否則 `${FileExists}` 會無聲地略過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAPnXckGzMJzJHyMFcZ681
