### PR TITLE
Update camera timeout for fisheye models

### DIFF
--- a/packages/core/src/web/app/actions/beambox/constant.ts
+++ b/packages/core/src/web/app/actions/beambox/constant.ts
@@ -30,6 +30,9 @@ export const fcodeV2Models = new Set(fcodeV2ModelsArray);
 export const supportAutoFocusModelsArray = ['fhexa1', ...adorModelsArray, 'fbb2', 'fhx2rf'] as const;
 export const supportAutoFocusModels = new Set(supportAutoFocusModelsArray);
 
+export const fisheyeModelsArray = [...adorModelsArray, 'fbb2', 'fhx2rf'] as const;
+export const fisheyeModels = new Set<string>(fisheyeModelsArray);
+
 export const supportCameraAutoExposureModels = ['fhx2rf', 'fbb2', 'fbm2'] as const;
 export const modelsWithWideAngleCamera: WorkAreaModel[] = ['fbb2', 'fhx2rf'] as const;
 

--- a/packages/core/src/web/helpers/api/camera.ts
+++ b/packages/core/src/web/helpers/api/camera.ts
@@ -7,7 +7,7 @@ import type { Observable } from 'rxjs';
 import { EmptyError, from, lastValueFrom, partition, Subject } from 'rxjs';
 import { concatMap, filter, map, take, timeout } from 'rxjs/operators';
 
-import constant from '@core/app/actions/beambox/constant';
+import constant, { fisheyeModels } from '@core/app/actions/beambox/constant';
 import Progress from '@core/app/actions/progress-caller';
 import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { getWorkarea } from '@core/app/constants/workarea-constants';
@@ -24,6 +24,8 @@ import type {
 import type { IDeviceInfo } from '@core/interfaces/IDevice';
 
 const TIMEOUT = 120000;
+// fisheye models transmit larger images; 2 min is not enough for IMAGE_TRANSMISSION_FAIL_THRESHOLD retries
+const FISHEYE_TIMEOUT = 300000;
 const IMAGE_TRANSMISSION_FAIL_THRESHOLD = 20;
 const CAMERA_CABLE_ALERT_THRESHOLD = 10;
 
@@ -79,6 +81,10 @@ class Camera {
   private lastRequireCommand = '';
   private commandQueue: PQueue;
 
+  private get imageTimeout(): number {
+    return fisheyeModels.has(this.device.model ?? '') ? FISHEYE_TIMEOUT : TIMEOUT;
+  }
+
   constructor(shouldCrop = true, cameraNeedFlip: boolean | null = null) {
     this.commandQueue = new PQueue({ concurrency: 1 });
     this.shouldCrop = shouldCrop;
@@ -110,7 +116,7 @@ class Camera {
               Progress.openNonstopProgress({
                 id: 'connect-camera',
                 message: t.connectingCamera,
-                timeout: TIMEOUT,
+                timeout: this.imageTimeout,
               });
             }
 
@@ -407,7 +413,7 @@ class Camera {
       this.lastRequireCommand = useLowResolution ? 'require_frame l' : 'require_frame';
       this.ws.send(this.lastRequireCommand);
 
-      const data = await lastValueFrom(this.source.pipe(take(1)).pipe(timeout(TIMEOUT)));
+      const data = await lastValueFrom(this.source.pipe(take(1)).pipe(timeout(this.imageTimeout)));
 
       return data;
     } catch (error) {
@@ -419,7 +425,7 @@ class Camera {
         error.message = `${t.camera.fail_to_transmit_image} ${error.message}`;
         throw error;
       } else {
-        throw new TypeError(`${t.camera.ws_closed_unexpectedly} ${(error as any).message}`);
+        throw new TypeError(`${t.camera.ws_closed_unexpectedly}\n${(error as any).message}`);
       }
     }
   }
@@ -431,7 +437,7 @@ class Camera {
   getLiveStreamSource() {
     this.ws.send('enable_streaming');
 
-    return this.source.pipe(timeout(TIMEOUT));
+    return this.source.pipe(timeout(this.imageTimeout));
   }
 
   closeWs(): void {


### PR DESCRIPTION
Currently camera timeout 120000ms is not enough for fisheye camera models to show `IMAGE_TRANSMISSION_FAIL_THRESHOLD` error message
update to 5 min

https://flux3dp.slack.com/archives/C2KV9ULLC/p1787218050173879