### PR TITLE
Improve text selection performance (font caches + Electron menu flush)

### DIFF
--- a/apps/app/src/implementations/menu.ts
+++ b/apps/app/src/implementations/menu.ts
@@ -19,9 +19,15 @@ const updateWindowsMenu = () => {
   }
 };
 
+type MenuItemStatus = { checked?: boolean; enabled?: boolean; visible?: boolean };
+
 class Menu extends AbstractMenu {
   private communicator;
-  private menuItemChanges: { [key: string]: { checked?: boolean; enabled?: boolean; visible?: boolean } } = {};
+  private menuItemChanges: { [id: string]: MenuItemStatus } = {};
+  // Status last applied to the native menu; lets no-op flushes skip the sync-IPC @electron/remote calls
+  private appliedMenuItemStatus: { [id: string]: MenuItemStatus } = {};
+  // Menu tree walked once per menu build; each item access via @electron/remote is a sync IPC round-trip
+  private menuItemsById: Map<string, Electron.MenuItem[]> | null = null;
 
   constructor(aCommunicator: any) {
     super();
@@ -94,6 +100,10 @@ class Menu extends AbstractMenu {
   };
 
   initMenuItemStatus = (): void => {
+    // the native menu was rebuilt, so the applied mirror and cached item references are stale
+    this.appliedMenuItemStatus = {};
+    this.menuItemsById = null;
+
     const globalPreference = useGlobalPreferenceStore.getState();
     const dockableStore = useDockableStore.getState();
 
@@ -156,44 +166,57 @@ class Menu extends AbstractMenu {
     }
   }
 
-  private findAllMenuItemsByIds = (menu: Electron.Menu, ids: Set<string>): Electron.MenuItem[] => {
-    const results: Electron.MenuItem[] = [];
+  private getMenuItemsByIds = (menu: Electron.Menu, ids: string[]): Electron.MenuItem[] => {
+    if (!this.menuItemsById) {
+      const map = new Map<string, Electron.MenuItem[]>();
+      const collect = (current: Electron.Menu): void => {
+        for (const item of current.items) {
+          if (item.id) map.set(item.id, [...(map.get(item.id) ?? []), item]);
 
-    for (const item of menu.items) {
-      if (ids.has(item.id)) results.push(item);
+          if (item.submenu) collect(item.submenu);
+        }
+      };
 
-      if (item.submenu) results.push(...this.findAllMenuItemsByIds(item.submenu, ids));
+      collect(menu);
+      this.menuItemsById = map;
     }
 
-    return results;
+    return ids.flatMap((id) => this.menuItemsById!.get(id) ?? []);
+  };
+
+  // drop pending changes that match what is already applied to the native menu
+  private pruneNoopChanges = (): void => {
+    for (const [id, changes] of Object.entries(this.menuItemChanges)) {
+      const applied = this.appliedMenuItemStatus[id];
+
+      if (applied && Object.entries(changes).every(([key, value]) => applied[key as keyof MenuItemStatus] === value)) {
+        delete this.menuItemChanges[id];
+      }
+    }
   };
 
   updateMenuItemChangesHandler = funnel(
     (): void => {
+      this.pruneNoopChanges();
+
+      const ids = Object.keys(this.menuItemChanges);
+
+      if (ids.length === 0) return;
+
       const menu = ElectronMenu.getApplicationMenu();
 
       if (!menu) return;
 
-      const ids = Object.keys(this.menuItemChanges);
-      const idSet = new Set(ids);
-      const menuItems = this.findAllMenuItemsByIds(menu, idSet);
-
-      for (const menuItem of menuItems) {
-        const changes = this.menuItemChanges[menuItem.id];
-
-        if (changes.checked !== undefined) {
-          menuItem.checked = changes.checked;
-        }
-
-        if (changes.enabled !== undefined) {
-          menuItem.enabled = changes.enabled;
-        }
-
-        if (changes.visible !== undefined) {
-          menuItem.visible = changes.visible;
-        }
+      for (const menuItem of this.getMenuItemsByIds(menu, ids)) {
+        Object.assign(menuItem, this.menuItemChanges[menuItem.id]);
       }
+
       this.rerenderMenu();
+
+      for (const id of ids) {
+        this.appliedMenuItemStatus[id] = { ...this.appliedMenuItemStatus[id], ...this.menuItemChanges[id] };
+      }
+
       this.menuItemChanges = {};
     },
     { minQuietPeriodMs: 100, triggerAt: 'end' },

--- a/packages/core/src/web/app/actions/beambox/font-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/font-funcs.ts
@@ -7,6 +7,7 @@ import Progress from '@core/app/actions/progress-caller';
 import AlertConstants from '@core/app/constants/alert-constants';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
 import { useGoogleFontStore } from '@core/app/stores/googleFontStore';
+import { useStorageStore } from '@core/app/stores/storageStore';
 import changeAttribute from '@core/app/svgedit/history/changeAttribute';
 import history from '@core/app/svgedit/history/history';
 import undoManager from '@core/app/svgedit/history/undoManager';
@@ -19,6 +20,7 @@ import SvgLaserParser from '@core/helpers/api/svg-laser-parser';
 import updateElementColor from '@core/helpers/color/updateElementColor';
 import type { AttributeMap } from '@core/helpers/element/attribute';
 import { getAttributes, setAttributes } from '@core/helpers/element/attribute';
+import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import { toggleUnsavedChangedDialog } from '@core/helpers/file/export';
 import fontHelper from '@core/helpers/fonts/fontHelper';
 import { getOS } from '@core/helpers/getOS';
@@ -94,10 +96,27 @@ const fontNameMap = new Map<string, string>();
 // Cache for available font families and lowercase mappings for O(1) lookup
 let lowercaseFontFamilyMap: Map<string, string> | null = null;
 
+// Cache computed family lists per variant; the underlying font list only changes
+// when monotype fonts finish loading or the active language changes
+const familiesCache = new Map<string, { families: string[]; lowercaseMap: Map<string, string> }>();
+const clearFamiliesCache = () => familiesCache.clear();
+
+eventEmitterFactory.createEventEmitter('font').on('GET_MONOTYPE_FONTS', clearFamiliesCache);
+useStorageStore.subscribe((state) => state['active-lang'], clearFamiliesCache);
+
 const requestAvailableFontFamilies = ({
   queryByLang = true,
   withoutMonotype = false,
 }: { queryByLang?: boolean; withoutMonotype?: boolean } = {}) => {
+  const cacheKey = `${queryByLang}:${withoutMonotype}`;
+  const cached = familiesCache.get(cacheKey);
+
+  if (cached) {
+    lowercaseFontFamilyMap = cached.lowercaseMap;
+
+    return cached.families;
+  }
+
   // get all available fonts in local
   const fonts = fontHelper.getAvailableFonts({ queryByLang, withoutMonotype });
 
@@ -126,6 +145,7 @@ const requestAvailableFontFamilies = ({
   );
 
   lowercaseFontFamilyMap = new Map(sortedFamilies.map((family) => [family.toLowerCase(), family]));
+  familiesCache.set(cacheKey, { families: sortedFamilies, lowercaseMap: lowercaseFontFamilyMap });
 
   return sortedFamilies;
 };

--- a/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/TextOptions/index.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/OptionsBlocks/TextOptions/index.tsx
@@ -32,7 +32,11 @@ import {
 } from '@core/helpers/fonts/fontUtils';
 import { googleFontsApiCache } from '@core/helpers/fonts/googleFontsApiCache';
 import type { FontOption } from '@core/helpers/fonts/renderTextOptions';
-import { fontFamilySelectFilterOption, renderTextOptions } from '@core/helpers/fonts/renderTextOptions';
+import {
+  fontFamilySelectFilterOption,
+  getFontFamilyOptions,
+  renderTextOptions,
+} from '@core/helpers/fonts/renderTextOptions';
 import useWorkarea from '@core/helpers/hooks/useWorkarea';
 import { updateConfigs } from '@core/helpers/update-configs';
 import useI18n from '@core/helpers/useI18n';
@@ -102,7 +106,7 @@ const TextOptions = ({ elem, isTextPath, showColorPanel, textElements }: Props) 
   const langOptionPanel = lang.beambox.right_panel.object_panel.option_panel;
   const isMobile = useIsMobile();
   const fontHistory = useStorageStore((state) => state['font-history']);
-  const [fontFamilies, setFontFamilies] = useState<string[]>(FontFuncs.requestAvailableFontFamilies());
+  const [fontFamilies, setFontFamilies] = useState<string[]>(() => FontFuncs.requestAvailableFontFamilies());
   const [configs, setConfigs] = useState(defaultTextConfigs);
   const { fontFamily } = configs;
   const workarea = useWorkarea();
@@ -435,7 +439,7 @@ const TextOptions = ({ elem, isTextPath, showColorPanel, textElements }: Props) 
   };
 
   const renderFontFamilyBlock = (): ReactNode => {
-    const options = fontFamilies.map((family) => renderTextOptions(family));
+    const options = getFontFamilyOptions(fontFamilies);
 
     if (isMobile) {
       return (

--- a/packages/core/src/web/helpers/fonts/renderTextOptions.tsx
+++ b/packages/core/src/web/helpers/fonts/renderTextOptions.tsx
@@ -33,6 +33,20 @@ export const renderTextOptions = (family: string, isHistory = false): FontOption
   return isHistory ? { family, label, value: `history-${family}` } : { label, value: family };
 };
 
+// Keyed by array identity: font-funcs caches the families array, so a new array means the list changed
+const fontFamilyOptionsCache = new WeakMap<string[], FontOption[]>();
+
+export const getFontFamilyOptions = (families: string[]): FontOption[] => {
+  let options = fontFamilyOptionsCache.get(families);
+
+  if (!options) {
+    options = families.map((family) => renderTextOptions(family));
+    fontFamilyOptionsCache.set(families, options);
+  }
+
+  return options;
+};
+
 export const fontFamilySelectFilterOption: any = (input: string, option?: FontOption) => {
   if (!option) return false;
 


### PR DESCRIPTION
https://app.clickup.com/t/5719332/86eytwpz6

## 摘要

選取文字物件時,mouse up 到右側面板顯示明顯比選取形狀/群組慢。經過計時分析,瓶頸不在 canvas 端(< 5ms),而是:

1. **TextOptions 每次 render 都重新列舉系統字型** — `useState(FontFuncs.requestAvailableFontFamilies())` 未使用 lazy initializer,每次 render 都執行字型列舉、排序與同步 `storage.set`(約 40ms × 每次點選 render 3 次)
2. **266 個字型選項的 JSX 每次 render 重建**(約 22ms × 3)
3. **Electron 選單 flush 造成每次選取後主執行緒凍結約 250ms** — `findAllMenuItemsByIds` 透過 `@electron/remote` 遍歷整個選單樹,每個屬性存取都是同步 IPC round-trip

修正:

- TextOptions 改用 lazy `useState` initializer
- `font-funcs` 依變體快取 `requestAvailableFontFamilies` 結果(含 lowercase map),於 `GET_MONOTYPE_FONTS` 事件與 `active-lang` 變更時失效
- 字型選項以 WeakMap 依 families 陣列 identity 快取
- Electron 選單:略過與已套用狀態相同的 no-op flush;`id → MenuItem` 對照表每次選單重建只遍歷一次(於 `NewAppMenu`/`TabFocused` 重置)

實測(dev build):文字選取的 input event blocking 由約 500ms 降至約 150ms,選取後的 250ms 選單凍結在狀態未變時完全消除。

## Summary

Selecting a text element took noticeably longer (mouse up → object panel) than shapes/groups. Timing instrumentation showed the canvas-side work was negligible (< 5ms); the real costs were:

1. **Font enumeration on every render** — `useState(FontFuncs.requestAvailableFontFamilies())` lacked a lazy initializer, so every TextOptions render re-enumerated fonts, re-sorted, and did a sync `storage.set` (~40ms × 3 renders per click)
2. **266 font Select options rebuilt as JSX every render** (~22ms × 3)
3. **Electron menu flush froze the renderer ~250ms after every selection** — `findAllMenuItemsByIds` walked the whole menu tree via `@electron/remote`, where each property access is a sync IPC round-trip

Fixes:

- Lazy `useState` initializer in TextOptions
- `font-funcs` caches `requestAvailableFontFamilies` results per variant (including the lowercase lookup map), invalidated on `GET_MONOTYPE_FONTS` and `active-lang` changes
- Font family options cached in a WeakMap keyed by the (now stable) families array identity
- Electron menu: no-op flushes (pending changes matching the applied status) skip the remote traversal entirely; the `id → MenuItem` map is built once per menu build and reset on `NewAppMenu`/`TabFocused`

Measured (dev build): text-selection input-event blocking dropped from ~500ms to ~150ms, and the post-selection 250ms menu freeze is eliminated when menu state is unchanged.

## Test plan

- [ ] Text: create/select text, change font family & style; canvas and panel stay in sync
- [ ] Font list: sorted, correct display names, "Recently used" group, previews
- [ ] Switch language → font dropdown reflects per-language web/Google fonts (cache invalidation)
- [ ] FLUX+ login → monotype fonts appear once loaded (`GET_MONOTYPE_FONTS` invalidation)
- [ ] Other font list consumers: Settings → Editor default font, Keychain Generator, Barcode Generator
- [ ] Electron menu: select/deselect cycles keep Duplicate/Delete/etc. in sync; image/SVG/path-specific items correct
- [ ] Menu checkboxes (Show Grids/Rulers, Zoom with Window, Anti-Aliasing, Auto Align) toggle every time
- [ ] Multi-tab: switching tabs keeps menu state correct (cache reset path)
- [ ] Workarea change updates Material Test + example file visibility
- [ ] Perf: text selection snappier; select-then-drag no longer hitches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYix8p9GXMh5p7aqev5JdA