### PR TITLE
Fix rubber-band multiselect selecting hollow shapes by bbox overlap

### DIFF
--- a/apps/web/cypress/e2e/modify/offset-result.spec.ts
+++ b/apps/web/cypress/e2e/modify/offset-result.spec.ts
@@ -35,9 +35,12 @@ const drawEllipse = (x1: number, y1: number, x2: number, y2: number) => {
   cy.getElementTitle().should('have.text', 'Layer 1 > Oval');
   // Switching to Cursor drops the selection; rubber-band re-select (unfilled oval has no
   // clickable interior) so the dimension panel shows.
+  const rx = x2 - x1;
+  const ry = y2 - y1;
+  const margin = 10; // rubber-band select safe margin
   cy.clickToolBtn('Cursor');
-  cy.get('svg#svgcontent').trigger('mousedown', x1 - 20, y1 - 20, { force: true });
-  cy.get('svg#svgcontent').trigger('mousemove', x2 + 20, y2 + 20, { force: true });
+  cy.get('svg#svgcontent').trigger('mousedown', x1 - rx - margin, y1 - ry - margin, { force: true });
+  cy.get('svg#svgcontent').trigger('mousemove', x2 + margin, y2 + margin, { force: true });
   cy.get('svg#svgcontent').trigger('mouseup', { force: true });
   cy.getElementTitle().should('have.text', 'Layer 1 > Oval');
 };

--- a/apps/web/cypress/e2e/modify/offset-result.spec.ts
+++ b/apps/web/cypress/e2e/modify/offset-result.spec.ts
@@ -53,10 +53,7 @@ const runOffset = (direction: 'inward' | 'outward', distance: number) => {
   // Direction Select has no testid — locate it by the field whose label is "Offset Direction".
   const label = direction === 'outward' ? 'Outward' : 'Inward';
 
-  cy.contains('span', 'Offset Direction')
-    .parent()
-    .find('.ant-select')
-    .click();
+  cy.contains('span', 'Offset Direction').parent().find('.ant-select').click();
   cy.get('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
     .find('.ant-select-item-option')
     .contains(label)
@@ -202,7 +199,7 @@ describe('offset result correctness', () => {
 
   it('compound (concentric rects): outward offset follows only the outer outline', () => {
     // Outer rect (larger)
-    drawRect(80, 80, 320, 320);
+    drawRect(80, 80, 500, 500);
     cy.showPanel('objects');
 
     let outerW = 0;

--- a/apps/web/cypress/e2e/modify/offset-result.spec.ts
+++ b/apps/web/cypress/e2e/modify/offset-result.spec.ts
@@ -216,8 +216,8 @@ describe('offset result correctness', () => {
 
     // Multi-select both rects
     cy.clickToolBtn('Cursor');
-    cy.get('svg#svgcontent').trigger('mousedown', 40, 40, { force: true });
-    cy.get('svg#svgcontent').trigger('mousemove', 360, 360, { force: true });
+    cy.get('svg#svgcontent').trigger('mousedown', 75, 75, { force: true });
+    cy.get('svg#svgcontent').trigger('mousemove', 505, 505, { force: true });
     cy.get('svg#svgcontent').trigger('mouseup', { force: true });
     cy.findAllByText('Multiple Objects').should('exist');
     cy.showPanel('objects');

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -12,6 +12,7 @@
 // -- This is a parent command --
 
 const setStorage = () => {
+  window.localStorage.setItem('active-lang', '"en"');
   window.localStorage.setItem('printer-is-ready', 'true');
   window.localStorage.setItem('keep-flux-id-login', 'true');
   window.localStorage.setItem('enable-sentry', 'false');

--- a/apps/web/src/global.ts
+++ b/apps/web/src/global.ts
@@ -44,7 +44,6 @@ declare global {
         hasMatrixTransform: (tlist: any) => boolean;
         isIdentity: (m: SVGMatrix) => boolean;
         matrixMultiply: (...matr: SVGMatrix[]) => SVGMatrix;
-        rectsIntersect: (r1: SVGRect, r2: SVGRect) => boolean;
         roundToDefault: (val: number) => number;
         roundToDigit: (val: number, digit?: number) => number;
         snapToAngle: (

--- a/packages/core/public/js/lib/svgeditor/math.js
+++ b/packages/core/public/js/lib/svgeditor/math.js
@@ -13,223 +13,225 @@
 // None.
 
 /**
-* @typedef AngleCoord
-* @type {object}
-* @property {number} x - The angle-snapped x value
-* @property {number} y - The angle-snapped y value
-* @property {number} a - The angle at which to snap
-*/
-
-(function() {'use strict';
-
-if (!svgedit.math) {
-	svgedit.math = {};
-}
-
-// Constants
-var NEAR_ZERO = 1e-14;
-const DEFAULT_DIGIT = 7;
-
-// Throw away SVGSVGElement used for creating matrices/transforms.
-var svg = document.createElementNS(svgedit.NS.SVG, 'svg');
-
-const roundToDigit = (val, digit = DEFAULT_DIGIT) => {
-  const factor = 10 ** digit;
-  return Math.round((val + Number.EPSILON) * factor) / factor;
-};
-svgedit.math.roundToDigit = roundToDigit;
-
-const roundToDefault = (val) => roundToDigit(val);
-svgedit.math.roundToDefault = roundToDefault;
-
-/**
- * A (hopefully) quicker function to transform a point by a matrix
- * (this function avoids any DOM calls and just does the math)
- * @param {number} x - Float representing the x coordinate
- * @param {number} y - Float representing the y coordinate
- * @param {SVGMatrix} m - Matrix object to transform the point with
- * @returns {object} An x, y object representing the transformed point
-*/
-svgedit.math.transformPoint = function (x, y, m) {
-	return { x: roundToDefault(m.a * x + m.c * y + m.e), y: roundToDefault(m.b * x + m.d * y + m.f) };
-};
-
-
-/**
- * Helper function to check if the matrix performs no actual transform
- * (i.e. exists for identity purposes)
- * @param {SVGMatrix} m - The matrix object to check
- * @returns {boolean} Indicates whether or not the matrix is 1,0,0,1,0,0
-*/
-svgedit.math.isIdentity = function (m) {
-	return (m.a === 1 && m.b === 0 && m.c === 0 && m.d === 1 && m.e === 0 && m.f === 0);
-};
-
-
-/**
- * This function tries to return a SVGMatrix that is the multiplication m1*m2.
- * We also round to zero when it's near zero
- * @param {...SVGMatrix} matr - Two or more matrix objects to multiply
- * @returns {SVGMatrix} The matrix object resulting from the calculation
-*/
-svgedit.math.matrixMultiply = function (matr) {
-	var args = arguments, i = args.length, m = args[i-1];
-
-	while (i-- > 1) {
-		var m1 = args[i-1];
-		m = m1.multiply(m);
-	}
-	if (Math.abs(m.a) < NEAR_ZERO) {m.a = 0;}
-	if (Math.abs(m.b) < NEAR_ZERO) {m.b = 0;}
-	if (Math.abs(m.c) < NEAR_ZERO) {m.c = 0;}
-	if (Math.abs(m.d) < NEAR_ZERO) {m.d = 0;}
-	if (Math.abs(m.e) < NEAR_ZERO) {m.e = 0;}
-	if (Math.abs(m.f) < NEAR_ZERO) {m.f = 0;}
-
-	return m;
-};
-
-/**
- * See if the given transformlist includes a non-indentity matrix transform
- * @param {object} [tlist] - The transformlist to check
- * @returns {boolean} Whether or not a matrix transform was found
-*/
-svgedit.math.hasMatrixTransform = function (tlist) {
-	if (!tlist) {return false;}
-	var num = tlist.numberOfItems;
-	while (num--) {
-		var xform = tlist.getItem(num);
-		if (xform.type == 1 && !svgedit.math.isIdentity(xform.matrix)) {return true;}
-	}
-	return false;
-};
-
-/**
- * Transforms a rectangle based on the given matrix
- * @param {number} l - Float with the box's left coordinate
- * @param {number} t - Float with the box's top coordinate
- * @param {number} w - Float with the box width
- * @param {number} h - Float with the box height
- * @param {SVGMatrix} m - Matrix object to transform the box by
- * @returns {object} An object with the following values:
- * tl - The top left coordinate (x,y object)
- * tr - The top right coordinate (x,y object)
- * bl - The bottom left coordinate (x,y object)
- * br - The bottom right coordinate (x,y object)
- * aabox - Object with the following values:
- * x - Float with the axis-aligned x coordinate
- * y - Float with the axis-aligned y coordinate
- * width - Float with the axis-aligned width coordinate
- * height - Float with the axis-aligned height coordinate
-*/
-svgedit.math.transformBox = function (l, t, w, h, m) {
-	var transformPoint = svgedit.math.transformPoint,
-
-		tl = transformPoint(l, t, m),
-		tr = transformPoint((l + w), t, m),
-		bl = transformPoint(l, (t + h), m),
-		br = transformPoint((l + w), (t + h), m),
-
-		minx = Math.min(tl.x, tr.x, bl.x, br.x),
-		maxx = Math.max(tl.x, tr.x, bl.x, br.x),
-		miny = Math.min(tl.y, tr.y, bl.y, br.y),
-		maxy = Math.max(tl.y, tr.y, bl.y, br.y);
-
-	return {
-		tl: tl,
-		tr: tr,
-		bl: bl,
-		br: br,
-		aabox: {
-			x: minx,
-			y: miny,
-			width: (maxx - minx),
-			height: (maxy - miny)
-		}
-	};
-};
-
-/**
- * This returns a single matrix Transform for a given Transform List
- * (this is the equivalent of SVGTransformList.consolidate() but unlike
- * that method, this one does not modify the actual SVGTransformList)
- * This function is very liberal with its min, max arguments
- * @param {object} tlist - The transformlist object
- * @param {integer} [min=0] - Optional integer indicating start transform position
- * @param {integer} [max] - Optional integer indicating end transform position;
- *   defaults to one less than the tlist's numberOfItems
- * @returns {object} A single matrix transform object
-*/
-svgedit.math.transformListToTransform = function (tlist, min, max) {
-	if (tlist == null) {
-		// Or should tlist = null have been prevented before this?
-		return svg.createSVGTransformFromMatrix(svg.createSVGMatrix());
-	}
-	min = min || 0;
-	max = max || (tlist.numberOfItems - 1);
-	min = parseInt(min, 10);
-	max = parseInt(max, 10);
-	if (min > max) { var temp = max; max = min; min = temp; }
-	var m = svg.createSVGMatrix();
-	var i;
-	for (i = min; i <= max; ++i) {
-		// if our indices are out of range, just use a harmless identity matrix
-		var mtom = (i >= 0 && i < tlist.numberOfItems ?
-						tlist.getItem(i).matrix :
-						svg.createSVGMatrix());
-		m = svgedit.math.matrixMultiply(m, mtom);
-	}
-	return svg.createSVGTransformFromMatrix(m);
-};
-
-
-/**
- * Get the matrix object for a given element
- * @param {Element} elem - The DOM element to check
- * @returns {SVGMatrix} The matrix object associated with the element's transformlist
-*/
-svgedit.math.getMatrix = function (elem) {
-	var tlist = svgedit.transformlist.getTransformList(elem, false);
-	return svgedit.math.transformListToTransform(tlist).matrix;
-};
-
-
-/**
- * Returns a 45 degree angle coordinate associated with the two given
- * coordinates
- * @param {number} x1 - First coordinate's x value
- * @param {number} y1 - First coordinate's y value
- * @param {number} x2 - Second coordinate's x value
- * @param {number} y2 - Second coordinate's y value
- * @param {number} snap - Snap unit (rad)
- * @returns {AngleCoord}
-*/
-svgedit.math.snapToAngle = function (x1, y1, x2, y2, snap = Math.PI / 2) {
-	var dx = x2 - x1;
-	var dy = y2 - y1;
-	var angle = Math.atan2(dy, dx);
-	var dist = Math.sqrt(dx * dx + dy * dy);
-	var snapangle = Math.round(angle / snap) * snap;
-
-	return {
-		x: x1 + dist * Math.cos(snapangle),
-		y: y1 + dist * Math.sin(snapangle),
-		a: snapangle
-	};
-};
-
-
-/**
- * Check if two rectangles (BBoxes objects) intersect each other
- * @param {SVGRect} r1 - The first BBox-like object
- * @param {SVGRect} r2 - The second BBox-like object
- * @returns {boolean} True if rectangles intersect
+ * @typedef AngleCoord
+ * @type {object}
+ * @property {number} x - The angle-snapped x value
+ * @property {number} y - The angle-snapped y value
+ * @property {number} a - The angle at which to snap
  */
-svgedit.math.rectsIntersect = function (r1, r2) {
-	return r2.x < (r1.x + r1.width) &&
-		(r2.x + r2.width) > r1.x &&
-		r2.y < (r1.y + r1.height) &&
-		(r2.y + r2.height) > r1.y;
-};
 
-}());
+(
+  (function () {
+    'use strict';
+
+    if (!svgedit.math) {
+      svgedit.math = {};
+    }
+
+    // Constants
+    var NEAR_ZERO = 1e-14;
+    const DEFAULT_DIGIT = 7;
+
+    // Throw away SVGSVGElement used for creating matrices/transforms.
+    var svg = document.createElementNS(svgedit.NS.SVG, 'svg');
+
+    const roundToDigit = (val, digit = DEFAULT_DIGIT) => {
+      const factor = 10 ** digit;
+      return Math.round((val + Number.EPSILON) * factor) / factor;
+    };
+    svgedit.math.roundToDigit = roundToDigit;
+
+    const roundToDefault = (val) => roundToDigit(val);
+    svgedit.math.roundToDefault = roundToDefault;
+
+    /**
+     * A (hopefully) quicker function to transform a point by a matrix
+     * (this function avoids any DOM calls and just does the math)
+     * @param {number} x - Float representing the x coordinate
+     * @param {number} y - Float representing the y coordinate
+     * @param {SVGMatrix} m - Matrix object to transform the point with
+     * @returns {object} An x, y object representing the transformed point
+     */
+    svgedit.math.transformPoint = function (x, y, m) {
+      return { x: roundToDefault(m.a * x + m.c * y + m.e), y: roundToDefault(m.b * x + m.d * y + m.f) };
+    };
+
+    /**
+     * Helper function to check if the matrix performs no actual transform
+     * (i.e. exists for identity purposes)
+     * @param {SVGMatrix} m - The matrix object to check
+     * @returns {boolean} Indicates whether or not the matrix is 1,0,0,1,0,0
+     */
+    svgedit.math.isIdentity = function (m) {
+      return m.a === 1 && m.b === 0 && m.c === 0 && m.d === 1 && m.e === 0 && m.f === 0;
+    };
+
+    /**
+     * This function tries to return a SVGMatrix that is the multiplication m1*m2.
+     * We also round to zero when it's near zero
+     * @param {...SVGMatrix} matr - Two or more matrix objects to multiply
+     * @returns {SVGMatrix} The matrix object resulting from the calculation
+     */
+    svgedit.math.matrixMultiply = function (matr) {
+      var args = arguments,
+        i = args.length,
+        m = args[i - 1];
+
+      while (i-- > 1) {
+        var m1 = args[i - 1];
+        m = m1.multiply(m);
+      }
+      if (Math.abs(m.a) < NEAR_ZERO) {
+        m.a = 0;
+      }
+      if (Math.abs(m.b) < NEAR_ZERO) {
+        m.b = 0;
+      }
+      if (Math.abs(m.c) < NEAR_ZERO) {
+        m.c = 0;
+      }
+      if (Math.abs(m.d) < NEAR_ZERO) {
+        m.d = 0;
+      }
+      if (Math.abs(m.e) < NEAR_ZERO) {
+        m.e = 0;
+      }
+      if (Math.abs(m.f) < NEAR_ZERO) {
+        m.f = 0;
+      }
+
+      return m;
+    };
+
+    /**
+     * See if the given transformlist includes a non-indentity matrix transform
+     * @param {object} [tlist] - The transformlist to check
+     * @returns {boolean} Whether or not a matrix transform was found
+     */
+    svgedit.math.hasMatrixTransform = function (tlist) {
+      if (!tlist) {
+        return false;
+      }
+      var num = tlist.numberOfItems;
+      while (num--) {
+        var xform = tlist.getItem(num);
+        if (xform.type == 1 && !svgedit.math.isIdentity(xform.matrix)) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    /**
+     * Transforms a rectangle based on the given matrix
+     * @param {number} l - Float with the box's left coordinate
+     * @param {number} t - Float with the box's top coordinate
+     * @param {number} w - Float with the box width
+     * @param {number} h - Float with the box height
+     * @param {SVGMatrix} m - Matrix object to transform the box by
+     * @returns {object} An object with the following values:
+     * tl - The top left coordinate (x,y object)
+     * tr - The top right coordinate (x,y object)
+     * bl - The bottom left coordinate (x,y object)
+     * br - The bottom right coordinate (x,y object)
+     * aabox - Object with the following values:
+     * x - Float with the axis-aligned x coordinate
+     * y - Float with the axis-aligned y coordinate
+     * width - Float with the axis-aligned width coordinate
+     * height - Float with the axis-aligned height coordinate
+     */
+    svgedit.math.transformBox = function (l, t, w, h, m) {
+      var transformPoint = svgedit.math.transformPoint,
+        tl = transformPoint(l, t, m),
+        tr = transformPoint(l + w, t, m),
+        bl = transformPoint(l, t + h, m),
+        br = transformPoint(l + w, t + h, m),
+        minx = Math.min(tl.x, tr.x, bl.x, br.x),
+        maxx = Math.max(tl.x, tr.x, bl.x, br.x),
+        miny = Math.min(tl.y, tr.y, bl.y, br.y),
+        maxy = Math.max(tl.y, tr.y, bl.y, br.y);
+
+      return {
+        tl: tl,
+        tr: tr,
+        bl: bl,
+        br: br,
+        aabox: {
+          x: minx,
+          y: miny,
+          width: maxx - minx,
+          height: maxy - miny,
+        },
+      };
+    };
+
+    /**
+     * This returns a single matrix Transform for a given Transform List
+     * (this is the equivalent of SVGTransformList.consolidate() but unlike
+     * that method, this one does not modify the actual SVGTransformList)
+     * This function is very liberal with its min, max arguments
+     * @param {object} tlist - The transformlist object
+     * @param {integer} [min=0] - Optional integer indicating start transform position
+     * @param {integer} [max] - Optional integer indicating end transform position;
+     *   defaults to one less than the tlist's numberOfItems
+     * @returns {object} A single matrix transform object
+     */
+    svgedit.math.transformListToTransform = function (tlist, min, max) {
+      if (tlist == null) {
+        // Or should tlist = null have been prevented before this?
+        return svg.createSVGTransformFromMatrix(svg.createSVGMatrix());
+      }
+      min = min || 0;
+      max = max || tlist.numberOfItems - 1;
+      min = parseInt(min, 10);
+      max = parseInt(max, 10);
+      if (min > max) {
+        var temp = max;
+        max = min;
+        min = temp;
+      }
+      var m = svg.createSVGMatrix();
+      var i;
+      for (i = min; i <= max; ++i) {
+        // if our indices are out of range, just use a harmless identity matrix
+        var mtom = i >= 0 && i < tlist.numberOfItems ? tlist.getItem(i).matrix : svg.createSVGMatrix();
+        m = svgedit.math.matrixMultiply(m, mtom);
+      }
+      return svg.createSVGTransformFromMatrix(m);
+    };
+
+    /**
+     * Get the matrix object for a given element
+     * @param {Element} elem - The DOM element to check
+     * @returns {SVGMatrix} The matrix object associated with the element's transformlist
+     */
+    svgedit.math.getMatrix = function (elem) {
+      var tlist = svgedit.transformlist.getTransformList(elem, false);
+      return svgedit.math.transformListToTransform(tlist).matrix;
+    };
+
+    /**
+     * Returns a 45 degree angle coordinate associated with the two given
+     * coordinates
+     * @param {number} x1 - First coordinate's x value
+     * @param {number} y1 - First coordinate's y value
+     * @param {number} x2 - Second coordinate's x value
+     * @param {number} y2 - Second coordinate's y value
+     * @param {number} snap - Snap unit (rad)
+     * @returns {AngleCoord}
+     */
+    svgedit.math.snapToAngle = function (x1, y1, x2, y2, snap = Math.PI / 2) {
+      var dx = x2 - x1;
+      var dy = y2 - y1;
+      var angle = Math.atan2(dy, dx);
+      var dist = Math.sqrt(dx * dx + dy * dy);
+      var snapangle = Math.round(angle / snap) * snap;
+
+      return {
+        x: x1 + dist * Math.cos(snapangle),
+        y: y1 + dist * Math.sin(snapangle),
+        a: snapangle,
+      };
+    };
+  })()
+);

--- a/packages/core/src/web/app/svgedit/operations/pathActions.ts
+++ b/packages/core/src/web/app/svgedit/operations/pathActions.ts
@@ -28,6 +28,7 @@ import Path from '../path/Path';
 import Segment from '../path/Segment';
 import { remapElement } from '../transform/coords';
 import { getBBox } from '../utils/getBBox';
+import rectsIntersect from '../utils/rectsIntersect';
 
 const canvasEventEmitter = eventEmitterFactory.createEventEmitter('canvas');
 
@@ -716,7 +717,7 @@ const mouseMove = (mouseX: number, mouseY: number) => {
         y: pt.y,
       };
 
-      const intersected = svgedit.math.rectsIntersect(rbb, ptBb);
+      const intersected = rectsIntersect(rbb, ptBb);
 
       seg.select(intersected);
 

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -44,6 +44,8 @@ import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
 import { getMouseMode, setMouseMode } from '@core/app/stores/canvas/utils/mouseMode';
 import { useDocumentStore } from '@core/app/stores/documentStore';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
+import elementIntersectsRect from '@core/app/svgedit/utils/elementIntersectsRect';
+import rectsIntersect from '@core/app/svgedit/utils/rectsIntersect';
 import { getAutoFeeder, getPassThrough } from '@core/helpers/addOn';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import { getAttributes } from '@core/helpers/element/attribute';
@@ -758,13 +760,20 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
       }
 
       var i = curBBoxes.length;
+      // precise check only for rubber-band selection; getMouseTarget's sensor
+      // region relies on plain bbox candidates
+      const contentCtmInverse = rect ? null : svgcontent.getScreenCTM()?.inverse();
 
       while (i--) {
         if (!rubberBBox.width) {
           continue;
         }
 
-        if (svgedit.math.rectsIntersect(rubberBBox, curBBoxes[i].bbox)) {
+        if (rectsIntersect(rubberBBox, curBBoxes[i].bbox)) {
+          if (contentCtmInverse && !elementIntersectsRect(curBBoxes[i].elem, rubberBBox, contentCtmInverse)) {
+            continue;
+          }
+
           resultList.push(curBBoxes[i].elem);
         }
       }

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
@@ -9,6 +9,7 @@ jest.mock('paper', () => {
     CompoundPath: core.CompoundPath,
     Matrix: core.Matrix,
     Path: core.Path,
+    Point: core.Point,
     get project() {
       return core.project;
     },
@@ -22,12 +23,19 @@ import elementIntersectsRect from './elementIntersectsRect';
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
 const identityCtm = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } as DOMMatrix;
+
+(identityCtm as { inverse: () => DOMMatrix }).inverse = () => identityCtm;
+
 // content CTM inverse stub: combining with an element's screen CTM just returns it
 const contentCtmInverse = { multiply: (m: DOMMatrix) => m } as DOMMatrix;
 
 // path stub whose outline is the polyline through verts, with linear getPointAtLength
 const makePath = (verts: Array<[number, number]>, ctm: DOMMatrix = identityCtm): SVGPathElement => {
   const elem = document.createElementNS(SVG_NS, 'path');
+
+  // model beam studio outline shapes; filled variants set their own fill
+  elem.setAttribute('fill', 'none');
+
   const segments: Array<{ from: [number, number]; len: number; to: [number, number] }> = [];
   let total = 0;
 
@@ -145,6 +153,23 @@ describe('elementIntersectsRect', () => {
     expect(spy.mock.calls.length).toBeLessThan(128);
   });
 
+  test('band inside a filled d-less shape selects via isPointInFill', () => {
+    const square = makePath([
+      [0, 0],
+      [100, 0],
+      [100, 100],
+      [0, 100],
+      [0, 0],
+    ]);
+
+    square.setAttribute('fill', '#333333');
+    Object.assign(square, {
+      isPointInFill: ({ x, y }: DOMPoint) => x >= 0 && x <= 100 && y >= 0 && y <= 100,
+    });
+
+    expect(elementIntersectsRect(square, { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(true);
+  });
+
   test('band much larger than the shape still detects a clipped edge', () => {
     // small square outline (perimeter 400) vs a huge band overlapping its right
     // half: in-band arc is far shorter than any band-derived step size
@@ -160,9 +185,10 @@ describe('elementIntersectsRect', () => {
   });
 
   describe('path with a d attribute goes through paper.js', () => {
-    const makeDPath = (d: string): SVGElement => {
+    const makeDPath = (d: string, fill = 'none'): SVGElement => {
       const elem = makeBoxElem('path', { height: 100, width: 100, x: 0, y: 0 });
 
+      elem.setAttribute('fill', fill);
       elem.setAttribute('d', d);
       // present so elementIntersectsRect routes into the outline branch;
       // paper answers from the d attribute before this is ever called
@@ -179,6 +205,26 @@ describe('elementIntersectsRect', () => {
 
     test('band crossing the outline intersects', () => {
       expect(elementIntersectsRect(cPath, { height: 20, width: 10, x: -5, y: 40 }, contentCtmInverse)).toBe(true);
+    });
+
+    test('band fully inside a filled shape selects it, but not inside an unfilled outline', () => {
+      const square = 'M0 0 h100 v100 h-100 z';
+
+      expect(
+        elementIntersectsRect(makeDPath(square, '#333333'), { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse),
+      ).toBe(true);
+      expect(
+        elementIntersectsRect(makeDPath(square, 'none'), { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse),
+      ).toBe(false);
+    });
+
+    test('band inside the hole of a filled donut does not intersect', () => {
+      // outer clockwise, inner counter-clockwise -> the inner square is a hole
+      const donut = makeDPath('M0 0 h100 v100 h-100 z M40 40 v20 h20 v-20 z', '#333333');
+
+      expect(elementIntersectsRect(donut, { height: 10, width: 10, x: 45, y: 45 }, contentCtmInverse)).toBe(false);
+      // band over the solid ring between outline and hole still selects
+      expect(elementIntersectsRect(donut, { height: 10, width: 8, x: 10, y: 45 }, contentCtmInverse)).toBe(true);
     });
 
     test('subpath fully inside the band intersects', () => {

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
@@ -1,0 +1,128 @@
+import elementIntersectsRect from './elementIntersectsRect';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const identityCtm = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } as DOMMatrix;
+// content CTM inverse stub: combining with an element's screen CTM just returns it
+const contentCtmInverse = { multiply: (m: DOMMatrix) => m } as DOMMatrix;
+
+// path stub whose outline is the polyline through verts, with linear getPointAtLength
+const makePath = (verts: Array<[number, number]>, ctm: DOMMatrix = identityCtm): SVGPathElement => {
+  const elem = document.createElementNS(SVG_NS, 'path');
+  const segments: Array<{ from: [number, number]; len: number; to: [number, number] }> = [];
+  let total = 0;
+
+  for (let i = 1; i < verts.length; i++) {
+    const len = Math.hypot(verts[i][0] - verts[i - 1][0], verts[i][1] - verts[i - 1][1]);
+
+    segments.push({ from: verts[i - 1], len, to: verts[i] });
+    total += len;
+  }
+
+  const xs = verts.map(([x]) => x);
+  const ys = verts.map(([, y]) => y);
+
+  Object.assign(elem, {
+    getBBox: () => ({
+      height: Math.max(...ys) - Math.min(...ys),
+      width: Math.max(...xs) - Math.min(...xs),
+      x: Math.min(...xs),
+      y: Math.min(...ys),
+    }),
+    getPointAtLength: (dist: number) => {
+      let remaining = dist;
+
+      for (const { from, len, to } of segments) {
+        if (remaining <= len) {
+          const t = len ? remaining / len : 0;
+
+          return { x: from[0] + (to[0] - from[0]) * t, y: from[1] + (to[1] - from[1]) * t };
+        }
+
+        remaining -= len;
+      }
+
+      return { x: verts[verts.length - 1][0], y: verts[verts.length - 1][1] };
+    },
+    getScreenCTM: () => ctm,
+    getTotalLength: () => total,
+  });
+
+  return elem as SVGPathElement;
+};
+
+// non-geometry stub (image-like): bbox only, no getTotalLength
+const makeBoxElem = (tag: string, bbox: { height: number; width: number; x: number; y: number }): SVGElement => {
+  const elem = document.createElementNS(SVG_NS, tag);
+
+  Object.assign(elem, { getBBox: () => bbox, getScreenCTM: () => identityCtm });
+
+  return elem;
+};
+
+describe('elementIntersectsRect', () => {
+  // open square missing its right edge, bbox (0,0)-(100,100)
+  const cShape = makePath([
+    [100, 0],
+    [0, 0],
+    [0, 100],
+    [100, 100],
+  ]);
+
+  test('rect inside the empty interior of a C shape does not intersect', () => {
+    expect(elementIntersectsRect(cShape, { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(false);
+  });
+
+  test('rect touching the outline of a C shape intersects', () => {
+    expect(elementIntersectsRect(cShape, { height: 20, width: 10, x: -5, y: 40 }, contentCtmInverse)).toBe(true);
+  });
+
+  test('rect fully containing the shape intersects', () => {
+    expect(elementIntersectsRect(cShape, { height: 200, width: 200, x: -50, y: -50 }, contentCtmInverse)).toBe(true);
+  });
+
+  test('scaled element is sampled in content space', () => {
+    // 20 local units long, scaled 5x -> spans x 0..100 in content space
+    const scaled = makePath(
+      [
+        [0, 0],
+        [20, 0],
+      ],
+      { a: 5, b: 0, c: 0, d: 5, e: 0, f: 0 } as DOMMatrix,
+    );
+
+    expect(elementIntersectsRect(scaled, { height: 10, width: 10, x: 50, y: -5 }, contentCtmInverse)).toBe(true);
+    expect(elementIntersectsRect(scaled, { height: 10, width: 10, x: 50, y: 20 }, contentCtmInverse)).toBe(false);
+  });
+
+  describe('group with sparse children', () => {
+    const group = makeBoxElem('g', { height: 100, width: 100, x: 0, y: 0 });
+
+    group.appendChild(makeBoxElem('image', { height: 10, width: 10, x: 0, y: 0 }));
+    group.appendChild(makeBoxElem('image', { height: 10, width: 10, x: 90, y: 90 }));
+
+    test('rect in the empty middle of the group does not intersect', () => {
+      expect(elementIntersectsRect(group, { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(false);
+    });
+
+    test('rect over one child intersects', () => {
+      expect(elementIntersectsRect(group, { height: 10, width: 10, x: 5, y: 5 }, contentCtmInverse)).toBe(true);
+    });
+  });
+
+  test('non-geometry leaf falls back to bbox overlap', () => {
+    const image = makeBoxElem('image', { height: 50, width: 50, x: 0, y: 0 });
+
+    expect(elementIntersectsRect(image, { height: 5, width: 5, x: 10, y: 10 }, contentCtmInverse)).toBe(true);
+  });
+
+  test('element without geometry APIs does not intersect', () => {
+    expect(
+      elementIntersectsRect(
+        document.createElementNS(SVG_NS, 'g'),
+        { height: 5, width: 5, x: 0, y: 0 },
+        contentCtmInverse,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
@@ -145,6 +145,20 @@ describe('elementIntersectsRect', () => {
     expect(spy.mock.calls.length).toBeLessThan(128);
   });
 
+  test('band much larger than the shape still detects a clipped edge', () => {
+    // small square outline (perimeter 400) vs a huge band overlapping its right
+    // half: in-band arc is far shorter than any band-derived step size
+    const square = makePath([
+      [0, 0],
+      [100, 0],
+      [100, 100],
+      [0, 100],
+      [0, 0],
+    ]);
+
+    expect(elementIntersectsRect(square, { height: 4000, width: 4000, x: 50, y: -2000 }, contentCtmInverse)).toBe(true);
+  });
+
   describe('path with a d attribute goes through paper.js', () => {
     const makeDPath = (d: string): SVGElement => {
       const elem = makeBoxElem('path', { height: 100, width: 100, x: 0, y: 0 });

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
@@ -1,3 +1,22 @@
+// ts-jest interop drops the classes on PaperScope.prototype; re-expose the
+// ones the module uses on the real paper-core (see unit-test skill)
+jest.mock('paper', () => {
+  const core = require('paper/dist/paper-core.js');
+
+  core.setup(new core.Size(1, 1));
+
+  return {
+    CompoundPath: core.CompoundPath,
+    Matrix: core.Matrix,
+    Path: core.Path,
+    get project() {
+      return core.project;
+    },
+    setup: (...args: unknown[]) => core.setup(...args),
+    Size: core.Size,
+  };
+});
+
 import elementIntersectsRect from './elementIntersectsRect';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -107,6 +126,53 @@ describe('elementIntersectsRect', () => {
 
     test('rect over one child intersects', () => {
       expect(elementIntersectsRect(group, { height: 10, width: 10, x: 5, y: 5 }, contentCtmInverse)).toBe(true);
+    });
+  });
+
+  test('long path far from the band is pruned instead of densely sampled', () => {
+    // dense zig-zag column on the left plus one far segment: total length ~5500,
+    // bbox (0,0)-(500,998), hollow everywhere right of x=10
+    const verts: Array<[number, number]> = [];
+
+    for (let i = 0; i < 500; i++) verts.push([(i % 2) * 10, i * 2]);
+    verts.push([500, 998]);
+
+    const longPath = makePath(verts);
+    const spy = jest.spyOn(longPath, 'getPointAtLength' as never);
+
+    // band inside the bbox but ~290 units away from any outline point
+    expect(elementIntersectsRect(longPath, { height: 20, width: 20, x: 300, y: 400 }, contentCtmInverse)).toBe(false);
+    expect(spy.mock.calls.length).toBeLessThan(128);
+  });
+
+  describe('path with a d attribute goes through paper.js', () => {
+    const makeDPath = (d: string): SVGElement => {
+      const elem = makeBoxElem('path', { height: 100, width: 100, x: 0, y: 0 });
+
+      elem.setAttribute('d', d);
+      // present so elementIntersectsRect routes into the outline branch;
+      // paper answers from the d attribute before this is ever called
+      Object.assign(elem, { getTotalLength: () => 0 });
+
+      return elem;
+    };
+
+    const cPath = makeDPath('M100 0 L0 0 L0 100 L100 100');
+
+    test('band inside the cavity does not intersect', () => {
+      expect(elementIntersectsRect(cPath, { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(false);
+    });
+
+    test('band crossing the outline intersects', () => {
+      expect(elementIntersectsRect(cPath, { height: 20, width: 10, x: -5, y: 40 }, contentCtmInverse)).toBe(true);
+    });
+
+    test('subpath fully inside the band intersects', () => {
+      // two square subpaths at opposite corners, like two glyphs
+      const glyphs = makeDPath('M0 0 h10 v10 h-10 z M90 90 h10 v10 h-10 z');
+
+      expect(elementIntersectsRect(glyphs, { height: 20, width: 20, x: -5, y: -5 }, contentCtmInverse)).toBe(true);
+      expect(elementIntersectsRect(glyphs, { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(false);
     });
   });
 

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.spec.ts
@@ -110,6 +110,41 @@ describe('elementIntersectsRect', () => {
     });
   });
 
+  describe('text with per-character extents', () => {
+    // four glyphs at the corners of a ring, bbox (0,0)-(100,100) — like text on a circle path
+    const makeText = (extents: Array<{ height: number; width: number; x: number; y: number }>): SVGElement => {
+      const elem = makeBoxElem('text', { height: 100, width: 100, x: 0, y: 0 });
+
+      Object.assign(elem, {
+        getExtentOfChar: (i: number) => extents[i],
+        getNumberOfChars: () => extents.length,
+      });
+
+      return elem;
+    };
+
+    const ringText = makeText([
+      { height: 10, width: 10, x: 45, y: 0 },
+      { height: 10, width: 10, x: 90, y: 45 },
+      { height: 10, width: 10, x: 45, y: 90 },
+      { height: 10, width: 10, x: 0, y: 45 },
+    ]);
+
+    test('rect inside the ring does not intersect', () => {
+      expect(elementIntersectsRect(ringText, { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(false);
+    });
+
+    test('rect over a glyph intersects', () => {
+      expect(elementIntersectsRect(ringText, { height: 10, width: 10, x: 48, y: 5 }, contentCtmInverse)).toBe(true);
+    });
+
+    test('empty text falls back to bbox overlap', () => {
+      expect(elementIntersectsRect(makeText([]), { height: 20, width: 20, x: 40, y: 40 }, contentCtmInverse)).toBe(
+        true,
+      );
+    });
+  });
+
   test('non-geometry leaf falls back to bbox overlap', () => {
     const image = makeBoxElem('image', { height: 50, width: 50, x: 0, y: 0 });
 

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
@@ -10,6 +10,44 @@ const applyMatrix = (m: DOMMatrix, x: number, y: number) => ({
   y: m.b * x + m.d * y + m.f,
 });
 
+// axis-aligned hull of a local-space rect mapped to content user space
+const mapRectHull = (bbox: IRect, matrix: DOMMatrix): IRect => {
+  const corners = [
+    applyMatrix(matrix, bbox.x, bbox.y),
+    applyMatrix(matrix, bbox.x + bbox.width, bbox.y),
+    applyMatrix(matrix, bbox.x + bbox.width, bbox.y + bbox.height),
+    applyMatrix(matrix, bbox.x, bbox.y + bbox.height),
+  ];
+  const xs = corners.map((p) => p.x);
+  const ys = corners.map((p) => p.y);
+
+  return {
+    height: Math.max(...ys) - Math.min(...ys),
+    width: Math.max(...xs) - Math.min(...xs),
+    x: Math.min(...xs),
+    y: Math.min(...ys),
+  };
+};
+
+const textIntersectsRect = (elem: SVGTextContentElement, rect: IRect, matrix: DOMMatrix): boolean => {
+  let count: number;
+
+  try {
+    count = elem.getNumberOfChars();
+  } catch {
+    return true;
+  }
+
+  // no chars (or absurdly many) -> keep the bbox answer
+  if (!count || count > 512) return true;
+
+  for (let i = 0; i < count; i++) {
+    if (rectsIntersect(rect, mapRectHull(elem.getExtentOfChar(i), matrix))) return true;
+  }
+
+  return false;
+};
+
 const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DOMMatrix): boolean => {
   let total: number;
 
@@ -69,22 +107,7 @@ export const elementIntersectsRect = (element: Element, rect: IRect, contentCtmI
     return false;
   }
 
-  const corners = [
-    applyMatrix(matrix, bbox.x, bbox.y),
-    applyMatrix(matrix, bbox.x + bbox.width, bbox.y),
-    applyMatrix(matrix, bbox.x + bbox.width, bbox.y + bbox.height),
-    applyMatrix(matrix, bbox.x, bbox.y + bbox.height),
-  ];
-  const xs = corners.map((p) => p.x);
-  const ys = corners.map((p) => p.y);
-  const hull = {
-    height: Math.max(...ys) - Math.min(...ys),
-    width: Math.max(...xs) - Math.min(...xs),
-    x: Math.min(...xs),
-    y: Math.min(...ys),
-  };
-
-  if (!rectsIntersect(rect, hull)) return false;
+  if (!rectsIntersect(rect, mapRectHull(bbox, matrix))) return false;
 
   if (elem.tagName === 'g') {
     return Array.from(elem.childNodes).some(
@@ -92,10 +115,18 @@ export const elementIntersectsRect = (element: Element, rect: IRect, contentCtmI
     );
   }
 
-  // text / image / use have no outline to sample; their bbox is close enough
-  if (typeof (elem as SVGGeometryElement).getTotalLength !== 'function') return true;
+  if (typeof (elem as SVGGeometryElement).getTotalLength === 'function') {
+    return outlineIntersectsRect(elem as SVGGeometryElement, rect, matrix);
+  }
 
-  return outlineIntersectsRect(elem as SVGGeometryElement, rect, matrix);
+  // text is hollow like a C shape when laid along a path, so test per-character
+  // extents, which hug the actual glyphs
+  if (typeof (elem as SVGTextContentElement).getNumberOfChars === 'function') {
+    return textIntersectsRect(elem as SVGTextContentElement, rect, matrix);
+  }
+
+  // image / use have no outline to sample; their bbox is close enough
+  return true;
 };
 
 export default elementIntersectsRect;

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
@@ -1,0 +1,101 @@
+import type { IRect } from '@core/interfaces/ISVGCanvas';
+
+import rectsIntersect from './rectsIntersect';
+
+const pointInRect = (rect: IRect, x: number, y: number): boolean =>
+  x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
+
+const applyMatrix = (m: DOMMatrix, x: number, y: number) => ({
+  x: m.a * x + m.c * y + m.e,
+  y: m.b * x + m.d * y + m.f,
+});
+
+const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DOMMatrix): boolean => {
+  let total: number;
+
+  try {
+    total = elem.getTotalLength();
+  } catch {
+    return true;
+  }
+
+  if (!total) return true;
+
+  // scale factor from element-local units to content user units
+  const scale = Math.hypot(matrix.a, matrix.b) || 1;
+  // half the band's smaller dimension (in local units): a segment crossing the
+  // band cannot be stepped over at this spacing
+  // ponytail: capped at 512 samples; an extremely long path may step past a tiny
+  // band — raise the cap or subdivide per-segment if users hit it
+  const sampleLength = Math.max(Math.min(rect.width, rect.height) / 2 / scale, total / 512);
+
+  for (let i = 0; i <= total + sampleLength; i += sampleLength) {
+    const dist = Math.min(i, total); // clamp so the endpoint is sampled exactly
+    const point = elem.getPointAtLength(dist);
+    const { x, y } = applyMatrix(matrix, point.x, point.y);
+
+    if (pointInRect(rect, x, y)) return true;
+  }
+
+  return false;
+};
+
+/**
+ * Precise (narrow-phase) intersection test between an element and a rect in
+ * content user space. Bbox overlap alone selects hollow shapes (a C shape, a
+ * sparse group) when the rect lies entirely in their empty interior, so
+ * geometry leaves are re-tested by sampling their outline and groups recurse
+ * into their children.
+ * @param contentCtmInverse inverse of the content element's screen CTM
+ */
+export const elementIntersectsRect = (element: Element, rect: IRect, contentCtmInverse: DOMMatrix): boolean => {
+  const elem = element as SVGGraphicsElement;
+
+  // instanceof SVGGraphicsElement / SVGGeometryElement would be cleaner, but
+  // jsdom does not implement them; duck-type instead
+  if (typeof elem.getBBox !== 'function' || typeof elem.getScreenCTM !== 'function') return false;
+
+  const screenCtm = elem.getScreenCTM();
+
+  if (!screenCtm) return true;
+
+  // maps element-local coordinates to content user space (same space as rect)
+  const matrix = contentCtmInverse.multiply(screenCtm);
+  let bbox: DOMRect;
+
+  try {
+    bbox = elem.getBBox();
+  } catch {
+    return false;
+  }
+
+  const corners = [
+    applyMatrix(matrix, bbox.x, bbox.y),
+    applyMatrix(matrix, bbox.x + bbox.width, bbox.y),
+    applyMatrix(matrix, bbox.x + bbox.width, bbox.y + bbox.height),
+    applyMatrix(matrix, bbox.x, bbox.y + bbox.height),
+  ];
+  const xs = corners.map((p) => p.x);
+  const ys = corners.map((p) => p.y);
+  const hull = {
+    height: Math.max(...ys) - Math.min(...ys),
+    width: Math.max(...xs) - Math.min(...xs),
+    x: Math.min(...xs),
+    y: Math.min(...ys),
+  };
+
+  if (!rectsIntersect(rect, hull)) return false;
+
+  if (elem.tagName === 'g') {
+    return Array.from(elem.childNodes).some(
+      (child) => child instanceof Element && elementIntersectsRect(child, rect, contentCtmInverse),
+    );
+  }
+
+  // text / image / use have no outline to sample; their bbox is close enough
+  if (typeof (elem as SVGGeometryElement).getTotalLength !== 'function') return true;
+
+  return outlineIntersectsRect(elem as SVGGeometryElement, rect, matrix);
+};
+
+export default elementIntersectsRect;

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
@@ -1,9 +1,8 @@
+import paper from 'paper';
+
 import type { IRect } from '@core/interfaces/ISVGCanvas';
 
 import rectsIntersect from './rectsIntersect';
-
-const pointInRect = (rect: IRect, x: number, y: number): boolean =>
-  x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
 
 const applyMatrix = (m: DOMMatrix, x: number, y: number) => ({
   x: m.a * x + m.c * y + m.e,
@@ -48,7 +47,56 @@ const textIntersectsRect = (elem: SVGTextContentElement, rect: IRect, matrix: DO
   return false;
 };
 
+// getPointAtLength re-walks the path's segment list on every call (~ms per
+// call on a glyph-outline path), so for <path> elements parse the d attribute
+// once with paper.js and run a proper curve-vs-rect intersection instead.
+// Returns null when paper cannot handle the data, to fall back to probing.
+const pathDIntersectsRect = (d: string, rect: IRect, matrix: DOMMatrix): boolean | null => {
+  try {
+    if (!paper.project) paper.setup(new paper.Size(1, 1));
+
+    const compound = new paper.CompoundPath({ insert: false, pathData: d });
+
+    compound.transform(new paper.Matrix(matrix.a, matrix.b, matrix.c, matrix.d, matrix.e, matrix.f));
+
+    const rectPath = new paper.Path.Rectangle({
+      insert: false,
+      point: [rect.x, rect.y],
+      size: [rect.width, rect.height],
+    });
+
+    if (compound.intersects(rectPath)) return true;
+
+    // a subpath (e.g. one glyph) can lie entirely inside the band without
+    // its outline ever crossing the band edge
+    const subpaths = compound.children.length
+      ? (compound.children as paper.Path[])
+      : [compound as unknown as paper.Path];
+
+    return subpaths.some((subpath) => {
+      const point = subpath.firstSegment?.point;
+
+      return Boolean(point) && rectPath.contains(point);
+    });
+  } catch {
+    return null;
+  }
+};
+
+// Fallback for shapes without a d attribute (ellipse, rect, line...), where
+// getPointAtLength is cheap. Subdivide arc-length spans and prune: a point at
+// most `span` local units along the path from a probed point cannot be farther
+// than `span * scale` content units away from it, so a span whose probed
+// endpoint is farther from the band than it can travel is skipped whole.
 const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DOMMatrix): boolean => {
+  const d = elem.getAttribute('d');
+
+  if (d) {
+    const paperResult = pathDIntersectsRect(d, rect, matrix);
+
+    if (paperResult !== null) return paperResult;
+  }
+
   let total: number;
 
   try {
@@ -61,18 +109,48 @@ const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DO
 
   // scale factor from element-local units to content user units
   const scale = Math.hypot(matrix.a, matrix.b) || 1;
-  // half the band's smaller dimension (in local units): a segment crossing the
-  // band cannot be stepped over at this spacing
-  // ponytail: capped at 512 samples; an extremely long path may step past a tiny
-  // band — raise the cap or subdivide per-segment if users hit it
-  const sampleLength = Math.max(Math.min(rect.width, rect.height) / 2 / scale, total / 512);
+  // half the band's smaller dimension (in local units): a span shorter than
+  // this cannot cross the band unnoticed; floored so a degenerate band cannot
+  // subdivide forever
+  const resolution = Math.max(Math.min(rect.width, rect.height) / 2 / scale, total / 4096);
 
-  for (let i = 0; i <= total + sampleLength; i += sampleLength) {
-    const dist = Math.min(i, total); // clamp so the endpoint is sampled exactly
-    const point = elem.getPointAtLength(dist);
-    const { x, y } = applyMatrix(matrix, point.x, point.y);
+  // distance from a content-space point to the band, 0 if inside
+  const distToRect = ({ x, y }: { x: number; y: number }) =>
+    Math.hypot(Math.max(rect.x - x, x - rect.x - rect.width, 0), Math.max(rect.y - y, y - rect.y - rect.height, 0));
+  const probe = (dist: number) => {
+    const p = elem.getPointAtLength(dist);
 
-    if (pointInRect(rect, x, y)) return true;
+    return distToRect(applyMatrix(matrix, p.x, p.y));
+  };
+
+  // ponytail: 2048-probe cap; an over-budget path reports no hit, which can
+  // miss a selection on absurdly complex geometry near the band
+  let budget = 2048;
+  const dStart = probe(0);
+
+  if (dStart === 0) return true;
+
+  // spans as [lo, hi, distance from point at lo to the band]
+  const stack: Array<[number, number, number]> = [[0, total, dStart]];
+
+  while (stack.length && budget > 0) {
+    const [lo, hi, dLo] = stack.pop()!;
+    const span = hi - lo;
+
+    // no point within this span can reach the band
+    if (dLo > span * scale) continue;
+
+    if (span <= resolution) continue;
+
+    const mid = (lo + hi) / 2;
+
+    budget -= 1;
+
+    const dMid = probe(mid);
+
+    if (dMid === 0) return true;
+
+    stack.push([lo, mid, dLo], [mid, hi, dMid]);
   }
 
   return false;
@@ -82,8 +160,8 @@ const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DO
  * Precise (narrow-phase) intersection test between an element and a rect in
  * content user space. Bbox overlap alone selects hollow shapes (a C shape, a
  * sparse group) when the rect lies entirely in their empty interior, so
- * geometry leaves are re-tested by sampling their outline and groups recurse
- * into their children.
+ * geometry leaves are re-tested along their outline and groups recurse into
+ * their children.
  * @param contentCtmInverse inverse of the content element's screen CTM
  */
 export const elementIntersectsRect = (element: Element, rect: IRect, contentCtmInverse: DOMMatrix): boolean => {

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
@@ -109,10 +109,11 @@ const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DO
 
   // scale factor from element-local units to content user units
   const scale = Math.hypot(matrix.a, matrix.b) || 1;
-  // half the band's smaller dimension (in local units): a span shorter than
-  // this cannot cross the band unnoticed; floored so a degenerate band cannot
-  // subdivide forever
-  const resolution = Math.max(Math.min(rect.width, rect.height) / 2 / scale, total / 4096);
+  // subdivision stops via the distance prune below; this tiny floor only bounds
+  // the depth. It must NOT be derived from the band size: a path can clip a
+  // large band's corner with an arbitrarily short arc, so band-sized spans
+  // cannot be skipped unprobed
+  const resolution = total / 4096;
 
   // distance from a content-space point to the band, 0 if inside
   const distToRect = ({ x, y }: { x: number; y: number }) =>

--- a/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
+++ b/packages/core/src/web/app/svgedit/utils/elementIntersectsRect.ts
@@ -47,11 +47,16 @@ const textIntersectsRect = (elem: SVGTextContentElement, rect: IRect, matrix: DO
   return false;
 };
 
+// missing fill means filled (the SVG default is black); outline shapes carry
+// an explicit fill="none"
+const isFilled = (elem: Element): boolean =>
+  elem.getAttribute('fill') !== 'none' && elem.getAttribute('fill-opacity') !== '0';
+
 // getPointAtLength re-walks the path's segment list on every call (~ms per
 // call on a glyph-outline path), so for <path> elements parse the d attribute
 // once with paper.js and run a proper curve-vs-rect intersection instead.
 // Returns null when paper cannot handle the data, to fall back to probing.
-const pathDIntersectsRect = (d: string, rect: IRect, matrix: DOMMatrix): boolean | null => {
+const pathDIntersectsRect = (d: string, rect: IRect, matrix: DOMMatrix, checkFill: boolean): boolean | null => {
   try {
     if (!paper.project) paper.setup(new paper.Size(1, 1));
 
@@ -73,11 +78,21 @@ const pathDIntersectsRect = (d: string, rect: IRect, matrix: DOMMatrix): boolean
       ? (compound.children as paper.Path[])
       : [compound as unknown as paper.Path];
 
-    return subpaths.some((subpath) => {
-      const point = subpath.firstSegment?.point;
+    if (
+      subpaths.some((subpath) => {
+        const point = subpath.firstSegment?.point;
 
-      return Boolean(point) && rectPath.contains(point);
-    });
+        return Boolean(point) && rectPath.contains(point);
+      })
+    ) {
+      return true;
+    }
+
+    // a band fully inside a filled shape touches no outline; its center decides
+    // (partial overlaps always cross the outline). contains() respects holes.
+    if (checkFill) return compound.contains(new paper.Point(rect.x + rect.width / 2, rect.y + rect.height / 2));
+
+    return false;
   } catch {
     return null;
   }
@@ -89,10 +104,11 @@ const pathDIntersectsRect = (d: string, rect: IRect, matrix: DOMMatrix): boolean
 // than `span * scale` content units away from it, so a span whose probed
 // endpoint is farther from the band than it can travel is skipped whole.
 const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DOMMatrix): boolean => {
+  const filled = isFilled(elem);
   const d = elem.getAttribute('d');
 
   if (d) {
-    const paperResult = pathDIntersectsRect(d, rect, matrix);
+    const paperResult = pathDIntersectsRect(d, rect, matrix, filled);
 
     if (paperResult !== null) return paperResult;
   }
@@ -154,7 +170,17 @@ const outlineIntersectsRect = (elem: SVGGeometryElement, rect: IRect, matrix: DO
     stack.push([lo, mid, dLo], [mid, hi, dMid]);
   }
 
-  return false;
+  // no outline hit: a band fully inside a filled shape still selects it
+  if (!filled || typeof elem.isPointInFill !== 'function') return false;
+
+  try {
+    const inverse = matrix.inverse();
+    const center = applyMatrix(inverse, rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+    return elem.isPointInFill({ x: center.x, y: center.y } as DOMPoint);
+  } catch {
+    return false;
+  }
 };
 
 /**

--- a/packages/core/src/web/app/svgedit/utils/rectsIntersect.ts
+++ b/packages/core/src/web/app/svgedit/utils/rectsIntersect.ts
@@ -1,0 +1,10 @@
+import type { IRect } from '@core/interfaces/ISVGCanvas';
+
+/**
+ * Check if two rectangles intersect each other.
+ * Extracted from svgedit.math.rectsIntersect (public/js/lib/svgeditor/math.js).
+ */
+export const rectsIntersect = (r1: IRect, r2: IRect): boolean =>
+  r2.x < r1.x + r1.width && r2.x + r2.width > r1.x && r2.y < r1.y + r1.height && r2.y + r2.height > r1.y;
+
+export default rectsIntersect;


### PR DESCRIPTION
https://flux3dp.slack.com/archives/C2KV9ULLC/p1788239459015859

## 摘要

框選（rubber band）多選原本只用 bounding box 重疊判斷，導致框在 C 形路徑或中空群組（例如兩個對角的小物件）的空白內部時也會選到該物件。此 PR 在既有的 bbox 粗篩之後加入精確的窄階段判斷：

- 群組遞迴檢查子元素，各自用自己的 bbox 與外形判斷
- 幾何元素沿外形取樣；`<path>` 元素改用 paper.js 解析 `d` 一次後做曲線與矩形的精確相交（含子路徑完全落在框內的判斷）
- 文字仍用 bbox intersect 判斷以減少文字轉路徑問題。但改用逐字元 `getExtentOfChar` 判斷，避免環形 text path bbox 過大。
- 無 `d` 屬性的圖形（ellipse、rect、line）保留 `getPointAtLength` 取樣，並以弧長細分剪枝控制成本
- 填色圖形：框完全落在填色（infill）圖形內部時仍會選取（以框中心對 fill 做 winding 判斷，尊重破洞——框在甜甜圈或 O 字內圈時不選取）；中空外框（`fill="none"`）的空腔行為不變。實際拖曳時滑鼠按在填色圖形上會直接點選、無法在其內部起框，此檢查僅在外形判斷都未命中時執行，成本趨近於零

另將 `svgedit.math.rectsIntersect` 從 legacy JS 遷移為 `svgedit/utils/rectsIntersect.ts`。點選（click target）與路徑節點框選行為不變。

## Summary

Rubber-band multiselect used plain bounding-box overlap, so a band drawn inside the empty interior of a hollow shape (a C-shaped path, a sparse group) still selected it. This PR adds a precise narrow phase after the existing bbox broad phase:

- Groups recurse into children, each tested with its own bbox and geometry
- `<path>` elements are parsed once with paper.js for a curve-vs-rect intersection plus a subpath-inside-band containment check; `d`-less shapes (ellipse, rect, line) keep `getPointAtLength` probing, pruned by arc-length subdivision
- Text is tested per character via `getExtentOfChar`, fixing text-on-path being selected through its ring-shaped bbox
- Filled shapes: a band fully inside a filled (infilled) shape still selects it (band-center winding test against the fill, respecting holes — a band inside a donut hole or an O's counter selects nothing); hollow outlines (`fill="none"`) keep the cavity behavior. Interactively a marquee can't start inside a filled shape (mousedown click-selects it), and the check only runs when the outline tests miss, so the cost is negligible

Also migrates `svgedit.math.rectsIntersect` from legacy JS to `svgedit/utils/rectsIntersect.ts`. Click targeting and path-node marquee selection are unchanged.

## Test plan

- [x] Unit tests: 19 specs in `elementIntersectsRect.spec.ts` (C-shape cavity vs touching, scaled elements, sparse groups, paper.js path branch incl. glyph-inside-band, filled shapes & donut holes, text extents, probe-count bound, huge-band regression)
- [x] CI e2e green (offset-result and text-on-path band-select cases)
- [x] Manual: band inside vs touching a C shape, rotated line, rotated group with circle and lines
- [x] Manual: text on path — band inside the circle no longer selects; converted-to-path text band-selects instantly (measured 224ms → 14ms)
- [x] Manual: imported SVG (`use`/nested groups) and photos band-select normally
- [x] Manual: path edit mode node marquee unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFgXFfceNpimdEdyJzMCKh
