### PR TITLE
Extract flip into svgedit/operations and fix group flip crash

### DIFF
--- a/packages/core/src/web/app/components/beambox/RightPanel/DimensionPanel/DimensionPanel.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/DimensionPanel/DimensionPanel.spec.tsx
@@ -39,7 +39,6 @@ const mockChangeSelectedAttribute = jest.fn();
 const mockSetSvgElemPosition = jest.fn();
 const mockChangeSelectedAttributeNoUndo = jest.fn();
 const setSvgElemSize = jest.fn();
-const flipSelectedElements = jest.fn();
 
 jest.mock('@core/helpers/svg-editor-helper', () => ({
   getSVGAsync: (callback) => {
@@ -47,7 +46,6 @@ jest.mock('@core/helpers/svg-editor-helper', () => ({
       Canvas: {
         changeSelectedAttribute: (...args) => mockChangeSelectedAttribute(...args),
         changeSelectedAttributeNoUndo: (...args) => mockChangeSelectedAttributeNoUndo(...args),
-        flipSelectedElements: (...args) => flipSelectedElements(...args),
         setSvgElemPosition: (...args) => mockSetSvgElemPosition(...args),
         setSvgElemSize: (...args) => setSvgElemSize(...args),
       },

--- a/packages/core/src/web/app/components/beambox/RightPanel/DimensionPanel/FlipButtons.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/DimensionPanel/FlipButtons.spec.tsx
@@ -6,14 +6,8 @@ import { useScreenStore } from '@core/app/stores/screenStore';
 
 const mockFlipSelectedElements = jest.fn();
 
-jest.mock('@core/helpers/svg-editor-helper', () => ({
-  getSVGAsync: (callback) => {
-    callback({
-      Canvas: {
-        flipSelectedElements: (...args) => mockFlipSelectedElements(...args),
-      },
-    });
-  },
+jest.mock('@core/app/svgedit/operations/flip', () => ({
+  flipSelectedElements: (...args) => mockFlipSelectedElements(...args),
 }));
 
 jest.mock('@core/helpers/useI18n', () => () => ({

--- a/packages/core/src/web/app/components/beambox/RightPanel/DimensionPanel/FlipButtons.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/DimensionPanel/FlipButtons.tsx
@@ -4,19 +4,12 @@ import { Button } from 'antd';
 
 import DimensionPanelIcons from '@core/app/icons/dimension-panel/DimensionPanelIcons';
 import { useIsMobile } from '@core/app/stores/screenStore';
-import { getSVGAsync } from '@core/helpers/svg-editor-helper';
+import { flipSelectedElements } from '@core/app/svgedit/operations/flip';
 import useI18n from '@core/helpers/useI18n';
-import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 
 import ObjectPanelItem from '../ObjectPanelItem';
 
 import styles from './FlipButtons.module.scss';
-
-let svgCanvas: ISVGCanvas;
-
-getSVGAsync((globalSVG) => {
-  svgCanvas = globalSVG.Canvas;
-});
 
 const FlipButtons = (): React.JSX.Element => {
   const t = useI18n().beambox.right_panel.object_panel;
@@ -29,12 +22,12 @@ const FlipButtons = (): React.JSX.Element => {
           {
             icon: <DimensionPanelIcons.HFlip />,
             label: t.hflip,
-            onClick: () => svgCanvas.flipSelectedElements(-1, 1),
+            onClick: () => flipSelectedElements(-1, 1),
           },
           {
             icon: <DimensionPanelIcons.VFlip />,
             label: t.vflip,
-            onClick: () => svgCanvas.flipSelectedElements(1, -1),
+            onClick: () => flipSelectedElements(1, -1),
           },
         ]}
         content={<DimensionPanelIcons.HFlip />}
@@ -49,14 +42,14 @@ const FlipButtons = (): React.JSX.Element => {
       <Button
         icon={<DimensionPanelIcons.HFlip />}
         id="horizontal_flip"
-        onClick={() => svgCanvas.flipSelectedElements(-1, 1)}
+        onClick={() => flipSelectedElements(-1, 1)}
         title={t.hflip}
         type="text"
       />
       <Button
         icon={<DimensionPanelIcons.VFlip />}
         id="vertical_flip"
-        onClick={() => svgCanvas.flipSelectedElements(1, -1)}
+        onClick={() => flipSelectedElements(1, -1)}
         title={t.vflip}
         type="text"
       />

--- a/packages/core/src/web/app/svgedit/operations/flip.spec.ts
+++ b/packages/core/src/web/app/svgedit/operations/flip.spec.ts
@@ -1,0 +1,132 @@
+const mockCall = jest.fn();
+const mockGetSelectedElements = jest.fn();
+const mockMoveElements = jest.fn();
+const mockSetRotationAngle = jest.fn();
+const mockAddCommandToHistory = jest.fn();
+const mockRecalculateDimensions = jest.fn();
+
+class FakeBatchCommand {
+  subs: unknown[] = [];
+  constructor(public name: string) {}
+  addSubCommand = (cmd: unknown) => this.subs.push(cmd);
+  isEmpty = () => this.subs.length === 0;
+}
+
+jest.mock('@core/app/svgedit/history/history', () => ({
+  BatchCommand: FakeBatchCommand,
+  ChangeElementCommand: class {
+    constructor(
+      public elem: Element,
+      public oldValues: Record<string, string>,
+    ) {}
+  },
+}));
+jest.mock('@core/app/svgedit/selection', () => ({ getSelectedElements: () => mockGetSelectedElements() }));
+jest.mock('@core/app/svgedit/selector', () => ({
+  getSelectorManager: () => ({ requestSelector: () => ({ resize: jest.fn(), show: jest.fn() }) }),
+}));
+jest.mock('@core/helpers/jimp-helper', () => ({ imageToUrl: jest.fn(), urlToImage: jest.fn() }));
+jest.mock('@core/helpers/svg-editor-helper', () => ({
+  getSVGAsync: (cb: any) => cb({ Canvas: { call: (...args: any[]) => mockCall(...args) } }),
+}));
+jest.mock('../history/undoManager', () => ({
+  addCommandToHistory: (...args: any[]) => mockAddCommandToHistory(...args),
+}));
+jest.mock('../transform/recalculate', () => ({
+  recalculateDimensions: (...args: any[]) => mockRecalculateDimensions(...args),
+  setStartTransform: jest.fn(),
+}));
+jest.mock('../transform/rotation', () => ({
+  getRotationAngle: (elem: Element) => Number(elem.getAttribute('data-angle') || 0),
+  setRotationAngle: (...args: any[]) => mockSetRotationAngle(...args),
+}));
+// jsdom has no SVGTransformList; expose the element so the math mock can read its transform attribute.
+jest.mock('../transform/transformlist', () => ({
+  getTransformList: (elem: Element) => ({
+    appendItem: jest.fn(),
+    elem,
+    insertItemBefore: jest.fn(),
+    numberOfItems: elem.getAttribute('transform') ? 1 : 0,
+  }),
+}));
+jest.mock('../utils/getBBox', () => ({
+  getBBox: (elem: Element) => {
+    const [x, y, width, height] = (elem.getAttribute('data-bbox') || '0 0 0 0').split(' ').map(Number);
+
+    return { height, width, x, y };
+  },
+}));
+jest.mock('./move', () => ({ moveElements: (...args: any[]) => mockMoveElements(...args) }));
+
+import { flipSelectedElements } from './flip';
+
+const translateMatrix = (e: number, f: number) => ({
+  a: 1,
+  b: 0,
+  c: 0,
+  d: 1,
+  e,
+  f,
+  inverse: () => translateMatrix(-e, -f),
+});
+
+const el = (tag: string, attrs: Record<string, string>, children: Element[] = []) => {
+  const node = document.createElementNS('http://www.w3.org/2000/svg', tag);
+
+  Object.entries(attrs).forEach(([k, v]) => node.setAttribute(k, v));
+  children.forEach((c) => node.appendChild(c));
+
+  return node;
+};
+
+describe('flipSelectedElements', () => {
+  beforeAll(() => {
+    (window as any).svgedit.math = {
+      hasMatrixTransform: () => false,
+      transformListToTransform: ({ elem }: { elem: Element }) => {
+        const m = /translate\(([-\d.]+),([-\d.]+)\)/.exec(elem.getAttribute('transform') || '');
+
+        return { matrix: translateMatrix(Number(m?.[1] ?? 0), Number(m?.[2] ?? 0)) };
+      },
+      transformPoint: (x: number, y: number, m: any) => ({ x: m.a * x + m.c * y + m.e, y: m.b * x + m.d * y + m.f }),
+    };
+
+    const svgroot = el('svg', { id: 'svgroot' });
+
+    (svgroot as any).createSVGTransform = () => ({ setScale: jest.fn(), setTranslate: jest.fn() });
+    document.body.appendChild(svgroot);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRecalculateDimensions.mockReturnValue(null);
+    mockMoveElements.mockReturnValue(null);
+  });
+
+  test('flips nested groups around the shared center, restores rotation, emits changed once', async () => {
+    // Outer group centered at (100, 100). DOM order puts the rotated, translated inner group before the
+    // sibling path, so the inner group's local center is on the stack when the sibling is reached.
+    const inner = el('path', { 'data-bbox': '0 50 60 100', id: 'inner' });
+    const innerGroup = el('g', { 'data-angle': '30', id: 'g1', transform: 'translate(50,0)' }, [inner]);
+    const sibling = el('path', { 'data-bbox': '100 50 100 100', id: 'sibling' });
+    const group = el('g', { 'data-bbox': '0 0 200 200', id: 'g0' }, [innerGroup, sibling]);
+
+    mockGetSelectedElements.mockReturnValue([group]);
+
+    await flipSelectedElements(-1, 1);
+
+    // inner: center (100,100) in group coords → (50,100) in g1 coords; inner's own center is (30,100).
+    expect(mockMoveElements).toHaveBeenCalledWith([40], [0], [inner], false, true);
+    // sibling: uses the outer center (100,100), not g1's leaked (50,100); own center is (150,100).
+    expect(mockMoveElements).toHaveBeenCalledWith([-100], [0], [sibling], false, true);
+
+    // Rotated group: zeroed on entry and negated on exit, both recorded into the batch for redo.
+    const batch = mockAddCommandToHistory.mock.calls[0][0];
+
+    expect(mockSetRotationAngle).toHaveBeenCalledWith(innerGroup, 0, { parentCmd: batch });
+    expect(mockSetRotationAngle).toHaveBeenCalledWith(innerGroup, -30, { parentCmd: batch });
+
+    expect(mockCall).toHaveBeenCalledTimes(1);
+    expect(mockCall).toHaveBeenCalledWith('changed', [group]);
+  });
+});

--- a/packages/core/src/web/app/svgedit/operations/flip.ts
+++ b/packages/core/src/web/app/svgedit/operations/flip.ts
@@ -1,0 +1,196 @@
+import history from '@core/app/svgedit/history/history';
+import selectionManager from '@core/app/svgedit/selection';
+import selector from '@core/app/svgedit/selector';
+import jimpHelper from '@core/helpers/jimp-helper';
+import { getSVGAsync } from '@core/helpers/svg-editor-helper';
+import type { IBatchCommand, ICommand } from '@core/interfaces/IHistory';
+import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
+
+import changeAttribute from '../history/changeAttribute';
+import undoManager from '../history/undoManager';
+import { recalculateDimensions, setStartTransform } from '../transform/recalculate';
+import { getRotationAngle, setRotationAngle } from '../transform/rotation';
+import { getTransformList } from '../transform/transformlist';
+import { getBBox } from '../utils/getBBox';
+
+import { moveElements } from './move';
+
+const { svgedit } = window;
+
+let svgCanvas: ISVGCanvas;
+
+getSVGAsync(({ Canvas }) => {
+  svgCanvas = Canvas;
+});
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/** Each axis is 1 (keep) or -1 (mirror). */
+interface FlipParams {
+  horizon: number;
+  vertical: number;
+}
+
+const addSubCommand = (batchCmd: IBatchCommand, cmd?: ICommand | null) => {
+  if (!cmd || ('isEmpty' in cmd && (cmd as IBatchCommand).isEmpty())) return;
+
+  batchCmd.addSubCommand(cmd);
+};
+
+/** Map a point from a group's parent coordinate system into the group's own. */
+const toLocalPoint = ({ x, y }: Point, group: SVGGraphicsElement): Point => {
+  const tlist = getTransformList(group);
+
+  if (!tlist || tlist.numberOfItems === 0) return { x, y };
+
+  const inverse = svgedit.math.transformListToTransform(tlist).matrix.inverse();
+
+  return svgedit.math.transformPoint(x, y, inverse);
+};
+
+/** Mirror the raster data of an image in place (both the display href and the original source). */
+const flipImage = async (image: SVGImageElement, { horizon, vertical }: FlipParams): Promise<IBatchCommand> => {
+  const batchCmd = new history.BatchCommand('Flip image');
+  const origImage = image.getAttribute('origImage');
+
+  if (origImage) {
+    const data = await jimpHelper.urlToImage(origImage);
+
+    data.flip(horizon === -1, vertical === -1);
+    addSubCommand(batchCmd, changeAttribute(image, { origImage: await jimpHelper.imageToUrl(data) }));
+  }
+
+  const flipCanvas = document.createElement('canvas');
+  const ctx = flipCanvas.getContext('2d')!;
+
+  flipCanvas.width = Number(image.getAttribute('width'));
+  flipCanvas.height = Number(image.getAttribute('height'));
+  ctx.translate(horizon < 0 ? flipCanvas.width : 0, vertical < 0 ? flipCanvas.height : 0);
+  ctx.scale(horizon, vertical);
+  ctx.drawImage(image, 0, 0, flipCanvas.width, flipCanvas.height);
+
+  addSubCommand(batchCmd, changeAttribute(image, { 'xlink:href': flipCanvas.toDataURL() }));
+
+  return batchCmd;
+};
+
+/**
+ * Flip a single (non-group) element across `center`, given in the element's parent coordinate system.
+ * Does not emit `changed`; callers batch that once for the whole operation.
+ */
+export const flipElement = async (
+  elem: SVGGraphicsElement,
+  center: Point,
+  params: FlipParams,
+): Promise<IBatchCommand> => {
+  const { horizon, vertical } = params;
+  const batchCmd = new history.BatchCommand('Flip Single Element');
+  const angle = getRotationAngle(elem);
+
+  // Mirroring negates rotation: bake the current transform in at 0°, then re-rotate by -angle.
+  const oldTransform = elem.getAttribute('transform') ?? '';
+
+  setRotationAngle(elem, 0);
+  recalculateDimensions(elem);
+  setRotationAngle(elem, -angle);
+  addSubCommand(batchCmd, new history.ChangeElementCommand(elem, { transform: oldTransform }));
+
+  const bbox = getBBox(elem);
+  const cx = bbox.x + bbox.width / 2;
+  const cy = bbox.y + bbox.height / 2;
+
+  if (elem.tagName === 'image') {
+    addSubCommand(batchCmd, await flipImage(elem as SVGImageElement, params));
+  } else {
+    setStartTransform(elem.getAttribute('transform'));
+
+    const svgroot = document.getElementById('svgroot') as unknown as SVGSVGElement;
+    const tlist = getTransformList(elem)!;
+    const translateOrigin = svgroot.createSVGTransform();
+    const scale = svgroot.createSVGTransform();
+    const translateBack = svgroot.createSVGTransform();
+
+    translateOrigin.setTranslate(-cx, -cy);
+    scale.setScale(horizon, vertical);
+    translateBack.setTranslate(cx, cy);
+
+    // Mirror about the element's own center: [translateBack][scale][translateOrigin].
+    if (svgedit.math.hasMatrixTransform(tlist)) {
+      const pos = angle ? 1 : 0;
+
+      tlist.insertItemBefore(translateOrigin, pos);
+      tlist.insertItemBefore(scale, pos);
+      tlist.insertItemBefore(translateBack, pos);
+    } else {
+      tlist.appendItem(translateBack);
+      tlist.appendItem(scale);
+      tlist.appendItem(translateOrigin);
+    }
+
+    addSubCommand(batchCmd, recalculateDimensions(elem));
+  }
+
+  // Then mirror the element's position across the shared center.
+  const dx = horizon < 0 ? 2 * (center.x - cx) : 0;
+  const dy = vertical < 0 ? 2 * (center.y - cy) : 0;
+
+  addSubCommand(batchCmd, moveElements([dx], [dy], [elem], false, true));
+
+  return batchCmd;
+};
+
+/**
+ * Flip the selected elements across their own centers.
+ * Groups are walked recursively: each leaf is flipped across the top-level center mapped into its own
+ * coordinate system, and a rotated group has its rotation negated.
+ */
+export const flipSelectedElements = async (horizon = 1, vertical = 1): Promise<void> => {
+  const selectedElements = selectionManager.getSelectedElements() as SVGGraphicsElement[];
+  const batchCmd = new history.BatchCommand('Flip Elements');
+  const params = { horizon, vertical };
+
+  for (const elem of selectedElements) {
+    const bbox = getBBox(elem);
+    const centers: Point[] = [{ x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height / 2 }];
+    // `exitAngle` marks the second visit of a group, after all its children were flipped.
+    const stack: Array<{ elem: SVGGraphicsElement; exitAngle?: number }> = [{ elem }];
+
+    while (stack.length > 0) {
+      const { elem: current, exitAngle } = stack.pop()!;
+
+      if (exitAngle !== undefined) {
+        centers.pop();
+
+        if (exitAngle !== 0) setRotationAngle(current, -exitAngle, { parentCmd: batchCmd });
+
+        continue;
+      }
+
+      if (current.tagName !== 'g') {
+        addSubCommand(batchCmd, await flipElement(current, centers[centers.length - 1], params));
+        continue;
+      }
+
+      const angle = getRotationAngle(current);
+
+      if (angle !== 0) setRotationAngle(current, 0, { parentCmd: batchCmd });
+
+      stack.push({ elem: current, exitAngle: angle });
+      centers.push(toLocalPoint(centers[centers.length - 1], current));
+      Array.from(current.children).forEach((child) => stack.push({ elem: child as SVGGraphicsElement }));
+    }
+
+    const elemSelector = selector.getSelectorManager().requestSelector(elem);
+
+    elemSelector?.resize();
+    elemSelector?.show(selectedElements.length === 1);
+  }
+
+  undoManager.addCommandToHistory(batchCmd);
+  svgCanvas.call('changed', selectedElements);
+};
+
+export default { flipElement, flipSelectedElements };

--- a/packages/core/src/web/app/svgedit/svgcanvas.ts
+++ b/packages/core/src/web/app/svgedit/svgcanvas.ts
@@ -51,7 +51,6 @@ import updateElementColor from '@core/helpers/color/updateElementColor';
 import { getAttributes } from '@core/helpers/element/attribute';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import i18n from '@core/helpers/i18n';
-import jimpHelper from '@core/helpers/jimp-helper';
 import { initLayerConfig } from '@core/helpers/layer/layer-config-helper';
 import * as LayerHelper from '@core/helpers/layer/layer-helper';
 import logMemory from '@core/helpers/log-memory';
@@ -62,7 +61,6 @@ import sanitizeXmlString from '@core/helpers/sanitize-xml-string';
 import { getSVGAsync } from '@core/helpers/svg-editor-helper';
 import type { Units } from '@core/helpers/units';
 import units from '@core/helpers/units';
-import imageProcessor from '@core/implementations/imageProcessor';
 import type ISVGCanvas from '@core/interfaces/ISVGCanvas';
 import type { IPoint } from '@core/interfaces/ISVGCanvas';
 import type ISVGConfig from '@core/interfaces/ISVGConfig';
@@ -3412,185 +3410,6 @@ export default $.SvgCanvas = function (container: SVGElement, config: ISVGConfig
 
       j += 1;
     }
-  };
-
-  this.flipSelectedElements = async function (horizon = 1, vertical = 1) {
-    const selectedElements = selectionManager.getSelectedElements();
-    const batchCmd = new history.BatchCommand('Flip Elements');
-
-    for (let i = 0; i < selectedElements.length; ++i) {
-      const elem = selectedElements[i];
-      const bbox = getBBox(elem);
-      const center = { x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height / 2 };
-      const centers = [center];
-      const flipPara = { horizon, vertical };
-
-      setStartTransform(elem.getAttribute('transform')); // maybe not need
-
-      let cmd;
-      const stack: Array<{ elem: SVGElement; originalAngle?: number }> = [{ elem }];
-
-      while (stack.length > 0) {
-        const { elem: topElem, originalAngle } = stack.pop()!;
-
-        if (topElem!.tagName !== 'g') {
-          cmd = await this.flipElementWithRespectToCenter(topElem, centers[centers.length - 1], flipPara);
-
-          if (cmd && !cmd.isEmpty()) {
-            batchCmd.addSubCommand(cmd);
-          }
-        } else if (originalAngle == null) {
-          const angle = getRotationAngle(topElem);
-
-          if (angle !== 0) {
-            setRotationAngle(topElem, 0, { parentCmd: batchCmd });
-
-            stack.push({ elem: topElem, originalAngle: angle });
-          }
-
-          // if g has tlist, inverse to flip element inside
-          const tlist = svgedit.transformlist.getTransformList(topElem);
-          let { x, y } = centers[centers.length - 1];
-
-          for (let j = 0; j < tlist.numberOfItems; j++) {
-            const t = tlist.getItem(j);
-
-            // type 4 does not matter
-            if (t.type === 4) {
-              continue;
-            }
-
-            const { a, b, c, d, e, f } = t.matrix;
-            const delta = a * d - b * c;
-
-            x = (d * x - c * y + c * f - d * e) / delta;
-            y = (-b * x + a * y - a * f + b * e) / delta;
-          }
-          centers.push({ x, y });
-          topElem.childNodes.forEach((elem) => {
-            stack.push({ elem: elem as SVGElement });
-          });
-        } else {
-          centers.pop();
-          setRotationAngle(topElem, -originalAngle, { addToHistory: false });
-        }
-      }
-      selectorManager.requestSelector(elem)?.resize();
-      selectorManager.requestSelector(elem)?.show(selectedElements.length === 1);
-      svgEditor.updateContextPanel();
-    }
-    addCommandToHistory(batchCmd);
-  };
-
-  this.flipElementWithRespectToCenter = async function (elem, center, flipPara) {
-    const batchCmd = new history.BatchCommand('Flip Single Element');
-
-    const angle = svgedit.utilities.getRotationAngle(elem);
-
-    canvas.undoMgr.beginUndoableChange('transform', [elem]);
-    setRotationAngle(elem, 0, { addToHistory: false });
-    recalculateDimensions(elem);
-    setRotationAngle(elem, -angle, { addToHistory: false });
-
-    let cmd = canvas.undoMgr.finishUndoableChange();
-
-    if (cmd && !cmd.isEmpty()) {
-      batchCmd.addSubCommand(cmd);
-    }
-
-    const bbox = getBBox(elem);
-    const cx = bbox.x + bbox.width / 2;
-    const cy = bbox.y + bbox.height / 2;
-    const dx = flipPara.horizon < 0 ? 2 * (center.x - cx) : 0;
-    const dy = flipPara.vertical < 0 ? 2 * (center.y - cy) : 0;
-    const tlist = svgedit.transformlist.getTransformList(elem);
-
-    if (elem.tagName !== 'image') {
-      setStartTransform(elem.getAttribute('transform'));
-
-      const translateOrigin = svgroot.createSVGTransform();
-      const scale = svgroot.createSVGTransform();
-      const translateBack = svgroot.createSVGTransform();
-
-      translateOrigin.setTranslate(-cx, -cy);
-      scale.setScale(flipPara.horizon, flipPara.vertical);
-      translateBack.setTranslate(cx, cy);
-
-      const hasMatrix = svgedit.math.hasMatrixTransform(tlist);
-
-      if (hasMatrix) {
-        const pos = angle ? 1 : 0;
-
-        tlist.insertItemBefore(translateOrigin, pos);
-        tlist.insertItemBefore(scale, pos);
-        tlist.insertItemBefore(translateBack, pos);
-      } else {
-        tlist.appendItem(translateBack);
-        tlist.appendItem(scale);
-        tlist.appendItem(translateOrigin);
-      }
-
-      cmd = recalculateDimensions(elem);
-    } else {
-      cmd = await this._flipImage(elem, flipPara.horizon, flipPara.vertical);
-    }
-
-    if (cmd && !cmd.isEmpty()) {
-      batchCmd.addSubCommand(cmd);
-    }
-
-    cmd = moveElements([dx], [dy], [elem], false);
-    batchCmd.addSubCommand(cmd);
-
-    return batchCmd;
-  };
-
-  this._flipImage = async function (image, horizon = 1, vertical = 1) {
-    const batchCmd = new history.BatchCommand('Flip image');
-
-    if (horizon === 1 && vertical === 1) {
-      return;
-    }
-
-    let cmd;
-    const origImage = $(image).attr('origImage');
-
-    if (origImage) {
-      let data: any = await jimpHelper.urlToImage(origImage);
-
-      data.flip(horizon === -1, vertical === -1);
-      data = await data.getBufferAsync(imageProcessor.MIME_PNG);
-      data = new Blob([data]);
-
-      const src = URL.createObjectURL(data);
-
-      canvas.undoMgr.beginUndoableChange('origImage', [image]);
-      image.setAttribute('origImage', src);
-      cmd = canvas.undoMgr.finishUndoableChange();
-
-      if (cmd && !cmd.isEmpty()) {
-        batchCmd.addSubCommand(cmd);
-      }
-    }
-
-    const flipCanvas = document.createElement('canvas');
-    const flipContext = flipCanvas.getContext('2d');
-
-    flipCanvas.width = Number(image.getAttribute('width'));
-    flipCanvas.height = Number(image.getAttribute('height'));
-    flipContext.translate(horizon < 0 ? flipCanvas.width : 0, vertical < 0 ? flipCanvas.height : 0);
-    flipContext.scale(horizon, vertical);
-    flipContext.drawImage(image, 0, 0, flipCanvas.width, flipCanvas.height);
-
-    canvas.undoMgr.beginUndoableChange('xlink:href', [image]);
-    image.setAttribute('xlink:href', flipCanvas.toDataURL());
-    cmd = canvas.undoMgr.finishUndoableChange();
-
-    if (cmd && !cmd.isEmpty()) {
-      batchCmd.addSubCommand(cmd);
-    }
-
-    return batchCmd;
   };
 
   // Function: alignSelectedElements

--- a/packages/core/src/web/interfaces/ISVGCanvas.ts
+++ b/packages/core/src/web/interfaces/ISVGCanvas.ts
@@ -61,7 +61,6 @@ export default interface ISVGCanvas {
   embedImage(url: string, callback?: (dataURI: string) => void): void;
   events: EventEmitter;
   findMatchedAlignPoints: (x: number, y: number) => Record<'farthest' | 'nearest', Record<'x' | 'y', IPoint | null>>;
-  flipSelectedElements: (horizon?: number, vertical?: number) => Promise<void>;
   getContainer: () => SVGElement;
   getContentElem: () => SVGGElement;
   getCurrentConfig: () => ISVGConfig;


### PR DESCRIPTION
## 摘要

- 翻轉群組時,每個子元素的 `moveElements` 都會觸發 `changed` 事件並重跑 context panel 更新,大型群組(例如 56 個旋轉路徑)會觸發 React 的 `Maximum update depth exceeded` 而崩潰。現在整個翻轉只發送一次 `changed`。
- 將舊的 `flipSelectedElements` / `flipElementWithRespectToCenter` / `_flipImage` 從 `svgcanvas.ts` 抽出至 `svgedit/operations/flip.ts`,改用已抽出的 TS helpers(`getBBox`、`setRotationAngle`、`getTransformList`、`recalculateDimensions`、`moveElements`、`changeAttribute`、`jimpHelper.imageToUrl`)。
- `FlipButtons` 直接 import `flipSelectedElements`,並自 `ISVGCanvas` 移除該方法。
- 順帶修正三個既有 bug:
  - 巢狀且未旋轉的群組會把自己的翻轉中心洩漏給後續的兄弟元素(DFS 只在旋轉群組時 pop)。
  - 旋轉群組在 redo 後角度變成 0(復原旋轉未寫入 history)。
  - 手寫的反矩陣在計算 `y` 時使用了已更新的 `x`,群組含旋轉/斜切 matrix 時結果錯誤。

## Summary

- Flipping a group emitted `changed` once per leaf through `moveElements`, re-running the full context-panel update for every child. Large groups (e.g. 56 rotated paths) tripped React's `Maximum update depth exceeded`. The whole flip now emits `changed` once.
- Moves `flipSelectedElements` / `flipElementWithRespectToCenter` / `_flipImage` out of `svgcanvas.ts` into `svgedit/operations/flip.ts`, built on the extracted TS helpers (`getBBox`, `setRotationAngle`, `getTransformList`, `recalculateDimensions`, `moveElements`, `changeAttribute`, `jimpHelper.imageToUrl`).
- `FlipButtons` imports `flipSelectedElements` directly; the method is removed from `ISVGCanvas`.
- Fixes three pre-existing bugs along the way:
  - Nested non-rotated groups leaked their flip center onto later siblings (the DFS only popped for rotated groups).
  - Redo left a rotated group at 0° because the rotation restore was never recorded.
  - The hand-rolled matrix inverse reused the already-updated `x` when computing `y`, wrong for groups carrying a rotation/skew matrix.

## Test plan

- [x] New `flip.spec.ts`: nested rotated group flips around the shared center, sibling is not affected by the inner group's center, rotation restore is recorded into the batch, `changed` fires exactly once.
- [x] `pnpm test DimensionPanel` (FlipButtons / DimensionPanel specs) pass.
- [x] `tsc` and `eslint` clean on touched files.
- [x] Manual: open `example-group.beam`, select `svg_11`, flip H and V — no crash, result mirrored, undo/redo round-trips.
- [x] Manual: flip a rotated path, an image with `origImage`, and a text element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LetpStKLquiPoHREwsrCvs
