### PR TITLE
Parse fcode directly in Path Preview and slice it for start-from-here

### DIFF
--- a/.agents/skills/fcode/SKILL.md
+++ b/.agents/skills/fcode/SKILL.md
@@ -80,7 +80,8 @@ One command byte, dispatched by exact value except moveto:
 | 24 / 16* | heater temp (printers) | float |
 | 16* | fast-gradient sub-commands (lasers) | see below |
 | 18 | grbl sync: sub 0 → u32; sub 1 (M137 type1) → u32 + flags u8 + floats per flag; sub 2 → u32 + flags u8 + float if flags&128 (Q) | u8 sub + varies |
-| 18 (P-cmds) | sub 1 P150 = acceleration override (per axis); sub 2 P154/P155/P157 Q = s-curve jerk/a_max/a0 (set_s_curve_params); sub 0 val 156 = s-curve off; sub 2 P179/P184/P185 = z-motion syncs | see above |
+| 18 (P-cmds) | sub 1 P150 = acceleration override (per axis); sub 2 P154/P155/P157 Q = s-curve jerk/a_max/a0 (set_s_curve_params); sub 0 val 156 = s-curve off, val 1/2 = enter/exit printer mode; sub 2 P179/P184/P185 = z-motion syncs | see above |
+| 17 | printer (inkjet) packets, single-color subs / 4C subs (fcode_printer.cpp): 0/11 = packet length u32, 1/12 = payload marker followed by that many RAW unframed bytes, 2/13 = crc u16, 3/10 = start packet u8 type, 4/14 = end packet, 5 = px count u32, 15 = burst refresh u16. Ink firing is marked by the sweep moveto's S axis (s=1 print, s=0 travel), not by the packets | u8 sub + varies |
 | 19 | flux custom cmd | u8 + u32 |
 | 20 / 21 / 22 | user-selection / miscellaneous / grbl system (`$H`=0, `$HZ`=1) | u8 |
 | 8 | calibrate | u32 |

--- a/.agents/skills/fcode/SKILL.md
+++ b/.agents/skills/fcode/SKILL.md
@@ -63,6 +63,9 @@ Inside `CONT`, a sequence of entries:
   pyx binding passes NULL for `''`): `xMIN` blocks have one (`0001`–`0008`, always
   ASCII digits), `TRAN`/`MAIN` do not. Disambiguate by digit-peeking the 4 bytes
   after the tag — a length whose 4 bytes are all `0x30–0x39` would be ≥ 800MB.
+  `xMIN` blocks are machine scripts (0003 pre-task homing, 0001/0002 prespray,
+  0005–0008 lid/table, 0004 post-task); parseFcode skips them so no records, moves,
+  or prespray swaths from them reach the preview (the slicer copies them as raw bytes).
 - **`TASK`**: bare 4-byte marker, no payload (one per layer, before its blocks).
 - **`INFO`**: 4-byte tag + u32 len + per-task json (time_cost, travel_dist…).
 - **`PREV`**: 4-byte tag + u32 len + per-task thumbnail. Yes, `PREV` appears both as

--- a/.agents/skills/fcode/SKILL.md
+++ b/.agents/skills/fcode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fcode
-description: FCode binary task format — v1/v2 container layouts, command opcodes, the moveto flag byte, and the fast-gradient raster line protocol. Use when working on parseFcode.ts, Path Preview's fcode path, or anything that reads or inspects .fc task files.
+description: FCode binary task format — v1/v2 container layouts, command opcodes, the moveto flag byte, the fast-gradient raster line protocol, and printer (inkjet) packets. Use when working on parseFcode.ts, sliceFcode.ts, Path Preview's fcode path, or anything that reads or inspects .fc task files.
 ---
 
 # FCode Format
@@ -81,7 +81,7 @@ One command byte, dispatched by exact value except moveto:
 | 16* | fast-gradient sub-commands (lasers) | see below |
 | 18 | grbl sync: sub 0 → u32; sub 1 (M137 type1) → u32 + flags u8 + floats per flag; sub 2 → u32 + flags u8 + float if flags&128 (Q) | u8 sub + varies |
 | 18 (P-cmds) | sub 1 P150 = acceleration override (per axis); sub 2 P154/P155/P157 Q = s-curve jerk/a_max/a0 (set_s_curve_params); sub 0 val 156 = s-curve off, val 1/2 = enter/exit printer mode; sub 2 P179/P184/P185 = z-motion syncs | see above |
-| 17 | printer (inkjet) packets, single-color subs / 4C subs (fcode_printer.cpp): 0/11 = packet length u32, 1/12 = payload marker followed by that many RAW unframed bytes, 2/13 = crc u16, 3/10 = start packet u8 type, 4/14 = end packet, 5 = px count u32, 15 = burst refresh u16. Ink firing is marked by the sweep moveto's S axis (s=1 print, s=0 travel), not by the packets | u8 sub + varies |
+| 17 | printer (inkjet) packets — see "Printer packets" below | u8 sub + varies |
 | 19 | flux custom cmd | u8 + u32 |
 | 20 / 21 / 22 | user-selection / miscellaneous / grbl system (`$H`=0, `$HZ`=1) | u8 |
 | 8 | calibrate | u32 |
@@ -114,6 +114,48 @@ Traps:
 - Pixel width needs no DPI lookup: `(endX − startX) / pixelCount`.
 - Each line is padded with blank pixels (~10–20mm) on both sides; the sweep extends
   past the engraved content, so metadata min/max x exceed the fired-pixel bounds.
+
+## Printer packets (cmd 17)
+
+Sub-commands come in two families — single-color (Ador `PRINTER`) 0-5, 4C (fbm2
+`PRINTER_4C`) 10-15 (`fcode_printer.cpp`): 0/11 = packet length u32, 1/12 = payload
+marker followed by that many RAW unframed bytes, 2/13 = crc u16, 3/10 = start packet
+u8 type, 4/14 = end packet, 5 = px count u32, 15 = burst refresh u16. Printer mode
+enter/sync/exit ride cmd 18 sub 0 with values 1/0/2.
+
+Per swath: positioning moveto (s=0) → image packet → px count →
+**sweep moveto with s=1** (the print stroke; S axis is the ink marker, PWM stays 0)
+→ moveto(s=0).
+
+Image payload: `u32 w | u32 h | u32 x | u32 y` (+4 reserved bytes, single-color
+only — header size follows the sub family), then w columns of pixel bits in sweep
+order, MSB first. Single-color: 1 bit/pixel. 4C: 4 bits/pixel, one per CMYK channel
+(nibble bit 3 = C .. bit 0 = K). Dot pitch is the same in both axes, so row pitch =
+sweep length / w. Traps (all verified against a real fbm2 export):
+
+- Channels are ALIGNED with each other in payload space (verified by cross-correlation
+  on a real export); the physical print applies the fixed per-channel x offsets
+  (`DEFAULT_COLOR_OFFSETS`: C 0, M 42, Y 84, K 126 px, machine +x), so the preview adds
+  offset x dot pitch per channel at draw time.
+- Swath rows extend downward in machine y from the sweep line. Row bit order differs
+  by family: 4C packs rows top-down, single-color bottom-up (`create_image_packet_data`
+  `reverse_y` — hardware install direction, per-machine; verified on fbm2 and Ador);
+  the decoder flips single-color rows so both read top-down.
+- parseFcode renders swath content per channel as zero-sim-time records (f = NaN adds
+  no time in GcodePreview) after the real sweep travel record, with NaN-position break
+  records hiding the synthetic jumps from the traversal display. 4C runs carry
+  `t = PRINTER_CHANNEL_T (7) + channel` and `s` = coverage; GcodePreview draws them in
+  a second pass with subtractive blending `blendFuncSeparate(ZERO, ONE_MINUS_SRC_COLOR,
+  ONE, ONE)` — rgb multiplies like ink on the white-cleared task framebuffer, alpha
+  accumulates coverage so the composite shows it (a plain ZERO/ONE_MINUS_SRC_COLOR pass
+  is invisible: the framebuffer clears to alpha 0). Single-color runs stay grayscale
+  `RASTER_T`. Coverage-to-density exponent (0.5) lives in the shader's print branch.
+- The start-packet type byte is the NozzleMode (LEFT=1/RIGHT=2/BOTH=3) for image
+  packets. 4C right-nozzle swaths bake the 0.55035mm left/right nozzle x gap into the
+  MOTION (printer_4c pixel_to_actual_position, sign by task direction); the preview
+  subtracts it from drawn content so it sits at the true deposit position.
+- Nozzle-settings packets (type 17, single-color only) share the framing; they fail
+  the image-payload size checks and are skipped.
 
 ## parseFcode.ts specifics
 

--- a/.agents/skills/fcode/SKILL.md
+++ b/.agents/skills/fcode/SKILL.md
@@ -86,7 +86,7 @@ One command byte, dispatched by exact value except moveto:
 | 20 / 21 / 22 | user-selection / miscellaneous / grbl system (`$H`=0, `$HZ`=1) | u8 |
 | 8 | calibrate | u32 |
 | 7 | set laser module | u32 |
-| 6 / 5 | pause in place / to standby | — |
+| 6 / 5 | pause in place / to standby; on laser firmware 6 = rotary-mode-on, 5 = gcode boost. Rotary tasks: v1 preamble movetos y to the axis then emits 6 and 5; v2 A-mode machines park y at the axis and move content on the A flag, non-A v2 uses rotary_wait_move (moveto y, 6, offset moveto, P185/P179 syncs). **A is in mm with the document rotary ratio already applied** (fluxclient `rotary_y + (y - rotary_y) * ratio`; the FILE min_y/max_y bounds are the A range) — parseFcode keeps `a` NaN until the first A move; the preview inverts the ratio back to design y (path-preview skill, `getSpinningAxis`), NOT LaserWeb's degrees model (a x diameter x pi/360). Start-here slicing re-emits 6/5 and pre-positions A (when set) after the position restore | — |
 | 4 | sleep | u32 ms |
 | 1 | home | — |
 

--- a/.agents/skills/fcode/SKILL.md
+++ b/.agents/skills/fcode/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: fcode
+description: FCode binary task format — v1/v2 container layouts, command opcodes, the moveto flag byte, and the fast-gradient raster line protocol. Use when working on parseFcode.ts, Path Preview's fcode path, or anything that reads or inspects .fc task files.
+---
+
+# FCode Format
+
+Client-side reader: `packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts`
+(feeds Path Preview via the same stride-9 records as `tmpParseGcode.js`). The sibling
+`sliceFcode.ts` builds "start from here" tasks by byte-splicing the original fcode at a
+record boundary (using `parseFcode`'s recordOffsets/module/gradient/blockPrologues extras),
+patching the containing block length, CONT length, and CONT crc32 — no gcode regeneration
+involved. Critical: each block's record-less prologue (grbl syncs, `miscellaneous_cmd(1)`
+arming, layer power pwm, layer clip M137) must be copied verbatim into the slice or the
+laser stays off. The FILE json time_cost and PREV thumbnail are rebuilt too — the machine
+displays them while running. A cut inside a raster sweep restarts at the next raster line.
+
+Source of truth (writers, in the fluxclient repo — verify there before changing the parser):
+
+- `../fluxclient-dev/src/toolpath/fcode_v1_writer.cpp` — v1 container + all command opcodes
+- `../fluxclient-dev/src/toolpath/fcode_v2_writer.cpp` — v2 chunked container
+- `../fluxclient-dev/src/toolpath/_toolpath.pyx` — Python bindings; fast-gradient pixel
+  packing (`fg_iterate_x_c`, `fg_iterate_x_pwm_c`), `write_task_info`
+- `../fluxclient-dev/fluxclient/toolpath/toolpath.py` — `process_svgeditor` task assembly
+  (block order, `magic_number` gating)
+- `../swiftray/src/toolpath_exporter/` — Swiftray's C++ port of the same writer
+  (`generators/fcode-generator.cpp`, `toolpath-exporter-fcode.cpp`); identical container,
+  block tags, arming, P150/P154-157 commands, and F16 opcodes as of 2026-09. TRAN/MAIN
+  proc ids are true NULL there (no bytes). Keep both writers in mind for format changes.
+
+All integers/floats are **little-endian**; floats are 4-byte IEEE 754.
+
+## Containers
+
+Magic: 8 bytes ASCII `FCx000N\n`. N = `magic_number`: 1 for legacy models (beamo,
+Beambox), ≥2 for newer models (Ador, Beambox II, HEXA…). N 2/3/4 share the v2
+container — the digit only gates generator behavior (e.g. N≥4 emits `$H` pre-task).
+
+### v1 (`FCx0001\n`)
+
+```text
+magic(8) | u32 scriptLen | script | u32 crc32
+| u32 metaLen | "KEY=value\0..." (utf8) | u32 crc32
+| { u32 len, previewImage }... | u32 0x00000000 terminator
+```
+
+### v2+ (`FCx0002\n`…)
+
+Tagged chunks, metadata first so machines can show job info without reading the script:
+
+```text
+magic(8)
+FILE u32 len | json metadata | u32 crc32
+PREV { u32 len, image }...            ← no count/terminator; ends at next chunk tag
+CONT u32 len | task blocks | u32 crc32
+POST u32 len | json | u32 crc32       ← optional
+```
+
+Inside `CONT`, a sequence of entries:
+
+- **Task script block**: 4-char tag (`xMIN`, `TRAN`, `MAIN`) `[+ 4-char proc id]` +
+  u32 length + command stream. **The proc id is written only when non-empty** (the
+  pyx binding passes NULL for `''`): `xMIN` blocks have one (`0001`–`0008`, always
+  ASCII digits), `TRAN`/`MAIN` do not. Disambiguate by digit-peeking the 4 bytes
+  after the tag — a length whose 4 bytes are all `0x30–0x39` would be ≥ 800MB.
+- **`TASK`**: bare 4-byte marker, no payload (one per layer, before its blocks).
+- **`INFO`**: 4-byte tag + u32 len + per-task json (time_cost, travel_dist…).
+- **`PREV`**: 4-byte tag + u32 len + per-task thumbnail. Yes, `PREV` appears both as
+  a top-level chunk and inside `CONT` — different framing in each position.
+
+## Command stream
+
+One command byte, dispatched by exact value except moveto:
+
+| byte | meaning | payload |
+|---|---|---|
+| `128\|flags` | moveto | one float per set bit, in order: 64=feedrate(mm/min), 32=X, 16=Y, 8=Z, 4=A, 2=(unused), 1=S |
+| 48 | fan speed | float |
+| 32 | toolhead PWM (0–100) | float |
+| 24 / 16* | heater temp (printers) | float |
+| 16* | fast-gradient sub-commands (lasers) | see below |
+| 18 | grbl sync: sub 0 → u32; sub 1 (M137 type1) → u32 + flags u8 + floats per flag; sub 2 → u32 + flags u8 + float if flags&128 (Q) | u8 sub + varies |
+| 18 (P-cmds) | sub 1 P150 = acceleration override (per axis); sub 2 P154/P155/P157 Q = s-curve jerk/a_max/a0 (set_s_curve_params); sub 0 val 156 = s-curve off; sub 2 P179/P184/P185 = z-motion syncs | see above |
+| 19 | flux custom cmd | u8 + u32 |
+| 20 / 21 / 22 | user-selection / miscellaneous / grbl system (`$H`=0, `$HZ`=1) | u8 |
+| 8 | calibrate | u32 |
+| 7 | set laser module | u32 |
+| 6 / 5 | pause in place / to standby | — |
+| 4 | sleep | u32 ms |
+| 1 | home | — |
+
+*Byte 16 is overloaded: heater on printer fcode, raster sub-commands on laser fcode.
+The parser only handles the laser meaning.
+
+## Fast-gradient raster lines (cmd 16)
+
+Sub-commands: 1 = mode on (u8 resolution char), 2 = `set_line_pixels` (u32 count),
+3 = `fill_32_pixels` (u32 word), 4 = fill end, 5 = print line (commit), 6 = mode off.
+
+Resolution char sets DPI **and** pixel depth: binary 1-bit `L/M/H/B/U/A`
+(5/10/20/39/40/78 px/mm; 32 px per word, MSB first, bit=1 → fire) vs PWM 8-bit
+`P/Q/R/C/S/T` (same dpi order; 4 px per word, MSB first, byte = 255−gray = power).
+
+Per line: `moveto(y)` → `moveto(x=start)` → settle moveto → sub 2 → sub 3… →
+sub 4 → sub 5 → **`moveto(x=end, feedrate)` = the engraving sweep**. Pixels are
+already in sweep order (bidirectional passes pre-reversed by the generator). The
+last fill word pads to a word boundary — trim to the sub-2 count before decoding.
+
+Traps:
+
+- **PWM stays 0 during fast gradient** — the fills drive the laser. A moveto-only
+  reader classifies all engraving as travel.
+- Pixel width needs no DPI lookup: `(endX − startX) / pixelCount`.
+- Each line is padded with blank pixels (~10–20mm) on both sides; the sweep extends
+  past the engraved content, so metadata min/max x exceed the fired-pixel bounds.
+
+## parseFcode.ts specifics
+
+- Y is negated into preview space (matching `parseGcode`); A is not.
+- Record `g` (cut vs travel) = PWM > 0 for vector moves, per pixel run for raster.
+- Raster runs split on every power change. Both records of a run carry `t = RASTER_T` (6)
+  and the run-end record carries `s` = pixel power 0–255; `GcodePreview` shades segment i
+  by record i's `t` and record i+1's `s`, so PWM images preview as grayscale. Vector
+  moves keep `t = 0` and stay solid.
+- Variable text needs no handling: it is Promark-only (`isVariableTextSupported`),
+  and Promark previews stay on the gcode-text path (`updateGcodeText`).
+- Debug workflow: export a `.fc` from the app, run the parser standalone with tsx,
+  and hexdump-verify against the writers. A real exported file catches
+  binding-level behavior the C++ source alone does not show.
+
+## Maintenance
+
+Update this skill and `parseFcode.ts` together if fluxclient's writers change:
+new command opcodes, new `CONT` entry tags, new resolution chars, or a new
+`magic_number` with container (not just generator) differences.

--- a/.agents/skills/path-preview/SKILL.md
+++ b/.agents/skills/path-preview/SKILL.md
@@ -28,6 +28,14 @@ Record contract (`ParsedGcode`, a chunked array dodging V8 length limits):
   from record i+1** — the arrival record. Emitting "cut to P" means: travel record,
   then record at P with g=1.
 - `y` is negated into preview space by both parsers (machine +y down → preview -y).
+- `a`: parseFcode leaves it NaN until the task moves the A axis (fluxclient NAN=absent);
+  parseGcode leaves it 0. Rotary/auto-feeder tasks carry y in rotary space
+  (`y' = axisY + (y - axisY) * ratio`, on A for fcode v2, on Y itself after the cmd-6
+  pause on v1). `setParsedGcode` takes `rotary = { axisY, ratio, scaledYFrom }` (built in
+  `updateFcode` from `getSpinningAxis`, job-origin relative) and stores in the draw array's
+  a slot the offset from the machine y to the design y, so the shader's `y + a` matches the
+  canvas while slot 2 keeps machine y for start-here slicing. Promark keeps its own
+  `y - a / rotaryRatio` fold.
 - `f` is mm/min; feeds the sim-time estimate per segment.
 - `s`/`t`: Promark uses `t` as dotting time. FCode raster runs set `t = RASTER_T` (6)
   with `s` = pixel power 0-255 so PWM engraving previews as grayscale; vector records

--- a/.agents/skills/path-preview/SKILL.md
+++ b/.agents/skills/path-preview/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: path-preview
+description: Path Preview subsystem — the stride-9 record pipeline, WebGL task rendering, sim-time model, task-code routing (fcode vs gcode), and the "start from here" flows. Use when working on components/beambox/PathPreview/ or helpers/path-preview/.
+---
+
+# Path Preview
+
+Location: `packages/core/src/web/app/components/beambox/PathPreview/` (component) and
+`packages/core/src/web/helpers/path-preview/` (WebGL draw commands). The renderer core
+(`tmpParseGcode.js`, `draw-commands/`) derives from Todd Fleming's LaserWeb (AGPL) —
+keep changes to those files minimal; new logic goes in sibling TS files.
+
+For the fcode binary format, `parseFcode.ts`, and `sliceFcode.ts` internals, see the
+`fcode` skill. This skill covers how the component consumes them.
+
+## Record pipeline
+
+Task code → parser → stride-9 records → `GcodePreview.setParsedGcode` → interleaved
+Float32Array segments → WebGL lines.
+
+Record contract (`ParsedGcode`, a chunked array dodging V8 length limits):
+
+```text
+[g, x, y, z, e, f, a, s, t] per waypoint
+```
+
+- **Segment i is drawn from record i to record i+1 and takes `g` (0=travel, 1=cut)
+  from record i+1** — the arrival record. Emitting "cut to P" means: travel record,
+  then record at P with g=1.
+- `y` is negated into preview space by both parsers (machine +y down → preview -y).
+- `f` is mm/min; feeds the sim-time estimate per segment.
+- `s`/`t`: Promark uses `t` as dotting time. FCode raster runs set `t = RASTER_T` (6)
+  with `s` = pixel power 0-255 so PWM engraving previews as grayscale; vector records
+  keep `t = 0`.
+
+Two parsers produce this: `tmpParseGcode.js` (gcode text; Promark wobble, `$H`,
+`G1S0/V0`) and `parseFcode.ts` (fcode binary; also returns the slicing extras).
+
+## Task code routing (`updateTaskCode`)
+
+- **Promark** (`promarkModels`) → `updateGcodeText`: Swiftray gcode text, variable-text
+  tasks merged by string concat (VT is Promark-only, see `isVariableTextSupported`).
+- **Everything else** → `updateFcode`: one `exportFuncs.getFcode()` call (single
+  fluxghost/Swiftray conversion — no gcode generated), parsed by `parseFcode`, and the
+  parse result cached as `this.fcodeTask` for start-here slicing. `gcodeString` stays
+  empty on this path and is fetched lazily only if the gcode fallback is ever needed.
+
+## Sim time model
+
+- `simTimeMax` = sim minutes from `gcodePreview.g0Time + g1Time` (kinematic estimate),
+  padded by half a `SIM_TIME_MINUTE`.
+- `timeDisplayRatio` = `fileTimeCost / (60 * simTimeMax)` — maps sim time to the
+  machine's own estimate; remaining real time = `(simTimeMax - simTime) * 60 * ratio`.
+- `GcodePreview.getSimTimeInfo(simTime)` → `{ index, position, next }`: `index` is the
+  record index of the current segment's **start**; `position` is the interpolated point
+  in machine coords; `next` is the arrival vertex in preview coords.
+
+## Start from here (`handleStartHere`)
+
+- simTime at 0 (or ~max): full `exportFuncs.uploadFcode`.
+- Mid-timeline, fcode path: `sliceFcode(this.fcodeTask, simTimeInfo, { previewPng,
+  timeCost })` byte-splices the cached task — zero fluxghost calls; the thumbnail
+  (remaining-path render) and remaining time are embedded so the machine monitor shows
+  the sliced task. Falls back to the gcode flow if slicing returns null.
+- Gcode fallback / Promark: lazy-fetch gcode text, map the record index to a gcode line
+  by counting `G1`s, splice preparation lines, `gcodeToFcode` via fluxghost. The
+  fast-gradient branch reconstructs `F16` raster words to resume mid-line.
+- **Dev export**: with `localStorage.dev = 'true'`, shift-clicking "Start here" saves
+  the sliced `.fc` via a file dialog instead of uploading — no machine needed.
+
+## Debugging
+
+Export a real task (`.fc` or shift-click dev export), run the parsers standalone with
+`npx tsx`, and validate structure/CRC with a short python script — see the fcode skill.
+The preview's console logs `Parsed FCode`/`Parsed GCode` with the record array.
+
+## Maintenance
+
+Update this skill if the record contract, task-code routing, sim-time mapping, or the
+start-here flows change. Format-level changes belong in the `fcode` skill.

--- a/packages/core/src/web/app/actions/beambox/export-funcs.ts
+++ b/packages/core/src/web/app/actions/beambox/export-funcs.ts
@@ -604,6 +604,12 @@ export default {
 
     return res.taskCodeBlob;
   },
+  getFcode: async (): Promise<{ fcodeBlob?: Blob; fileTimeCost: number }> => {
+    const { convertEngine } = getConvertEngine();
+    const res = await convertEngine(null);
+
+    return { fcodeBlob: res?.taskCodeBlob, fileTimeCost: res?.fileTimeCost || 0 };
+  },
   getGcode: async (): Promise<{
     fileTimeCost: number;
     gcodeBlob?: Blob;

--- a/packages/core/src/web/app/components/beambox/PathPreview/PathPreview.tsx
+++ b/packages/core/src/web/app/components/beambox/PathPreview/PathPreview.tsx
@@ -28,6 +28,7 @@ import getRotaryRatio from '@core/helpers/device/get-rotary-ratio';
 import deviceMaster from '@core/helpers/device-master';
 import eventEmitterFactory from '@core/helpers/eventEmitterFactory';
 import i18n from '@core/helpers/i18n';
+import isDev from '@core/helpers/is-dev';
 import getJobOrigin from '@core/helpers/job-origin';
 import { DrawCommands } from '@core/helpers/path-preview/draw-commands';
 import { GcodePreview } from '@core/helpers/path-preview/draw-commands/GcodePreview';
@@ -39,11 +40,15 @@ import {
   removeVariableText,
 } from '@core/helpers/variableText';
 import VersionChecker from '@core/helpers/version-checker';
+import dialog from '@core/implementations/dialog';
 
+import { parseFcode } from './parseFcode';
 import styles from './PathPreview.module.scss';
 import Pointable from './Pointable';
 import ProgressBar from './ProgressBar';
 import SidePanel from './SidePanel';
+import { sliceFcode } from './sliceFcode';
+import type { FcodeTask } from './sliceFcode';
 import { parseGcode } from './tmpParseGcode';
 
 const TOOLS_PANEL_HEIGHT = 100;
@@ -598,6 +603,8 @@ class PathPreview extends React.Component<Props, State> {
   private simInterval?: NodeJS.Timeout;
   private drawGcodeState: any;
   private gcodeString: string = '';
+
+  private fcodeTask: FcodeTask | null = null;
   private fastGradientGcodeString?: string;
   private isUpdating: boolean = false;
   private spaceKey: boolean = false;
@@ -666,7 +673,7 @@ class PathPreview extends React.Component<Props, State> {
     window.addEventListener('resize', this.resizeHandler);
     this.resetView();
     this.updateJobOrigin();
-    this.updateGcode();
+    this.updateTaskCode();
 
     canvasEventEmitter.on('canvas-change', this.onDeviceChange);
   }
@@ -759,8 +766,21 @@ class PathPreview extends React.Component<Props, State> {
     this.resetView();
   };
 
-  updateGcode = async (): Promise<void> => {
+  updateTaskCode = async (): Promise<void> => {
+    // Promark previews rely on gcode-only behavior (wobble, dotting, variable text);
+    // everything else previews the fcode directly.
+    if (promarkModels.has(workareaManager.model)) {
+      await this.updateGcodeText();
+    } else {
+      await this.updateFcode();
+    }
+  };
+
+  // Gcode-text preview path (Promark, incl. its variable-text tasks).
+  updateGcodeText = async (): Promise<void> => {
     const { togglePathPreview } = useCanvasStore.getState();
+
+    this.fcodeTask = null;
 
     let fileTimeCost: number;
     let gcodeBlob: Blob | undefined;
@@ -835,6 +855,49 @@ class PathPreview extends React.Component<Props, State> {
       progressCaller.popById('parsing-gcode');
     };
     fileReader.readAsText(gcodeBlob);
+  };
+
+  // FLUXGhost machines: parse the fcode binary directly, no extra gcode generation.
+  updateFcode = async (): Promise<void> => {
+    const { togglePathPreview } = useCanvasStore.getState();
+
+    // Variable text is Promark-only (isVariableTextSupported), so no VT handling here.
+    const { fcodeBlob, fileTimeCost } = await exportFuncs.getFcode();
+
+    if (!fcodeBlob) {
+      togglePathPreview();
+
+      return;
+    }
+
+    progressCaller.openNonstopProgress({
+      caption: 'Parsing FCode',
+      id: 'parsing-gcode',
+      timeout: 30000,
+    });
+
+    this.gcodeString = '';
+
+    const arrayBuffer = await fcodeBlob.arrayBuffer();
+    const { metadata, parsedGcode, ...sliceExtras } = parseFcode(arrayBuffer);
+
+    // Cached so "start here" can slice the fcode directly instead of regenerating gcode.
+    this.fcodeTask = parsedGcode.length > 0 ? { buffer: arrayBuffer, parsedGcode, ...sliceExtras } : null;
+
+    if (parsedGcode.length > 0) {
+      this.gcodePreview.setParsedGcode(
+        parsedGcode,
+        false,
+        (dpiTextMap[useGlobalPreferenceStore.getState().engrave_dpi] || 254) / 25.4,
+      );
+      this.simTimeMax =
+        Math.ceil((this.gcodePreview.g1Time + this.gcodePreview.g0Time) / SIM_TIME_MINUTE) * SIM_TIME_MINUTE +
+        SIM_TIME_MINUTE / 2;
+      this.timeDisplayRatio = fileTimeCost / (60 * this.simTimeMax);
+      this.handleSimTimeChange(this.simTimeMax);
+    }
+
+    progressCaller.popById('parsing-gcode');
   };
 
   private windowKeyDown = (e: KeyboardEvent) => {
@@ -1020,7 +1083,7 @@ class PathPreview extends React.Component<Props, State> {
       }));
     }
 
-    this.updateGcode();
+    this.updateTaskCode();
   };
 
   onPointerCancel = (e: { pointerId: any; preventDefault: () => void }) => {
@@ -1405,8 +1468,27 @@ class PathPreview extends React.Component<Props, State> {
     };
   };
 
-  private handleStartHere = async (): Promise<void> => {
+  private handleStartHere = async (e?: React.MouseEvent): Promise<void> => {
     const { workspace } = this.state;
+
+    // Dev-only: shift-click exports the sliced start-here fcode for inspection,
+    // no machine needed. Enable with localStorage.setItem('dev', 'true').
+    if (isDev() && e?.shiftKey && this.fcodeTask && workspace.simTime > 0) {
+      const simTimeInfo = this.gcodePreview.getSimTimeInfo(Number(workspace.simTime));
+      const remainingTime = Math.max(0, (this.simTimeMax - workspace.simTime) * 60 * this.timeDisplayRatio);
+      const slicedBlob = sliceFcode(this.fcodeTask, simTimeInfo, { timeCost: remainingTime });
+
+      if (slicedBlob) {
+        await dialog.writeFileDialog(() => slicedBlob, 'Export Start Here FCode', 'start-here.fc', [
+          { extensions: ['fc'], name: 'FCode' },
+        ]);
+      } else {
+        alertCaller.popUpError({ message: 'sliceFcode returned null; see console.' });
+      }
+
+      return;
+    }
+
     const { device } = await getDevice();
 
     if (!device) {
@@ -1555,6 +1637,47 @@ class PathPreview extends React.Component<Props, State> {
       });
       try {
         const simTimeInfo = this.gcodePreview.getSimTimeInfo(Number(workspace.simTime));
+
+        // Preview came from fcode: slice the cached binary directly, no gcode round-trips.
+        if (this.fcodeTask) {
+          const remainingTime = Math.max(0, (this.simTimeMax - workspace.simTime) * 60 * this.timeDisplayRatio);
+          // thumbnail is a png data url of the remaining path; embed it so the
+          // machine shows the sliced task, not the original full task
+          const previewPng = Uint8Array.from(atob(thumbnail.split(',')[1]), (c) => c.charCodeAt(0));
+          const slicedBlob = sliceFcode(this.fcodeTask, simTimeInfo, { previewPng, timeCost: remainingTime });
+
+          if (slicedBlob) {
+            const report = await deviceMaster.getReport();
+
+            if (report && (await checkDeviceStatus(device))) {
+              await exportFuncs.openTaskInDeviceMonitor(device, {
+                blob: slicedBlob,
+                taskTime: remainingTime,
+                thumbnailUrl,
+              });
+            }
+
+            return;
+          }
+          // fall through to the gcode-text flow if slicing failed
+        }
+
+        if (!this.gcodeString) {
+          // Promark preview never cached gcode text (e.g. after a failed slice fallback).
+          const { gcodeBlob, useSwiftray } = await exportFuncs.getGcode();
+
+          if (gcodeBlob) {
+            if (useSwiftray) {
+              this.gcodeString = await gcodeBlob.text();
+            } else {
+              const result = (await gcodeBlob.text()).split('\n');
+
+              result.splice(5, 0, 'G1 X0 Y0');
+              this.gcodeString = result.join('\n');
+            }
+          }
+        }
+
         const gcodeList = this.gcodeString.split('\n');
         let target = 0;
         let count = -2;

--- a/packages/core/src/web/app/components/beambox/PathPreview/PathPreview.tsx
+++ b/packages/core/src/web/app/components/beambox/PathPreview/PathPreview.tsx
@@ -21,6 +21,7 @@ import { useCanvasStore } from '@core/app/stores/canvas/canvasStore';
 import { useDocumentStore } from '@core/app/stores/documentStore';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
 import workareaManager from '@core/app/svgedit/workarea';
+import { getSpinningAxis } from '@core/helpers/addOn/rotary';
 import checkDeviceStatus from '@core/helpers/check-device-status';
 import { checkBlockedSerial } from '@core/helpers/device/checkBlockedSerial';
 import getDevice from '@core/helpers/device/get-device';
@@ -281,7 +282,10 @@ const settings = {
 const defaultWorkspace = {
   cursorPos: [0, 0, 0],
   g0Rate: 7500,
-  rotaryDiameter: 10,
+  // mm of preview y per a-slot unit: for fcode the a slot already holds the display offset
+  // that maps rotary-space y back to the design y (GcodePreview.setParsedGcode), so 1
+  // (the LaserWeb degrees->arc model does not apply)
+  rotaryScale: 1,
   showCursor: true,
   showGcode: true,
   showRotary: false,
@@ -391,7 +395,7 @@ function cacheDrawing(
     height?: any;
     isInverting?: boolean;
     perspective?: any;
-    rotaryDiameter?: any;
+    rotaryScale?: any;
     showRemaining?: boolean;
     showTraversal?: boolean;
     simTime?: any;
@@ -438,7 +442,7 @@ const drawTaskPreview = (
   workspace: {
     cursorPos?: number[];
     g0Rate: any;
-    rotaryDiameter: any;
+    rotaryScale: any;
     showCursor?: boolean;
     showGcode?: boolean;
     showRotary?: boolean;
@@ -456,7 +460,7 @@ const drawTaskPreview = (
       camera.view,
       workspace.g0Rate,
       workspace.simTime,
-      workspace.rotaryDiameter,
+      workspace.rotaryScale,
       isInverting,
       showTraversal,
       showRemaining,
@@ -470,7 +474,7 @@ const drawTaskPreview = (
     height: canvas.height,
     isInverting,
     perspective: camera.perspective,
-    rotaryDiameter: workspace.rotaryDiameter,
+    rotaryScale: workspace.rotaryScale,
     showRemaining,
     showTraversal,
     simTime: workspace.simTime,
@@ -578,7 +582,7 @@ interface State {
   workspace: {
     cursorPos: number[];
     g0Rate: number;
-    rotaryDiameter: number;
+    rotaryScale: number;
     showCursor: boolean;
     showGcode: boolean;
     showRotary: boolean;
@@ -595,6 +599,8 @@ class PathPreview extends React.Component<Props, State> {
   private fingers: any;
   private pointers: any;
   private position: any;
+
+  private positionA: number = 0;
   private moveStarted: boolean;
   private adjustingCamera: boolean;
   private gcodePreview: GcodePreview;
@@ -616,6 +622,7 @@ class PathPreview extends React.Component<Props, State> {
     // TODO: make config interface
     this.canvas = null;
     this.position = [0, 0];
+    this.positionA = 0;
     this.grid = new Grid();
 
     let { width } = workareaManager;
@@ -885,10 +892,29 @@ class PathPreview extends React.Component<Props, State> {
     this.fcodeTask = parsedGcode.length > 0 ? { buffer: arrayBuffer, parsedGcode, ...sliceExtras } : null;
 
     if (parsedGcode.length > 0) {
+      const model = workareaManager.model;
+      const globalPreference = useGlobalPreferenceStore.getState();
+      const spinningAxis = getSpinningAxis(model, {
+        jobOriginY: this.jobOrigin?.y,
+        reverse: globalPreference['reverse-engraving'],
+      });
+      // Rotary/auto-feeder tasks carry y in rotary space; map it back to the design y so the
+      // preview matches the canvas (fcode coords are job-origin relative, like the grid).
+      const rotary = spinningAxis && {
+        axisY: spinningAxis.spin / constant.dpmm - (this.jobOrigin?.y ?? 0),
+        ratio: spinningAxis.ratio,
+        // v1 firmware scales y itself from rotary-mode-on (cmd 6); v2 moves content on the A axis
+        scaledYFrom: constant.fcodeV2Models.has(model)
+          ? Number.POSITIVE_INFINITY
+          : (sliceExtras.pauseEvents.find(([, cmd]) => cmd === 6)?.[0] ?? Number.POSITIVE_INFINITY),
+      };
+
       this.gcodePreview.setParsedGcode(
         parsedGcode,
         false,
-        (dpiTextMap[useGlobalPreferenceStore.getState().engrave_dpi] || 254) / 25.4,
+        (dpiTextMap[globalPreference.engrave_dpi] || 254) / 25.4,
+        1,
+        rotary,
       );
       this.simTimeMax =
         Math.ceil((this.gcodePreview.g1Time + this.gcodePreview.g0Time) / SIM_TIME_MINUTE) * SIM_TIME_MINUTE +
@@ -937,23 +963,12 @@ class PathPreview extends React.Component<Props, State> {
     if (this.position[0] !== 0 && this.position[1] !== 0) {
       const crossPoints = [];
       const crossValue = 10 / this.camera.scale;
+      // rotary tasks draw content at y + a * rotaryScale (see the gcode shader);
+      // place the cross with the same offset so it tracks the displayed path
+      const displayY = -this.position[1] + this.positionA * workspace.rotaryScale;
 
-      crossPoints.push(
-        this.position[0] - crossValue,
-        -this.position[1],
-        0,
-        this.position[0] + crossValue,
-        -this.position[1],
-        0,
-      );
-      crossPoints.push(
-        this.position[0],
-        -this.position[1] - crossValue,
-        0,
-        this.position[0],
-        -this.position[1] + crossValue,
-        0,
-      );
+      crossPoints.push(this.position[0] - crossValue, displayY, 0, this.position[0] + crossValue, displayY, 0);
+      crossPoints.push(this.position[0], displayY - crossValue, 0, this.position[0], displayY + crossValue, 0);
 
       const crossPosition = new Float32Array(crossPoints);
 
@@ -1355,8 +1370,10 @@ class PathPreview extends React.Component<Props, State> {
 
   private handleSimTimeChange = (value: number) => {
     const { workspace } = this.state;
+    const simTimeInfo = this.gcodePreview.getSimTimeInfo(Number(value));
 
-    this.position = this.gcodePreview.getSimTimeInfo(Number(value)).position;
+    this.position = simTimeInfo.position;
+    this.positionA = simTimeInfo.a ?? 0;
     this.setState({
       workspace: {
         ...workspace,

--- a/packages/core/src/web/app/components/beambox/PathPreview/SidePanel.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/PathPreview/SidePanel.spec.tsx
@@ -4,10 +4,12 @@ import { fireEvent, render } from '@testing-library/react';
 
 import SidePanel from './SidePanel';
 
-const mockGetConvertEngine = jest.fn();
+let mockModel = 'fbb2';
 
-jest.mock('@core/app/actions/beambox/export-funcs', () => ({
-  getConvertEngine: () => mockGetConvertEngine(),
+jest.mock('@core/app/svgedit/workarea', () => ({
+  get model() {
+    return mockModel;
+  },
 }));
 
 const mockTogglePathPreview = jest.fn();
@@ -23,7 +25,7 @@ jest.mock('@core/app/stores/canvas/canvasStore', () => ({
 describe('side panel test', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetConvertEngine.mockReturnValue({ useSwiftray: false });
+    mockModel = 'fbb2';
   });
 
   it('should render correctly when enabled', () => {
@@ -80,8 +82,8 @@ describe('side panel test', () => {
     expect(mockTogglePathPreview).toHaveBeenCalledTimes(1);
   });
 
-  it('should render correctly with Swiftray engine', () => {
-    mockGetConvertEngine.mockReturnValue({ useSwiftray: true });
+  it('should hide start here for Promark', () => {
+    mockModel = 'fpm1';
 
     const handleStartHere = jest.fn();
     const { container } = render(

--- a/packages/core/src/web/app/components/beambox/PathPreview/SidePanel.tsx
+++ b/packages/core/src/web/app/components/beambox/PathPreview/SidePanel.tsx
@@ -3,8 +3,9 @@ import React, { useMemo } from 'react';
 import { Button } from 'antd';
 import classNames from 'classnames';
 
-import { getConvertEngine } from '@core/app/actions/beambox/export-funcs';
+import { promarkModels } from '@core/app/actions/beambox/constant';
 import { useCanvasStore } from '@core/app/stores/canvas/canvasStore';
+import workareaManager from '@core/app/svgedit/workarea';
 import { getOS } from '@core/helpers/getOS';
 import isWeb from '@core/helpers/is-web';
 import useI18n from '@core/helpers/useI18n';
@@ -52,11 +53,7 @@ function SidePanel({
     [],
   );
 
-  const isStartHereHidden = useMemo(() => {
-    const { useSwiftray } = getConvertEngine();
-
-    return useSwiftray;
-  }, []);
+  const isStartHereHidden = useMemo(() => promarkModels.has(workareaManager.model), []);
 
   return (
     <div className={sideClass} id="path-preview-side-panel">

--- a/packages/core/src/web/app/components/beambox/PathPreview/__snapshots__/SidePanel.spec.tsx.snap
+++ b/packages/core/src/web/app/components/beambox/PathPreview/__snapshots__/SidePanel.spec.tsx.snap
@@ -1,5 +1,139 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`side panel test should hide start here for Promark 1`] = `
+<div>
+  <div
+    class="container wide"
+    id="path-preview-side-panel"
+  >
+    <div
+      class="title"
+    >
+      Preview Information
+    </div>
+    <div
+      class="datas"
+    >
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Size
+        </div>
+        <div
+          class="value"
+        >
+          100 x 100 mm
+        </div>
+      </div>
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Total Time Estimated
+        </div>
+        <div
+          class="value"
+        >
+          60 s
+        </div>
+      </div>
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Cut Time
+        </div>
+        <div
+          class="value"
+        >
+          30 s
+        </div>
+      </div>
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Travel Time
+        </div>
+        <div
+          class="value"
+        >
+          10 s
+        </div>
+      </div>
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Cut Distance
+        </div>
+        <div
+          class="value"
+        >
+          50 mm
+        </div>
+      </div>
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Travel Distance
+        </div>
+        <div
+          class="value"
+        >
+          30 mm
+        </div>
+      </div>
+      <div
+        class="data-block"
+      >
+        <div
+          class="item"
+        >
+          Current Position
+        </div>
+        <div
+          class="value"
+        >
+          50, 50 mm
+        </div>
+      </div>
+    </div>
+    <div
+      class="remark"
+    >
+      * All pieces of information are estimated value for reference.
+    </div>
+    <div
+      class="buttons"
+    >
+      <button
+        class="ant-btn css-dev-only-do-not-override-hash ant-btn-default ant-btn-color-default ant-btn-variant-outlined btn"
+        type="button"
+      >
+        <span>
+          End Preview
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`side panel test should render correctly when disabled 1`] = `
 <div>
   <div
@@ -272,140 +406,6 @@ exports[`side panel test should render correctly when enabled 1`] = `
           Start Here
         </span>
       </button>
-      <button
-        class="ant-btn css-dev-only-do-not-override-hash ant-btn-default ant-btn-color-default ant-btn-variant-outlined btn"
-        type="button"
-      >
-        <span>
-          End Preview
-        </span>
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`side panel test should render correctly with Swiftray engine 1`] = `
-<div>
-  <div
-    class="container wide"
-    id="path-preview-side-panel"
-  >
-    <div
-      class="title"
-    >
-      Preview Information
-    </div>
-    <div
-      class="datas"
-    >
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Size
-        </div>
-        <div
-          class="value"
-        >
-          100 x 100 mm
-        </div>
-      </div>
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Total Time Estimated
-        </div>
-        <div
-          class="value"
-        >
-          60 s
-        </div>
-      </div>
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Cut Time
-        </div>
-        <div
-          class="value"
-        >
-          30 s
-        </div>
-      </div>
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Travel Time
-        </div>
-        <div
-          class="value"
-        >
-          10 s
-        </div>
-      </div>
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Cut Distance
-        </div>
-        <div
-          class="value"
-        >
-          50 mm
-        </div>
-      </div>
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Travel Distance
-        </div>
-        <div
-          class="value"
-        >
-          30 mm
-        </div>
-      </div>
-      <div
-        class="data-block"
-      >
-        <div
-          class="item"
-        >
-          Current Position
-        </div>
-        <div
-          class="value"
-        >
-          50, 50 mm
-        </div>
-      </div>
-    </div>
-    <div
-      class="remark"
-    >
-      * All pieces of information are estimated value for reference.
-    </div>
-    <div
-      class="buttons"
-    >
       <button
         class="ant-btn css-dev-only-do-not-override-hash ant-btn-default ant-btn-color-default ant-btn-variant-outlined btn"
         type="button"

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.spec.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.spec.ts
@@ -1,7 +1,7 @@
 // tmpParseGcode.js is untransformed ESM; decodePixelRuns never touches it.
 jest.mock('./tmpParseGcode', () => ({ ParsedGcode: class {} }));
 
-import { decodePixelRuns } from './parseFcode';
+import { decodePixelRuns, decodePrinterSwath } from './parseFcode';
 
 describe('decodePixelRuns', () => {
   test('splits on laser off and on power changes, keeping each run power', () => {
@@ -14,5 +14,46 @@ describe('decodePixelRuns', () => {
 
   test('returns no runs for a blank line', () => {
     expect(decodePixelRuns([0, 0, 0])).toEqual([]);
+  });
+});
+
+describe('decodePrinterSwath', () => {
+  // single-color header: w=4, h=16, x, y, 4 reserved bytes; 4 columns x 2 bytes
+  const payload = Uint8Array.from([
+    ...[4, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ...[0x00, 0x00, 0xff, 0xff, 0x0f, 0x00, 0x00, 0x01],
+  ]);
+
+  test('decodes single-color pixels (1 bit each)', () => {
+    const swath = decodePrinterSwath(payload, 20)!;
+
+    expect(swath.w).toBe(4);
+    expect(swath.rows).toBe(16);
+    expect(swath.channels).toBe(1);
+    // single-color rows are stored bottom-up and flipped to top-down by the decoder
+    expect(swath.pixelAt(0, 0)).toBe(0);
+    expect(swath.pixelAt(1, 0)).toBe(1);
+    expect(swath.pixelAt(1, 15)).toBe(1);
+    expect(swath.pixelAt(2, 12)).toBe(0); // 0x0f00: bits 4-7 set -> rows 8-11
+    expect(swath.pixelAt(2, 11)).toBe(1);
+    expect(swath.pixelAt(2, 8)).toBe(1);
+    expect(swath.pixelAt(3, 0)).toBe(1); // 0x0001: last bit -> top row
+  });
+
+  test('decodes 4C pixels (4 CMYK channel bits each, aligned in payload space)', () => {
+    const payload4c = Uint8Array.from([...payload.subarray(0, 16), ...payload.subarray(20)]);
+    const swath = decodePrinterSwath(payload4c, 16)!;
+
+    expect(swath.rows).toBe(4); // 2 bytes per column / 4 bits per pixel
+    expect(swath.channels).toBe(4);
+    expect(swath.w).toBe(4);
+    expect(swath.pixelAt(1, 0)).toBe(0xf); // all 4 channels
+    expect(swath.pixelAt(2, 0)).toBe(0); // 0x0f00: high nibble of first byte is 0
+    expect(swath.pixelAt(2, 1)).toBe(0xf); // low nibble
+    expect(swath.pixelAt(3, 3)).toBe(0x1); // K only (nibble bit 0)
+  });
+
+  test('rejects non-image packets', () => {
+    expect(decodePrinterSwath(Uint8Array.from([1, 2, 3, 4, 5]), 20)).toBeNull();
   });
 });

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.spec.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.spec.ts
@@ -1,0 +1,18 @@
+// tmpParseGcode.js is untransformed ESM; decodePixelRuns never touches it.
+jest.mock('./tmpParseGcode', () => ({ ParsedGcode: class {} }));
+
+import { decodePixelRuns } from './parseFcode';
+
+describe('decodePixelRuns', () => {
+  test('splits on laser off and on power changes, keeping each run power', () => {
+    expect(decodePixelRuns([0, 255, 255, 128, 128, 0, 16])).toEqual([
+      [1, 3, 255],
+      [3, 5, 128],
+      [6, 7, 16],
+    ]);
+  });
+
+  test('returns no runs for a blank line', () => {
+    expect(decodePixelRuns([0, 0, 0])).toEqual([]);
+  });
+});

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
@@ -37,6 +37,14 @@ export class Reader {
     return v;
   };
 
+  u16 = (): number => {
+    const v = this.view.getUint16(this.pos, true);
+
+    this.pos += 2;
+
+    return v;
+  };
+
   u32 = (): number => {
     const v = this.view.getUint32(this.pos, true);
 
@@ -146,8 +154,12 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
   const reader = new Reader(buffer);
 
   // Machine coords, y kept in preview space (negated, matching parseGcode)
-  const state = { a: 0, f: 7500, pwm: 0, x: 0, y: 0, z: 0 };
+  // printS: the moveto S axis — printer swath sweeps carry s=1, travels s=0
+  const state = { a: 0, f: 7500, printS: 0, pwm: 0, x: 0, y: 0, z: 0 };
   let raster: null | RasterState = null;
+  // Payload length announced by the printer packet-length sub-command; the
+  // payload marker is followed by that many raw unframed bytes.
+  let printerPayloadLength = 0;
 
   const push = (g: number, s = state.pwm, t = 0) => {
     parsedGcode.push(g);
@@ -200,13 +212,13 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
 
     if (cmd & 2) reader.f32();
 
-    if (cmd & 1) reader.f32();
+    if (cmd & 1) state.printS = reader.f32();
 
     if (raster?.armed && targetX !== state.x) {
       emitRasterSweep(targetX);
     } else {
       state.x = targetX;
-      push(state.pwm > 0 ? 1 : 0);
+      push(state.pwm > 0 || state.printS > 0 ? 1 : 0);
     }
   };
 
@@ -287,6 +299,43 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
       case 16: // fast gradient sub-commands
         handleRasterCmd();
         break;
+      case 17: {
+        // printer (inkjet) packets, single-color subs 0-5 / 4C subs 10-15 (fcode_printer.cpp)
+        const sub = reader.u8();
+
+        switch (sub) {
+          case 0: // packet length
+          case 11:
+            printerPayloadLength = reader.u32();
+            break;
+          case 1: // payload marker, followed by raw unframed bytes
+          case 12:
+            reader.pos += printerPayloadLength;
+            printerPayloadLength = 0;
+            break;
+          case 2: // packet crc16
+          case 13:
+            reader.u16();
+            break;
+          case 3: // start packet (u8 type)
+          case 10:
+            reader.u8();
+            break;
+          case 4: // end packet
+          case 14:
+            break;
+          case 5: // pixel count
+            reader.u32();
+            break;
+          case 15: // burst refresh
+            reader.u16();
+            break;
+          default:
+            throw new Error(`Unknown fcode printer sub-command ${sub}`);
+        }
+
+        break;
+      }
       case 18: {
         // grbl sync / M137 sync motion
         const sub = reader.u8();

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
@@ -1,0 +1,454 @@
+import { ParsedGcode } from './tmpParseGcode';
+
+// FCode binary parser for Path Preview.
+// Emits the same stride-9 records as parseGcode ([g, x, y, z, e, f, a, s, t]),
+// so GcodePreview.setParsedGcode consumes it unchanged.
+// Format reference: fluxclient src/toolpath/fcode_v1_writer.cpp, fcode_v2_writer.cpp,
+// _toolpath.pyx (fg_iterate_x_c / fg_iterate_x_pwm_c for fast gradient).
+
+// Resolution chars of turn_on_gradient_print_mode that mean 8-bit PWM pixels
+// (their binary 1-bit counterparts are L/M/H/B/U/A at the same dpi).
+const PWM_MODE_CHARS = new Set(['P', 'Q', 'R', 'C', 'S', 'T'].map((c) => c.charCodeAt(0)));
+
+/**
+ * Record `t` value marking a raster pixel run. `t` is Promark dotting time in gcode records and unused for fcode,
+ * so the preview shader uses it to shade raster segments by `s` (0-255 pixel power) instead of solid black.
+ */
+export const RASTER_T = 6;
+
+export class Reader {
+  view: DataView;
+
+  bytes: Uint8Array;
+
+  pos: number;
+
+  constructor(buffer: ArrayBuffer, pos = 0) {
+    this.view = new DataView(buffer);
+    this.bytes = new Uint8Array(buffer);
+    this.pos = pos;
+  }
+
+  u8 = (): number => {
+    const v = this.view.getUint8(this.pos);
+
+    this.pos += 1;
+
+    return v;
+  };
+
+  u32 = (): number => {
+    const v = this.view.getUint32(this.pos, true);
+
+    this.pos += 4;
+
+    return v;
+  };
+
+  f32 = (): number => {
+    const v = this.view.getFloat32(this.pos, true);
+
+    this.pos += 4;
+
+    return v;
+  };
+
+  tag = (): string => {
+    const s = String.fromCharCode(...this.bytes.subarray(this.pos, this.pos + 4));
+
+    this.pos += 4;
+
+    return s;
+  };
+
+  utf8 = (length: number): string => {
+    const s = new TextDecoder().decode(this.bytes.subarray(this.pos, this.pos + length));
+
+    this.pos += length;
+
+    return s;
+  };
+}
+
+interface RasterState {
+  armed: boolean;
+  pixelCount: number;
+  pixels: number[];
+  pwmMode: boolean;
+}
+
+/**
+ * Splits one raster line's pixel buffer into laser-on runs of constant power.
+ * @param pixels power per pixel along the sweep direction, 0 = laser off, 1-255 = laser on
+ * @returns runs as [startIndex, endIndexExclusive, power], in increasing index order
+ */
+export function decodePixelRuns(pixels: ArrayLike<number>): Array<[number, number, number]> {
+  const runs: Array<[number, number, number]> = [];
+  let start = -1;
+  let power = 0;
+
+  for (let i = 0; i < pixels.length; i += 1) {
+    const p = pixels[i];
+
+    if (p === power) continue;
+
+    if (start >= 0) runs.push([start, i, power]);
+
+    start = p > 0 ? i : -1;
+    power = p;
+  }
+
+  if (start >= 0) runs.push([start, pixels.length, power]);
+
+  return runs;
+}
+
+export interface ParsedFcode {
+  /**
+   * [recordIndex, [startOffset, endOffset]]: M137 type-1 acceleration-override commands
+   * (set_acceleration_override, incl. s-curve's derived acc), sparse. Start-here slicing
+   * re-emits the latest one's bytes verbatim, since they can occur mid-layer (per item).
+   */
+  accelEvents: Array<[number, [number, number]]>;
+  /**
+   * [bodyStartOffset, prologueEndOffset] per script block: the record-less commands at the
+   * start of a block (grbl syncs, miscellaneous arming, layer power pwm) that "start here"
+   * slicing must replay verbatim, ending at the first record-producing command.
+   */
+  blockPrologues: Array<[number, number]>;
+  /** [recordIndex, resolutionChar | null]: gradient print mode changes, sparse */
+  gradientEvents: Array<[number, null | number]>;
+  metadata: Record<string, number | string>;
+  /** [recordIndex, laserModule]: cmd-7 laser module changes, sparse */
+  moduleEvents: Array<[number, number]>;
+  parsedGcode: ParsedGcode;
+  /** Per record: byte offset of the END of the command that produced it (for start-here slicing) */
+  recordOffsets: number[];
+  /**
+   * [recordIndex, pCmd, [startOffset, endOffset] | null]: s-curve device commands, sparse.
+   * pCmd 154/155/157 set jerk/a_max/a0 (set_s_curve_params, M137 type-2); pCmd 156 with a
+   * null span turns s-curve off (sync_grbl_motion(156)). Start-here slicing re-emits the
+   * live triplet, or nothing when the last event is off (fresh jobs default to off).
+   */
+  sCurveEvents: Array<[number, number, [number, number] | null]>;
+}
+
+export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
+  const parsedGcode = new ParsedGcode();
+  const metadata: Record<string, number | string> = {};
+  const recordOffsets: number[] = [];
+  const moduleEvents: Array<[number, number]> = [];
+  const gradientEvents: Array<[number, null | number]> = [];
+  const blockPrologues: Array<[number, number]> = [];
+  const accelEvents: Array<[number, [number, number]]> = [];
+  const sCurveEvents: Array<[number, number, [number, number] | null]> = [];
+  let pendingBlock: null | { bodyStart: number; recordCount: number } = null;
+  const reader = new Reader(buffer);
+
+  // Machine coords, y kept in preview space (negated, matching parseGcode)
+  const state = { a: 0, f: 7500, pwm: 0, x: 0, y: 0, z: 0 };
+  let raster: null | RasterState = null;
+
+  const push = (g: number, s = state.pwm, t = 0) => {
+    parsedGcode.push(g);
+    parsedGcode.push(state.x);
+    parsedGcode.push(state.y);
+    parsedGcode.push(state.z);
+    parsedGcode.push(0); // e
+    parsedGcode.push(state.f);
+    parsedGcode.push(state.a);
+    parsedGcode.push(s);
+    parsedGcode.push(t);
+    recordOffsets.push(reader.pos);
+  };
+
+  const emitRasterSweep = (targetX: number) => {
+    const { pixelCount, pixels } = raster!;
+    const x1 = state.x;
+    const pixelWidth = (targetX - x1) / pixelCount;
+    const runs = decodePixelRuns(pixels.length > pixelCount ? pixels.slice(0, pixelCount) : pixels);
+
+    // The preview shades segment i by record i's `t` and record i+1's `s`, so tag both ends of each run.
+    for (const [start, end, power] of runs) {
+      state.x = x1 + start * pixelWidth;
+      push(0, state.pwm, RASTER_T);
+      state.x = x1 + end * pixelWidth;
+      push(1, power, RASTER_T);
+    }
+
+    if (state.x !== targetX) {
+      state.x = targetX;
+      push(0);
+    }
+
+    raster!.armed = false;
+    raster!.pixels = [];
+  };
+
+  const handleMoveto = (cmd: number) => {
+    let targetX = state.x;
+
+    if (cmd & 64) state.f = reader.f32();
+
+    if (cmd & 32) targetX = reader.f32();
+
+    if (cmd & 16) state.y = -reader.f32();
+
+    if (cmd & 8) state.z = reader.f32();
+
+    if (cmd & 4) state.a = reader.f32();
+
+    if (cmd & 2) reader.f32();
+
+    if (cmd & 1) reader.f32();
+
+    if (raster?.armed && targetX !== state.x) {
+      emitRasterSweep(targetX);
+    } else {
+      state.x = targetX;
+      push(state.pwm > 0 ? 1 : 0);
+    }
+  };
+
+  const handleRasterCmd = () => {
+    const sub = reader.u8();
+
+    switch (sub) {
+      case 1: {
+        const modeChar = reader.u8();
+
+        raster = { armed: false, pixelCount: 0, pixels: [], pwmMode: PWM_MODE_CHARS.has(modeChar) };
+        gradientEvents.push([recordOffsets.length, modeChar]);
+        break;
+      }
+      case 2:
+        if (!raster) raster = { armed: false, pixelCount: 0, pixels: [], pwmMode: false };
+
+        raster.pixelCount = reader.u32();
+        raster.pixels = [];
+        break;
+      case 3: {
+        const word = reader.u32();
+
+        if (!raster) break;
+
+        if (raster.pwmMode) {
+          raster.pixels.push((word >>> 24) & 0xff, (word >>> 16) & 0xff, (word >>> 8) & 0xff, word & 0xff);
+        } else {
+          for (let bit = 31; bit >= 0; bit -= 1) {
+            raster.pixels.push(word & (1 << bit) ? 255 : 0);
+          }
+        }
+
+        break;
+      }
+      case 4:
+        break;
+      case 5:
+        if (raster) raster.armed = true;
+
+        break;
+      case 6:
+        raster = null;
+        gradientEvents.push([recordOffsets.length, null]);
+        break;
+      default:
+        throw new Error(`Unknown fcode raster sub-command ${sub}`);
+    }
+  };
+
+  const parseCommands = (end: number) => {
+    while (reader.pos < end) {
+      const cmdStart = reader.pos;
+      const cmd = reader.u8();
+
+      if (cmd & 128) {
+        handleMoveto(cmd);
+      } else {
+        parseSimpleCommand(cmd, cmdStart);
+      }
+
+      if (pendingBlock && recordOffsets.length > pendingBlock.recordCount) {
+        blockPrologues.push([pendingBlock.bodyStart, cmdStart]);
+        pendingBlock = null;
+      }
+    }
+  };
+
+  const parseSimpleCommand = (cmd: number, cmdStart: number) => {
+    switch (cmd) {
+      case 48: // fan speed
+      case 32: // toolhead pwm
+      case 24: // heater (blocking)
+        if (cmd === 32) state.pwm = reader.f32();
+        else reader.f32();
+
+        break;
+      case 16: // fast gradient sub-commands
+        handleRasterCmd();
+        break;
+      case 18: {
+        // grbl sync / M137 sync motion
+        const sub = reader.u8();
+
+        if (sub === 0) {
+          const value = reader.u32();
+
+          // sync_grbl_motion(156) turns s-curve off on the device
+          if (value === 156) sCurveEvents.push([recordOffsets.length, value, null]);
+        } else if (sub === 2) {
+          const pCmd = reader.u32();
+          const flags = reader.u8();
+
+          if (flags & 128) reader.f32();
+
+          // set_s_curve_params: P154 Q=jerk, P155 Q=a_max, P157 Q=a0
+          if (pCmd === 154 || pCmd === 155 || pCmd === 157) {
+            sCurveEvents.push([recordOffsets.length, pCmd, [cmdStart, reader.pos]]);
+          }
+        } else {
+          // sub 1: M137 type1, uint32 cmd + flags byte + one float per flag.
+          // Used for acceleration overrides (P150); tracked for start-here slicing.
+          reader.u32();
+
+          const flags = reader.u8();
+
+          for (const bit of [64, 32, 16, 8, 4, 1]) {
+            if (flags & bit) reader.f32();
+          }
+
+          accelEvents.push([recordOffsets.length, [cmdStart, reader.pos]]);
+        }
+
+        break;
+      }
+      case 19: // flux custom cmd
+        reader.u8();
+        reader.u32();
+        break;
+      case 20: // user selection cmd
+      case 21: // miscellaneous cmd
+      case 22: // grbl system cmd ($H resets position, but a moveto always follows)
+        reader.u8();
+        break;
+      case 7: // set laser module
+        moduleEvents.push([recordOffsets.length, reader.u32()]);
+        break;
+      case 8: // calibrate
+      case 4: // sleep (uint32 ms)
+        reader.u32();
+        break;
+      case 5: // pause to standby
+      case 6: // pause in place
+        break;
+      case 1: // home
+        state.x = 0;
+        state.y = 0;
+        state.z = 0;
+        push(0);
+        break;
+      default:
+        throw new Error(`Unknown fcode command ${cmd} at offset ${reader.pos - 1}`);
+    }
+  };
+
+  const parseV2Blocks = (end: number) => {
+    while (reader.pos < end) {
+      const blockTag = reader.tag();
+
+      if (blockTag === 'TASK') continue; // bare marker, no payload
+
+      if (blockTag === 'INFO' || blockTag === 'PREV') {
+        // length-prefixed per-task info json / preview image
+        const length = reader.u32();
+
+        reader.pos += length;
+        continue;
+      }
+
+      // Task script block: 4-char header [+ 4-char proc id] + uint32 length + commands.
+      // The proc id is omitted when empty (TRAN/MAIN); present ones are ASCII digits
+      // ('0001'..'0008'), which can never be a real length (would be >800MB).
+      const peek = reader.bytes.subarray(reader.pos, reader.pos + 4);
+
+      if (peek.every((b) => b >= 0x30 && b <= 0x39)) reader.pos += 4;
+
+      const length = reader.u32();
+
+      pendingBlock = { bodyStart: reader.pos, recordCount: recordOffsets.length };
+      parseCommands(reader.pos + length);
+      pendingBlock = null;
+    }
+  };
+
+  try {
+    const magic = reader.utf8(8); // "FCx000N\n"
+
+    if (!magic.startsWith('FCx')) throw new Error(`Bad fcode header: ${magic}`);
+
+    const version = Number.parseInt(magic.slice(3, 7), 10);
+
+    if (version === 1) {
+      const scriptLength = reader.u32();
+
+      pendingBlock = { bodyStart: reader.pos, recordCount: 0 };
+      parseCommands(reader.pos + scriptLength);
+      pendingBlock = null;
+      reader.u32(); // script crc32
+
+      const metadataLength = reader.u32();
+
+      for (const pair of reader.utf8(metadataLength).split('\x00')) {
+        const eq = pair.indexOf('=');
+
+        if (eq > 0) metadata[pair.slice(0, eq)] = pair.slice(eq + 1);
+      }
+    } else {
+      // v2+: tagged chunks FILE (json metadata), PREV (previews), CONT (script blocks)
+      while (reader.pos < reader.bytes.length - 8) {
+        const chunkTag = reader.tag();
+
+        if (chunkTag === 'FILE') {
+          Object.assign(metadata, JSON.parse(reader.utf8(reader.u32())));
+          reader.u32(); // crc32
+        } else if (chunkTag === 'PREV') {
+          // previews have no count: entries of uint32 length + data until the next chunk tag
+          while (reader.tag() !== 'CONT') {
+            reader.pos -= 4;
+
+            const previewLength = reader.u32();
+
+            reader.pos += previewLength;
+          }
+
+          reader.pos -= 4;
+        } else if (chunkTag === 'CONT') {
+          const length = reader.u32();
+
+          parseV2Blocks(reader.pos + length);
+          break; // ignore trailing crc32 / POST chunk
+        } else {
+          throw new Error(`Unknown fcode chunk: ${chunkTag}`);
+        }
+      }
+    }
+  } catch (error) {
+    // Return what was parsed so far; a truncated preview beats no preview.
+    console.error('parseFcode failed:', error);
+  }
+
+  console.log('Parsed FCode', parsedGcode);
+
+  return {
+    accelEvents,
+    blockPrologues,
+    gradientEvents,
+    metadata,
+    moduleEvents,
+    parsedGcode,
+    recordOffsets,
+    sCurveEvents,
+  };
+};
+
+export default parseFcode;

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
@@ -16,6 +16,24 @@ const PWM_MODE_CHARS = new Set(['P', 'Q', 'R', 'C', 'S', 'T'].map((c) => c.charC
  */
 export const RASTER_T = 6;
 
+/**
+ * Record `t` base value for 4C printer channel runs: t = PRINTER_CHANNEL_T + channel
+ * (0=C, 1=M, 2=Y, 3=K, 4=white). Also used for single-color layers whose ink comes
+ * from the layer INFO metadata. The preview shader draws these runs in a dedicated
+ * pass with subtractive ink blending, using `s`/255 as coverage.
+ */
+export const PRINTER_CHANNEL_T = 7;
+
+// bm2 4C physical nozzle-column x offsets in pixels at the task's fixed dot pitch
+// (fluxclient DEFAULT_COLOR_OFFSETS), indexed C, M, Y, K. Payload channels are
+// aligned with each other (verified by cross-correlation on a real export), so the
+// printed position of channel c is payload x + offset * dot pitch (machine +x).
+const CHANNEL_X_OFFSETS_4C = [0, 42, 84, 126];
+
+// x gap between the 4C left and right nozzle columns in mm (printer_4c
+// pixel_to_actual_position); right-nozzle swaths bake it into the motion.
+const RIGHT_NOZZLE_X_GAP = 0.55035;
+
 export class Reader {
   view: DataView;
 
@@ -30,7 +48,7 @@ export class Reader {
   }
 
   u8 = (): number => {
-    const v = this.view.getUint8(this.pos);
+    const v = this.bytes[this.pos];
 
     this.pos += 1;
 
@@ -111,6 +129,114 @@ export function decodePixelRuns(pixels: ArrayLike<number>): Array<[number, numbe
   return runs;
 }
 
+export interface PrinterSwath {
+  /** 1 for single-color, 4 for 4C (C, M, Y, K) */
+  channels: 1 | 4;
+  /**
+   * Ink bitmask of pixel (column, row): 0|1 for single-color, a CMYK nibble
+   * (bit 3 = C .. bit 0 = K) for 4C; channels are aligned in payload space
+   */
+  pixelAt: (col: number, row: number) => number;
+  rows: number;
+  w: number;
+}
+
+/**
+ * Decodes a printer image packet payload (printer.py create_image_packet_data /
+ * printer_4c generate_payload) into a 2D swath accessor.
+ *
+ * Layout: u32 w | u32 h | u32 x | u32 y | [4 reserved bytes, single-color only]
+ * then w columns of pixel bits in sweep order, MSB first: single-color packs
+ * 1 bit per pixel, 4C packs 4 bits per pixel (one per CMYK channel; channels are
+ * aligned with each other in payload space — verified against a real fbm2 export —
+ * while the physical print applies CHANNEL_X_OFFSETS_4C per channel). The header
+ * length comes from the packet sub-command family (subs 0-5 single, 10-15 4C).
+ * Payloads failing the size checks (nozzle-settings packets) return null.
+ */
+export function decodePrinterSwath(payload: Uint8Array, headerLength: 16 | 20): null | PrinterSwath {
+  if (payload.length <= headerLength) return null;
+
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+  const w = view.getUint32(0, true);
+  const h = view.getUint32(4, true);
+  const dataLength = payload.length - headerLength;
+
+  if (w < 1 || w > 100000 || h < 1 || h > 8192 || dataLength % w !== 0) return null;
+
+  const bytesPerColumn = dataLength / w;
+
+  if (bytesPerColumn < 1 || bytesPerColumn > 2048) return null;
+
+  const channels = headerLength === 16 ? 4 : 1;
+  const rows = Math.floor((bytesPerColumn * 8) / channels);
+  const pixelAt =
+    channels === 1
+      ? (col: number, row: number): number => {
+          // single-color packets store rows bottom-up (create_image_packet_data
+          // reverse_y=True; 4C passes False), so flip to match 4C's top-down order
+          const r = rows - 1 - row;
+
+          return (payload[headerLength + col * bytesPerColumn + (r >> 3)] >> (7 - (r & 7))) & 1;
+        }
+      : (col: number, row: number): number => {
+          // 4 bits per pixel, nibble bit 3 = C .. bit 0 = K
+          const byte = payload[headerLength + col * bytesPerColumn + (row >> 1)];
+
+          return (row & 1) === 0 ? byte >> 4 : byte & 0x0f;
+        };
+
+  return { channels, pixelAt, rows, w };
+}
+
+export interface ContentEntry {
+  bodyStart: number;
+  end: number;
+  isBlock: boolean;
+  start: number;
+  tag: string;
+}
+
+/**
+ * Structure-only walk of a v2 CONT chunk's entries — task script blocks
+ * (4-char tag [+ 4-char all-digit proc id] + u32 length), bare TASK markers,
+ * and length-prefixed INFO/PREV items. Shared by parsing and start-here slicing.
+ */
+export function walkContentEntries(buffer: ArrayBuffer, start: number, end: number): ContentEntry[] {
+  const r = new Reader(buffer, start);
+  const entries: ContentEntry[] = [];
+
+  while (r.pos < end) {
+    const entryStart = r.pos;
+    const tag = r.tag();
+
+    if (tag === 'TASK') {
+      entries.push({ bodyStart: r.pos, end: r.pos, isBlock: false, start: entryStart, tag });
+      continue;
+    }
+
+    if (tag === 'INFO' || tag === 'PREV') {
+      const length = r.u32();
+
+      entries.push({ bodyStart: r.pos, end: r.pos + length, isBlock: false, start: entryStart, tag });
+      r.pos += length;
+      continue;
+    }
+
+    // task script block; the proc id is omitted when empty (TRAN/MAIN), and present
+    // ones are ASCII digits ('0001'..'0008') — never a valid length (would be >800MB)
+    const peek = r.bytes.subarray(r.pos, r.pos + 4);
+
+    if (peek.every((b) => b >= 0x30 && b <= 0x39)) r.pos += 4;
+
+    const length = r.u32();
+
+    entries.push({ bodyStart: r.pos, end: r.pos + length, isBlock: true, start: entryStart, tag });
+    r.pos += length;
+  }
+
+  return entries;
+}
+
 export interface ParsedFcode {
   /**
    * [recordIndex, [startOffset, endOffset]]: M137 type-1 acceleration-override commands
@@ -160,6 +286,13 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
   // Payload length announced by the printer packet-length sub-command; the
   // payload marker is followed by that many raw unframed bytes.
   let printerPayloadLength = 0;
+  // Payload byte spans (+ header length by packet family) buffered since the last
+  // positioning move; decoded into per-column ink runs when the swath sweep
+  // (moveto with s > 0) arrives.
+  let printerPayloads: Array<[number, number, 16 | 20, number]> = [];
+  // Packet type from start_printer_packet: NozzleMode LEFT=1 / RIGHT=2 / BOTH=3 for
+  // image packets (17 = nozzle settings, 5 = white ink, 6 = varnish)
+  let printerPacketType = 0;
 
   const push = (g: number, s = state.pwm, t = 0) => {
     parsedGcode.push(g);
@@ -197,6 +330,131 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
     raster!.pixels = [];
   };
 
+  // Emits a printer swath as 2D content: the real sweep as a travel record (it
+  // carries the motion time), then the packet's pixel rows as zero-sim-time run
+  // records (f = NaN adds no time in GcodePreview), downsampled to ~0.2mm cells.
+  const emitPrinterSweep = (targetX: number): boolean => {
+    let swath: null | PrinterSwath = null;
+    let packetType = 0;
+
+    for (const [start, end, headerLength, type] of printerPayloads) {
+      swath = decodePrinterSwath(reader.bytes.subarray(start, end), headerLength);
+
+      if (swath) {
+        packetType = type;
+        break;
+      }
+    }
+
+    printerPayloads = [];
+
+    if (!swath) return false;
+
+    const x1 = state.x;
+    const sweepY = state.y;
+    const savedF = state.f;
+    const pixelWidth = (targetX - x1) / swath.w;
+    // dot interval is a fixed pixel-per-mm in both axes, so row pitch = column pitch
+    const rowPitch = Math.abs(pixelWidth);
+    // 4C right-nozzle swaths compensate the nozzle x gap in the MOTION
+    // (printer_4c pixel_to_actual_position adds +-0.55035mm to the movetos, sign by
+    // task direction); undo it so content draws at the true deposit position
+    const nozzleAdjust =
+      swath.channels === 4 && packetType === 2 ? (targetX > x1 ? -RIGHT_NOZZLE_X_GAP : RIGHT_NOZZLE_X_GAP) : 0;
+
+    state.x = targetX;
+    push(0);
+
+    state.f = Number.NaN;
+
+    // A NaN-position record makes the segments touching it non-rasterizable,
+    // hiding the synthetic jumps between runs/rows from the traversal display
+    // (they are not actual head motion; the real sweep travel above remains).
+    const pushBreak = () => {
+      const { x: sx, y: sy } = state;
+
+      state.x = Number.NaN;
+      state.y = Number.NaN;
+      push(0, 0);
+      state.x = sx;
+      state.y = sy;
+    };
+    const colStep = Math.max(1, Math.round(0.2 / rowPitch));
+    const rowStep = Math.max(1, Math.round(0.2 / rowPitch));
+    const cellCount = Math.ceil(swath.w / colStep);
+    const cells = new Uint8Array(cellCount);
+
+    // single-color layers carry their ink in the layer INFO metadata (Ador)
+    const taskInk = taskInkChannels[taskIndex] ?? null;
+    const { channels } = swath;
+    // per-cell ink sums for every channel, filled in one pass per row block so
+    // each pixel is decoded once (a 4C nibble carries all four channel bits)
+    const sums = new Uint16Array(cellCount * channels);
+
+    for (let row = 0; row < swath.rows; row += rowStep) {
+      const rowEnd = Math.min(row + rowStep, swath.rows);
+
+      sums.fill(0);
+
+      for (let col = 0; col < swath.w; col += 1) {
+        const base = Math.floor(col / colStep) * channels;
+
+        for (let r = row; r < rowEnd; r += 1) {
+          const mask = swath.pixelAt(col, r);
+
+          if (!mask) continue;
+
+          if (channels === 4) {
+            sums[base] += (mask >> 3) & 1;
+            sums[base + 1] += (mask >> 2) & 1;
+            sums[base + 2] += (mask >> 1) & 1;
+            sums[base + 3] += mask & 1;
+          } else {
+            sums[base] += 1;
+          }
+        }
+      }
+
+      // swath rows extend from the sweep line toward larger machine y (preview -y);
+      // verified against a real fbm2 export
+      state.y = sweepY - (row + (rowEnd - row) / 2) * rowPitch;
+
+      for (let channel = 0; channel < channels; channel += 1) {
+        // physical nozzle-column offset, always machine +x regardless of sweep direction
+        const channelOffset = channels === 4 ? CHANNEL_X_OFFSETS_4C[channel] * rowPitch : 0;
+        const runT =
+          channels === 4 ? PRINTER_CHANNEL_T + channel : taskInk === null ? RASTER_T : PRINTER_CHANNEL_T + taskInk;
+
+        for (let ci = 0; ci < cellCount; ci += 1) {
+          const colEnd = Math.min((ci + 1) * colStep, swath.w);
+          const area = (colEnd - ci * colStep) * (rowEnd - row);
+
+          // quantize to 16 levels so smooth regions merge into long runs
+          cells[ci] = Math.round((sums[ci * channels + channel] / area) * 15) * 17;
+        }
+
+        const runs = decodePixelRuns(cells);
+
+        for (const [start, end, power] of runs) {
+          pushBreak();
+          state.x = x1 + start * colStep * pixelWidth + channelOffset + nozzleAdjust;
+          push(0, 0, runT);
+          state.x = x1 + Math.min(end * colStep, swath.w) * pixelWidth + channelOffset + nozzleAdjust;
+          push(1, power, runT);
+        }
+      }
+    }
+
+    // zero-time return to the sweep end so subsequent motion connects correctly
+    pushBreak();
+    state.x = targetX;
+    state.y = sweepY;
+    push(0);
+    state.f = savedF;
+
+    return true;
+  };
+
   const handleMoveto = (cmd: number) => {
     let targetX = state.x;
 
@@ -212,10 +470,17 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
 
     if (cmd & 2) reader.f32();
 
-    if (cmd & 1) state.printS = reader.f32();
+    if (cmd & 1) {
+      state.printS = reader.f32();
+
+      // a positioning move (s=0) discards buffered non-image packets (nozzle settings)
+      if (state.printS === 0) printerPayloads = [];
+    }
 
     if (raster?.armed && targetX !== state.x) {
       emitRasterSweep(targetX);
+    } else if (state.printS > 0 && printerPayloads.length > 0 && targetX !== state.x && emitPrinterSweep(targetX)) {
+      // handled as per-column ink runs
     } else {
       state.x = targetX;
       push(state.pwm > 0 || state.printS > 0 ? 1 : 0);
@@ -310,6 +575,12 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
             break;
           case 1: // payload marker, followed by raw unframed bytes
           case 12:
+            printerPayloads.push([
+              reader.pos,
+              reader.pos + printerPayloadLength,
+              sub === 12 ? 16 : 20,
+              printerPacketType,
+            ]);
             reader.pos += printerPayloadLength;
             printerPayloadLength = 0;
             break;
@@ -317,9 +588,9 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
           case 13:
             reader.u16();
             break;
-          case 3: // start packet (u8 type)
+          case 3: // start packet (u8 type = NozzleMode for image packets)
           case 10:
-            reader.u8();
+            printerPacketType = reader.u8();
             break;
           case 4: // end packet
           case 14:
@@ -401,31 +672,42 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
     }
   };
 
-  const parseV2Blocks = (end: number) => {
-    while (reader.pos < end) {
-      const blockTag = reader.tag();
+  // Ink channel per ink name (single-color layers, Ador): C=0, M=1, Y=2, K=3
+  // map to PRINTER_CHANNEL_T + channel; white gets its own t (11).
+  const INK_CHANNELS: Record<string, number> = { black: 3, cyan: 0, magenta: 1, white: 4, yellow: 2 };
+  // Per-task ink channel from the INFO jsons (submodule.color), in TASK order;
+  // INFO trails its layer's MAIN block, so a structure-only pre-scan collects them.
+  let taskInkChannels: Array<null | number> = [];
+  let taskIndex = -1;
 
-      if (blockTag === 'TASK') continue; // bare marker, no payload
+  const parseV2Content = (start: number, end: number) => {
+    const entries = walkContentEntries(buffer, start, end);
 
-      if (blockTag === 'INFO' || blockTag === 'PREV') {
-        // length-prefixed per-task info json / preview image
-        const length = reader.u32();
+    // INFO trails its layer's MAIN block, so collect the per-task ink first
+    for (const entry of entries) {
+      if (entry.tag !== 'INFO') continue;
 
-        reader.pos += length;
+      try {
+        const json = new TextDecoder().decode(reader.bytes.subarray(entry.bodyStart, entry.end));
+        const info = JSON.parse(json) as { submodule?: { color?: string } };
+
+        taskInkChannels.push(INK_CHANNELS[info.submodule?.color ?? ''] ?? null);
+      } catch {
+        taskInkChannels.push(null);
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.tag === 'TASK') {
+        taskIndex += 1;
         continue;
       }
 
-      // Task script block: 4-char header [+ 4-char proc id] + uint32 length + commands.
-      // The proc id is omitted when empty (TRAN/MAIN); present ones are ASCII digits
-      // ('0001'..'0008'), which can never be a real length (would be >800MB).
-      const peek = reader.bytes.subarray(reader.pos, reader.pos + 4);
+      if (!entry.isBlock) continue;
 
-      if (peek.every((b) => b >= 0x30 && b <= 0x39)) reader.pos += 4;
-
-      const length = reader.u32();
-
-      pendingBlock = { bodyStart: reader.pos, recordCount: recordOffsets.length };
-      parseCommands(reader.pos + length);
+      reader.pos = entry.bodyStart;
+      pendingBlock = { bodyStart: entry.bodyStart, recordCount: recordOffsets.length };
+      parseCommands(entry.end);
       pendingBlock = null;
     }
   };
@@ -474,7 +756,7 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
         } else if (chunkTag === 'CONT') {
           const length = reader.u32();
 
-          parseV2Blocks(reader.pos + length);
+          parseV2Content(reader.pos, reader.pos + length);
           break; // ignore trailing crc32 / POST chunk
         } else {
           throw new Error(`Unknown fcode chunk: ${chunkTag}`);

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
@@ -713,7 +713,9 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
         continue;
       }
 
-      if (!entry.isBlock) continue;
+      // xMIN blocks are machine scripts (homing, prespray, lid/table moves, post-task),
+      // not design content: skip them so their moves and prespray swaths stay out of the preview
+      if (!entry.isBlock || entry.tag === 'xMIN') continue;
 
       reader.pos = entry.bodyStart;
       pendingBlock = { bodyStart: entry.bodyStart, recordCount: recordOffsets.length };

--- a/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/parseFcode.ts
@@ -256,6 +256,13 @@ export interface ParsedFcode {
   /** [recordIndex, laserModule]: cmd-7 laser module changes, sparse */
   moduleEvents: Array<[number, number]>;
   parsedGcode: ParsedGcode;
+  /**
+   * [recordIndex, cmd]: pause commands, sparse. On laser firmware cmd 6 (pause in
+   * place) doubles as rotary-mode-on and cmd 5 (pause to standby) as gcode boost;
+   * both can trail the first movetos (v1 rotary preamble, v2 rotary_wait_move), so
+   * start-here slicing re-emits them after restoring the y/axis position.
+   */
+  pauseEvents: Array<[number, number]>;
   /** Per record: byte offset of the END of the command that produced it (for start-here slicing) */
   recordOffsets: number[];
   /**
@@ -276,12 +283,14 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
   const blockPrologues: Array<[number, number]> = [];
   const accelEvents: Array<[number, [number, number]]> = [];
   const sCurveEvents: Array<[number, number, [number, number] | null]> = [];
+  const pauseEvents: Array<[number, number]> = [];
   let pendingBlock: null | { bodyStart: number; recordCount: number } = null;
   const reader = new Reader(buffer);
 
   // Machine coords, y kept in preview space (negated, matching parseGcode)
+  // a: NaN until the task moves the A axis (fcode v2 rotary), like fluxclient's NAN=absent
   // printS: the moveto S axis — printer swath sweeps carry s=1, travels s=0
-  const state = { a: 0, f: 7500, printS: 0, pwm: 0, x: 0, y: 0, z: 0 };
+  const state = { a: Number.NaN, f: 7500, printS: 0, pwm: 0, x: 0, y: 0, z: 0 };
   let raster: null | RasterState = null;
   // Payload length announced by the printer packet-length sub-command; the
   // payload marker is followed by that many raw unframed bytes.
@@ -658,8 +667,9 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
       case 4: // sleep (uint32 ms)
         reader.u32();
         break;
-      case 5: // pause to standby
-      case 6: // pause in place
+      case 5: // pause to standby (doubles as gcode-boost-on for laser firmware)
+      case 6: // pause in place (doubles as rotary-mode-on for laser firmware)
+        pauseEvents.push([recordOffsets.length, cmd]);
         break;
       case 1: // home
         state.x = 0;
@@ -777,6 +787,7 @@ export const parseFcode = (buffer: ArrayBuffer): ParsedFcode => {
     metadata,
     moduleEvents,
     parsedGcode,
+    pauseEvents,
     recordOffsets,
     sCurveEvents,
   };

--- a/packages/core/src/web/app/components/beambox/PathPreview/sliceFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/sliceFcode.ts
@@ -23,6 +23,7 @@ export interface FcodeTask extends Omit<ParsedFcode, 'metadata'> {
 }
 
 const TRAVEL_FEEDRATE = 7500; // mm/min, matches the gcode start-here preparation
+const A_TRAVEL_FEEDRATE = 2400; // mm/min, rotary a-axis travel speed
 
 const CRC_TABLE = new Uint32Array(256).map((_, n) => {
   let c = n;
@@ -66,11 +67,14 @@ class ByteWriter {
 
 /** Commands re-establishing modal machine state at the cut point. */
 const buildRestoreCommands = (opts: {
+  a: number;
+  boostOn: boolean;
   feedrate: number;
   gradientChar: null | number;
   isV1: boolean;
   laserModule: null | number;
   pwm: number;
+  rotaryOn: boolean;
   x: number;
   y: number;
   z: number;
@@ -96,6 +100,19 @@ const buildRestoreCommands = (opts: {
   if (opts.z > 0) {
     w.u8(128 | 8);
     w.f32(opts.z);
+  }
+
+  // rotary mode / gcode boost (pause cmds 6 / 5 on laser firmware) can trail the
+  // first movetos in the original stream, so re-arm them after the position is set
+  if (opts.rotaryOn) w.u8(6);
+
+  if (opts.boostOn) w.u8(5);
+
+  // rotary tasks: pre-position the a axis (workpiece rotation) at travel speed
+  if (!Number.isNaN(opts.a)) {
+    w.u8(128 | 64 | 4);
+    w.f32(A_TRAVEL_FEEDRATE);
+    w.f32(opts.a);
   }
 
   // restore modal feedrate for remainder movetos that omit F
@@ -188,6 +205,7 @@ export const sliceFcode = (
       gradientEvents,
       moduleEvents,
       parsedGcode,
+      pauseEvents,
       recordOffsets,
       sCurveEvents,
     } = task;
@@ -228,13 +246,18 @@ export const sliceFcode = (
     }
 
     const sCurveBytes = concatBytes([...sCurveSpans.values()].map(([start, end]) => bytes.subarray(start, end)));
+    const rotaryOn = pauseEvents.some(([index, cmd]) => index <= arrival && cmd === 6);
+    const boostOn = pauseEvents.some(([index, cmd]) => index <= arrival && cmd === 5);
     const buildRestore = (hasPrologue: boolean) =>
       buildRestoreCommands({
+        a: record(6),
+        boostOn,
         feedrate: record(5),
         gradientChar: lastEventAt(gradientEvents, arrival),
         isV1: version === 1 && !hasPrologue,
         laserModule: lastEventAt(moduleEvents, arrival),
         pwm: isRaster ? 0 : record(7),
+        rotaryOn,
         x: simTimeInfo.position[0],
         y: simTimeInfo.position[1],
         z: record(3),

--- a/packages/core/src/web/app/components/beambox/PathPreview/sliceFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/sliceFcode.ts
@@ -1,5 +1,5 @@
 import type { ParsedFcode } from './parseFcode';
-import { RASTER_T, Reader } from './parseFcode';
+import { RASTER_T, Reader, walkContentEntries } from './parseFcode';
 
 // Builds a "start from here" fcode by byte-splicing the original task at the
 // simulation-time cut point, so no gcode regeneration or fluxghost round-trip
@@ -114,49 +114,6 @@ const buildRestoreCommands = (opts: {
   }
 
   return w.toArray();
-};
-
-interface ContentEntry {
-  bodyStart: number;
-  end: number;
-  isBlock: boolean;
-  start: number;
-  tag: string;
-}
-
-/** Structure-only walk of CONT entries (no command parsing). */
-const walkContentEntries = (reader: Reader, end: number): ContentEntry[] => {
-  const entries: ContentEntry[] = [];
-
-  while (reader.pos < end) {
-    const start = reader.pos;
-    const tag = reader.tag();
-
-    if (tag === 'TASK') {
-      entries.push({ bodyStart: reader.pos, end: reader.pos, isBlock: false, start, tag });
-      continue;
-    }
-
-    if (tag === 'INFO' || tag === 'PREV') {
-      const length = reader.u32();
-
-      entries.push({ bodyStart: reader.pos, end: reader.pos + length, isBlock: false, start, tag });
-      reader.pos += length;
-      continue;
-    }
-
-    // task script block; optional all-digit proc id (see parseFcode)
-    const peek = reader.bytes.subarray(reader.pos, reader.pos + 4);
-
-    if (peek.every((b) => b >= 0x30 && b <= 0x39)) reader.pos += 4;
-
-    const length = reader.u32();
-
-    entries.push({ bodyStart: reader.pos, end: reader.pos + length, isBlock: true, start, tag });
-    reader.pos += length;
-  }
-
-  return entries;
 };
 
 const lastEventAt = <T>(events: Array<[number, T]>, recordIndex: number): null | T => {
@@ -363,7 +320,7 @@ export const sliceFcode = (
 
         if (cutOffset <= contentStart || cutOffset >= contentEnd) return null;
 
-        const entries = walkContentEntries(new Reader(buffer, contentStart), contentEnd);
+        const entries = walkContentEntries(buffer, contentStart, contentEnd);
         const containing = entries.find((e) => e.isBlock && e.bodyStart <= cutOffset && cutOffset < e.end);
 
         if (!containing) return null;

--- a/packages/core/src/web/app/components/beambox/PathPreview/sliceFcode.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/sliceFcode.ts
@@ -1,0 +1,446 @@
+import type { ParsedFcode } from './parseFcode';
+import { RASTER_T, Reader } from './parseFcode';
+
+// Builds a "start from here" fcode by byte-splicing the original task at the
+// simulation-time cut point, so no gcode regeneration or fluxghost round-trip
+// is needed. See .agents/skills/fcode/SKILL.md for the container format.
+//
+// v2 layout of the sliced CONT content:
+//   [pre-task entries] [cut layer's TASK..MAIN header] [block prologue: the layer's
+//   record-less arming/power commands, copied verbatim] [state-restore commands]
+//   [original bytes from cut offset to end of content]
+// Prior layers are dropped; the containing MAIN block's length, the CONT length,
+// and the CONT crc32 are patched. v1 splices the flat script the same way. The
+// FILE metadata (time_cost) and PREV thumbnail are rebuilt when extras are given,
+// since the machine displays them while running.
+//
+// ponytail: a cut inside a raster sweep restarts at the next raster line (the
+// remainder of the current line is skipped, ≤0.2mm). Pixel-exact restart would
+// mask leading pixels of the current line's fill words, like the gcode flow does.
+
+export interface FcodeTask extends Omit<ParsedFcode, 'metadata'> {
+  buffer: ArrayBuffer;
+}
+
+const TRAVEL_FEEDRATE = 7500; // mm/min, matches the gcode start-here preparation
+
+const CRC_TABLE = new Uint32Array(256).map((_, n) => {
+  let c = n;
+
+  for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+
+  return c;
+});
+
+const crc32 = (bytes: Uint8Array): number => {
+  let c = 0xffffffff;
+
+  for (let i = 0; i < bytes.length; i += 1) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+
+  return (c ^ 0xffffffff) >>> 0;
+};
+
+class ByteWriter {
+  bytes: number[] = [];
+
+  private scratch = new DataView(new ArrayBuffer(4));
+
+  u8 = (value: number): void => {
+    this.bytes.push(value);
+  };
+
+  u32 = (value: number): void => {
+    this.scratch.setUint32(0, value, true);
+
+    for (let i = 0; i < 4; i += 1) this.bytes.push(this.scratch.getUint8(i));
+  };
+
+  f32 = (value: number): void => {
+    this.scratch.setFloat32(0, value, true);
+
+    for (let i = 0; i < 4; i += 1) this.bytes.push(this.scratch.getUint8(i));
+  };
+
+  toArray = (): Uint8Array<ArrayBuffer> => Uint8Array.from(this.bytes);
+}
+
+/** Commands re-establishing modal machine state at the cut point. */
+const buildRestoreCommands = (opts: {
+  feedrate: number;
+  gradientChar: null | number;
+  isV1: boolean;
+  laserModule: null | number;
+  pwm: number;
+  x: number;
+  y: number;
+  z: number;
+}): Uint8Array<ArrayBuffer> => {
+  const w = new ByteWriter();
+
+  // v1 has no pre-task block to keep; its homing lived at the dropped script start
+  if (opts.isV1) w.u8(1);
+
+  if (opts.laserModule !== null) {
+    w.u8(7);
+    w.u32(opts.laserModule);
+  }
+
+  // laser off while traveling to the cut position
+  w.u8(32);
+  w.f32(0);
+  w.u8(128 | 64 | 32 | 16);
+  w.f32(TRAVEL_FEEDRATE);
+  w.f32(opts.x);
+  w.f32(opts.y);
+
+  if (opts.z > 0) {
+    w.u8(128 | 8);
+    w.f32(opts.z);
+  }
+
+  // restore modal feedrate for remainder movetos that omit F
+  w.u8(128 | 64);
+  w.f32(opts.feedrate);
+
+  if (opts.gradientChar !== null) {
+    // re-enter fast gradient mode; the remainder starts at a raster line prologue
+    w.u8(16);
+    w.u8(1);
+    w.u8(opts.gradientChar);
+  } else if (opts.pwm > 0) {
+    // remainder was mid-cut relying on modal pwm
+    w.u8(32);
+    w.f32(opts.pwm);
+  }
+
+  return w.toArray();
+};
+
+interface ContentEntry {
+  bodyStart: number;
+  end: number;
+  isBlock: boolean;
+  start: number;
+  tag: string;
+}
+
+/** Structure-only walk of CONT entries (no command parsing). */
+const walkContentEntries = (reader: Reader, end: number): ContentEntry[] => {
+  const entries: ContentEntry[] = [];
+
+  while (reader.pos < end) {
+    const start = reader.pos;
+    const tag = reader.tag();
+
+    if (tag === 'TASK') {
+      entries.push({ bodyStart: reader.pos, end: reader.pos, isBlock: false, start, tag });
+      continue;
+    }
+
+    if (tag === 'INFO' || tag === 'PREV') {
+      const length = reader.u32();
+
+      entries.push({ bodyStart: reader.pos, end: reader.pos + length, isBlock: false, start, tag });
+      reader.pos += length;
+      continue;
+    }
+
+    // task script block; optional all-digit proc id (see parseFcode)
+    const peek = reader.bytes.subarray(reader.pos, reader.pos + 4);
+
+    if (peek.every((b) => b >= 0x30 && b <= 0x39)) reader.pos += 4;
+
+    const length = reader.u32();
+
+    entries.push({ bodyStart: reader.pos, end: reader.pos + length, isBlock: true, start, tag });
+    reader.pos += length;
+  }
+
+  return entries;
+};
+
+const lastEventAt = <T>(events: Array<[number, T]>, recordIndex: number): null | T => {
+  let value: null | T = null;
+
+  for (const [index, eventValue] of events) {
+    if (index > recordIndex) break;
+
+    value = eventValue;
+  }
+
+  return value;
+};
+
+const concatBytes = (parts: Array<Uint8Array<ArrayBuffer>>): Uint8Array<ArrayBuffer> => {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+
+  return out;
+};
+
+const u32Bytes = (value: number): Uint8Array<ArrayBuffer> => {
+  const w = new ByteWriter();
+
+  w.u32(value);
+
+  return w.toArray();
+};
+
+export interface SliceExtras {
+  /** Replacement task thumbnail (png bytes) for the FILE/PREV chunks the machine displays */
+  previewPng?: Uint8Array<ArrayBuffer>;
+  /** Remaining task time in seconds, patched into the metadata time_cost */
+  timeCost?: number;
+}
+
+const asciiBytes = (s: string): Uint8Array<ArrayBuffer> => Uint8Array.from(s, (c) => c.charCodeAt(0));
+
+const patchTimeCostJson = (jsonBytes: Uint8Array, timeCost: number): Uint8Array<ArrayBuffer> => {
+  const obj = JSON.parse(new TextDecoder().decode(jsonBytes)) as Record<string, unknown>;
+
+  obj.time_cost = Math.round(timeCost * 100) / 100;
+
+  return new TextEncoder().encode(JSON.stringify(obj)) as Uint8Array<ArrayBuffer>;
+};
+
+/**
+ * Slices the fcode task at the simulation-time cut point.
+ *
+ * @param task the parsed task from updateFcode
+ * @param simTimeInfo from GcodePreview.getSimTimeInfo: index = record index of the
+ *   current segment's start, position = interpolated [x, y] in machine coords
+ * @param extras optional replacement thumbnail / remaining-time metadata
+ * @returns a machine-ready fcode Blob, or null if slicing is not possible
+ */
+export const sliceFcode = (
+  task: FcodeTask,
+  simTimeInfo: { index: number; position: number[] },
+  extras: SliceExtras = {},
+): Blob | null => {
+  try {
+    const {
+      accelEvents,
+      blockPrologues,
+      buffer,
+      gradientEvents,
+      moduleEvents,
+      parsedGcode,
+      recordOffsets,
+      sCurveEvents,
+    } = task;
+    const { previewPng, timeCost } = extras;
+    const recordCount = recordOffsets.length;
+    const cutAfter = simTimeInfo.index;
+
+    if (cutAfter < 0 || cutAfter + 1 >= recordCount) return null;
+
+    const arrival = cutAfter + 1;
+    const cutOffset = recordOffsets[cutAfter];
+    const record = (field: number) => parsedGcode.getItem(arrival * 9 + field);
+    const isRaster = record(8) === RASTER_T;
+    const bytes = new Uint8Array(buffer);
+    const reader = new Reader(buffer);
+    const magic = reader.utf8(8);
+    const version = Number.parseInt(magic.slice(3, 7), 10);
+    // Record-less arming commands at the containing block's start (grbl syncs,
+    // miscellaneous enable, layer power) must be replayed or the laser stays off.
+    const prologueEndFor = (bodyStart: number): number => {
+      const entry = blockPrologues.find(([b]) => b === bodyStart);
+
+      return Math.min(entry ? entry[1] : bodyStart, cutOffset);
+    };
+    // Latest M137 acceleration override before the cut (can occur mid-layer, per item);
+    // re-emitted verbatim so acc overrides survive the slice.
+    const accelSpan = lastEventAt(accelEvents, arrival);
+    const accelBytes = accelSpan ? bytes.subarray(accelSpan[0], accelSpan[1]) : new Uint8Array(0);
+    // Live s-curve params (P154/155/157) at the cut; an off event (P156) clears them,
+    // and a fresh job defaults to off, so nothing is emitted in that case.
+    const sCurveSpans = new Map<number, [number, number]>();
+
+    for (const [recordIndex, pCmd, span] of sCurveEvents) {
+      if (recordIndex > arrival) break;
+
+      if (span === null) sCurveSpans.clear();
+      else sCurveSpans.set(pCmd, span);
+    }
+
+    const sCurveBytes = concatBytes([...sCurveSpans.values()].map(([start, end]) => bytes.subarray(start, end)));
+    const buildRestore = (hasPrologue: boolean) =>
+      buildRestoreCommands({
+        feedrate: record(5),
+        gradientChar: lastEventAt(gradientEvents, arrival),
+        isV1: version === 1 && !hasPrologue,
+        laserModule: lastEventAt(moduleEvents, arrival),
+        pwm: isRaster ? 0 : record(7),
+        x: simTimeInfo.position[0],
+        y: simTimeInfo.position[1],
+        z: record(3),
+      });
+
+    if (version === 1) {
+      const scriptStart = reader.pos + 4;
+      const scriptLength = new DataView(buffer).getUint32(reader.pos, true);
+      const scriptEnd = scriptStart + scriptLength;
+
+      if (cutOffset <= scriptStart || cutOffset >= scriptEnd) return null;
+
+      const prologueEnd = prologueEndFor(scriptStart);
+      const restore = buildRestore(prologueEnd > scriptStart);
+      const newScript = concatBytes([
+        bytes.subarray(scriptStart, prologueEnd),
+        accelBytes,
+        sCurveBytes,
+        restore,
+        bytes.subarray(cutOffset, scriptEnd),
+      ]);
+      const parts: Array<Uint8Array<ArrayBuffer>> = [
+        bytes.subarray(0, 8),
+        u32Bytes(newScript.length),
+        newScript,
+        u32Bytes(crc32(newScript)),
+      ];
+      const metadataStart = scriptEnd + 4;
+      const metadataLength = new DataView(buffer).getUint32(metadataStart, true);
+      const metadataEnd = metadataStart + 4 + metadataLength;
+
+      if (timeCost !== undefined) {
+        const pairs = new TextDecoder().decode(bytes.subarray(metadataStart + 4, metadataEnd)).split('\x00');
+        const patched = pairs
+          .map((pair) =>
+            pair.startsWith('TIME_COST=') ? `TIME_COST=${(Math.round(timeCost * 100) / 100).toFixed(2)}` : pair,
+          )
+          .join('\x00');
+        const metaBytes = new TextEncoder().encode(patched) as Uint8Array<ArrayBuffer>;
+
+        parts.push(u32Bytes(metaBytes.length), metaBytes, u32Bytes(crc32(metaBytes)));
+      } else {
+        parts.push(bytes.subarray(metadataStart, metadataEnd + 4));
+      }
+
+      if (previewPng) {
+        parts.push(u32Bytes(previewPng.length), previewPng, u32Bytes(0));
+      } else {
+        parts.push(bytes.subarray(metadataEnd + 4));
+      }
+
+      return new Blob(parts);
+    }
+
+    // v2+: find the CONT chunk, remembering the FILE json span for metadata patching
+    let fileJsonStart = -1;
+    let fileJsonLength = 0;
+    let fileChunkEnd = -1;
+
+    while (reader.pos < bytes.length - 8) {
+      const chunkTag = reader.tag();
+
+      if (chunkTag === 'FILE') {
+        fileJsonLength = reader.u32();
+        fileJsonStart = reader.pos;
+        fileChunkEnd = reader.pos + fileJsonLength + 4; // json + crc32
+        reader.pos = fileChunkEnd;
+      } else if (chunkTag === 'PREV') {
+        while (reader.tag() !== 'CONT') {
+          reader.pos -= 4;
+
+          const previewLength = reader.u32();
+
+          reader.pos += previewLength;
+        }
+
+        reader.pos -= 4;
+      } else if (chunkTag === 'CONT') {
+        const contTagStart = reader.pos - 4;
+        const contentLength = reader.u32();
+        const contentStart = reader.pos;
+        const contentEnd = contentStart + contentLength;
+
+        if (cutOffset <= contentStart || cutOffset >= contentEnd) return null;
+
+        const entries = walkContentEntries(new Reader(buffer, contentStart), contentEnd);
+        const containing = entries.find((e) => e.isBlock && e.bodyStart <= cutOffset && cutOffset < e.end);
+
+        if (!containing) return null;
+
+        const prologueEnd = prologueEndFor(containing.bodyStart);
+        const restore = buildRestore(false);
+        const firstTask = entries.find((e) => e.tag === 'TASK');
+        const parts: Array<Uint8Array<ArrayBuffer>> = [];
+
+        if (!firstTask || containing.start <= firstTask.start) {
+          // cut inside the pre-task block: keep everything up to its body
+          parts.push(bytes.subarray(contentStart, containing.bodyStart));
+        } else {
+          // keep pre-task entries, drop finished layers, keep the cut layer's
+          // TASK/TRAN entries and the containing block's header
+          const layerTask = entries.filter((e) => e.tag === 'TASK' && e.start <= containing.start).at(-1)!;
+
+          parts.push(bytes.subarray(contentStart, firstTask.start));
+          parts.push(bytes.subarray(layerTask.start, containing.bodyStart));
+        }
+
+        const prefixLength = parts.reduce((sum, p) => sum + p.length, 0);
+        const prologue = bytes.subarray(containing.bodyStart, prologueEnd);
+
+        parts.push(prologue, accelBytes, sCurveBytes, restore, bytes.subarray(cutOffset, contentEnd));
+
+        const newContent = concatBytes(parts);
+
+        // patch the containing block's length (its u32 sits right before bodyStart)
+        new DataView(newContent.buffer).setUint32(
+          prefixLength - 4,
+          prologue.length + accelBytes.length + sCurveBytes.length + restore.length + (containing.end - cutOffset),
+          true,
+        );
+
+        // rebuild the head: FILE metadata (patched time_cost) + PREV thumbnail
+        const headParts: Array<Uint8Array<ArrayBuffer>> = [];
+
+        if (timeCost !== undefined && fileJsonStart >= 0) {
+          const newJson = patchTimeCostJson(bytes.subarray(fileJsonStart, fileJsonStart + fileJsonLength), timeCost);
+
+          headParts.push(
+            bytes.subarray(0, fileJsonStart - 8),
+            asciiBytes('FILE'),
+            u32Bytes(newJson.length),
+            newJson,
+            u32Bytes(crc32(newJson)),
+          );
+        } else {
+          headParts.push(bytes.subarray(0, fileChunkEnd >= 0 ? fileChunkEnd : contTagStart));
+        }
+
+        if (previewPng && fileChunkEnd >= 0) {
+          headParts.push(asciiBytes('PREV'), u32Bytes(previewPng.length), previewPng);
+        } else if (fileChunkEnd >= 0) {
+          headParts.push(bytes.subarray(fileChunkEnd, contTagStart));
+        }
+
+        return new Blob([
+          ...headParts,
+          asciiBytes('CONT'),
+          u32Bytes(newContent.length),
+          newContent,
+          u32Bytes(crc32(newContent)),
+          bytes.subarray(contentEnd + 4), // POST chunk, if any
+        ]);
+      } else {
+        return null;
+      }
+    }
+
+    return null;
+  } catch (error) {
+    console.error('sliceFcode failed:', error);
+
+    return null;
+  }
+};
+
+export default sliceFcode;

--- a/packages/core/src/web/app/components/beambox/PathPreview/tmpParseGcode.d.ts
+++ b/packages/core/src/web/app/components/beambox/PathPreview/tmpParseGcode.d.ts
@@ -1,0 +1,11 @@
+export class ParsedGcode {
+  chunks: number[][];
+  length: number;
+  getItem(index: number): number;
+  push(item: number): void;
+  setItem(index: number, item: number): void;
+}
+
+export function parseGcode(gcode: string, isPromark?: boolean): ParsedGcode;
+
+export default parseGcode;

--- a/packages/core/src/web/app/components/beambox/PathPreview/tmpParseGcode.js
+++ b/packages/core/src/web/app/components/beambox/PathPreview/tmpParseGcode.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-class ParsedGcode {
+export class ParsedGcode {
   chunks = [[]];
 
   maxChunkSize = 1000000;

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerContextMenu.tsx
@@ -28,7 +28,13 @@ import { deleteLayers } from '@core/helpers/layer/deleteLayer';
 import splitFullColorLayer from '@core/helpers/layer/full-color/splitFullColorLayer';
 import toggleFullColorLayer from '@core/helpers/layer/full-color/toggleFullColorLayer';
 import { getData } from '@core/helpers/layer/layer-config-helper';
-import { cloneLayers, getLayerPosition, mergeLayers, setLayersLock } from '@core/helpers/layer/layer-helper';
+import {
+  cloneLayers,
+  getLayerName,
+  getLayerPosition,
+  mergeLayers,
+  setLayersLock,
+} from '@core/helpers/layer/layer-helper';
 import useI18n from '@core/helpers/useI18n';
 
 import { ObjectPanelContext } from '../contexts/ObjectPanelContext';
@@ -160,8 +166,9 @@ const LayerContextMenu = ({ children, renameLayer, selectOnlyLayer }: Props): Re
 
     const layer = selectedLayers[0];
 
-    await splitFullColorLayer(layer);
-    layerManager.setSelectedLayers([]);
+    const splitRes = await splitFullColorLayer(layer);
+
+    layerManager.setSelectedLayers(splitRes?.newLayers.map(getLayerName) ?? []);
   };
 
   const handleLayerFullColor = (newColor?: string) => {

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.spec.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react';
 
 import { useScreenStore } from '@core/app/stores/screenStore';
 import { useLayerStore } from '@core/app/stores/layer/layerStore';
+import type { Layer } from '@core/app/svgedit/layer/layer';
 
 const mockGetSupportedModules = jest.fn();
 
@@ -106,10 +107,12 @@ describe('test LayerList', () => {
 
     const mockLayerObject1 = {
       getGroup: () => mockLayer1,
+      getName: () => 'layer1',
       isVisible: jest.fn().mockReturnValue(false),
     };
     const mockLayerObject2 = {
       getGroup: () => mockLayer2,
+      getName: () => 'layer2',
       isVisible: jest.fn().mockReturnValue(true),
     };
 
@@ -120,7 +123,10 @@ describe('test LayerList', () => {
       layerName === 'layer1' ? mockLayerObject1 : mockLayerObject2,
     );
     mockGetAllLayers.mockReturnValue([mockLayerObject1, mockLayerObject2]);
-    useLayerStore.setState({ selectedLayers: ['layer1'] });
+    useLayerStore.setState({
+      layers: [mockLayerObject1, mockLayerObject2] as unknown as Layer[],
+      selectedLayers: ['layer1'],
+    });
 
     const { container } = render(
       <LayerList
@@ -160,10 +166,12 @@ describe('test LayerList', () => {
 
     const mockLayerObject1 = {
       getGroup: () => mockLayer1,
+      getName: () => 'layer1',
       isVisible: jest.fn().mockReturnValue(false),
     };
     const mockLayerObject2 = {
       getGroup: () => mockLayer2,
+      getName: () => 'layer2',
       isVisible: jest.fn().mockReturnValue(true),
     };
 
@@ -183,7 +191,10 @@ describe('test LayerList', () => {
       return false;
     });
     useScreenStore.setState({ isMobile: true });
-    useLayerStore.setState({ selectedLayers: ['layer1'] });
+    useLayerStore.setState({
+      layers: [mockLayerObject1, mockLayerObject2] as unknown as Layer[],
+      selectedLayers: ['layer1'],
+    });
 
     const { container } = render(
       <LayerList
@@ -219,10 +230,12 @@ describe('test LayerList', () => {
 
     const mockLayerObject1 = {
       getGroup: () => mockLayer1,
+      getName: () => 'layer1',
       isVisible: jest.fn().mockReturnValue(false),
     };
     const mockLayerObject2 = {
       getGroup: () => mockLayer2,
+      getName: () => 'layer2',
       isVisible: jest.fn().mockReturnValue(true),
     };
 
@@ -241,7 +254,10 @@ describe('test LayerList', () => {
 
       return false;
     });
-    useLayerStore.setState({ selectedLayers: ['layer1'] });
+    useLayerStore.setState({
+      layers: [mockLayerObject1, mockLayerObject2] as unknown as Layer[],
+      selectedLayers: ['layer1'],
+    });
 
     const { container, getAllByText, getByTestId } = render(
       <LayerList

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/LayerList.tsx
@@ -57,9 +57,12 @@ const LayerList = ({
   unLockLayers,
 }: Props): React.JSX.Element => {
   const selectedLayers = useLayerStore((state) => state.selectedLayers);
+  // Subscribe to layers/currentLayerName so store rebuilds (identifyLayers/resync,
+  // e.g. the temp full-color split revert during export) re-render the list.
+  const layers = useLayerStore((state) => state.layers);
+  const currentLayerName = useLayerStore((state) => state.currentLayerName);
 
   const items: React.ReactNode[] = [];
-  const currentLayerName = layerManager.getCurrentLayerName();
   const isMobile = useIsMobile();
   const workarea = useWorkarea();
   const supportedModules = useSupportedModules(workarea);
@@ -71,17 +74,15 @@ const LayerList = ({
     }
   }, [ref, draggingDestIndex, selectedLayers]);
 
-  const allLayerNames = layerManager.getAllLayerNames();
-
-  if (draggingDestIndex === allLayerNames.length) {
+  if (draggingDestIndex === layers.length) {
     items.push(renderDragBar());
   }
 
   const shouldShowModuleIcon = supportedModules.length > 1;
 
-  for (let i = allLayerNames.length - 1; i >= 0; i -= 1) {
-    const layerName = allLayerNames[i];
-    const layerObject = layerManager.getLayerByName(layerName);
+  for (let i = layers.length - 1; i >= 0; i -= 1) {
+    const layerObject = layers[i];
+    const layerName = layerObject.getName();
 
     if (layerObject) {
       const layer = layerObject.getGroup();

--- a/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/__snapshots__/LayerList.spec.tsx.snap
+++ b/packages/core/src/web/app/components/beambox/RightPanel/LayerPanel/__snapshots__/LayerList.spec.tsx.snap
@@ -81,7 +81,7 @@ exports[`test LayerList should render correctly 1`] = `
       />
     </div>
     <div
-      class="layer-item item selected"
+      class="layer-item item current selected"
       data-layer="layer1"
       data-testid="layer1"
       draggable="true"
@@ -311,7 +311,7 @@ exports[`test LayerList should render correctly on mobile 1`] = `
             style="pointer-events: auto;"
           >
             <div
-              class="layer-item item selected"
+              class="layer-item item current selected"
               data-layer="layer1"
               data-testid="layer1"
               draggable="true"

--- a/packages/core/src/web/app/components/beambox/TopBar/PathPreviewButton.spec.tsx
+++ b/packages/core/src/web/app/components/beambox/TopBar/PathPreviewButton.spec.tsx
@@ -23,10 +23,6 @@ jest.mock('@core/app/svgedit/selection', () => ({
 
 import PathPreviewButton from './PathPreviewButton';
 
-const mockUseWorkarea = jest.fn();
-
-jest.mock('@core/helpers/hooks/useWorkarea', () => () => mockUseWorkarea());
-
 describe('test PathPreviewButton', () => {
   beforeEach(() => {
     useCanvasStore.getState().setMode(CanvasMode.PathPreview);
@@ -38,16 +34,6 @@ describe('test PathPreviewButton', () => {
     const { container } = render(<PathPreviewButton isDeviceConnected />);
 
     expect(container).toMatchSnapshot();
-  });
-
-  describe('workarea is Ador', () => {
-    it('should not render', () => {
-      mockUseWorkarea.mockReturnValue('ado1');
-
-      const { container } = render(<PathPreviewButton isDeviceConnected />);
-
-      expect(container).toMatchSnapshot();
-    });
   });
 
   describe('has WebGL', () => {

--- a/packages/core/src/web/app/components/beambox/TopBar/PathPreviewButton.tsx
+++ b/packages/core/src/web/app/components/beambox/TopBar/PathPreviewButton.tsx
@@ -5,15 +5,12 @@ import classNames from 'classnames';
 import { pick } from 'remeda';
 import { useShallow } from 'zustand/shallow';
 
-import { modelsWithModules } from '@core/app/actions/beambox/constant';
 import { CanvasMode } from '@core/app/constants/canvasMode';
 import TopBarIcons from '@core/app/icons/top-bar/TopBarIcons';
 import { useCanvasStore } from '@core/app/stores/canvas/canvasStore';
 import { useIsMobile } from '@core/app/stores/screenStore';
 import selectionManager from '@core/app/svgedit/selection';
 import checkWebGL from '@core/helpers/check-webgl';
-import useWorkarea from '@core/helpers/hooks/useWorkarea';
-import isDev from '@core/helpers/is-dev';
 import isWeb from '@core/helpers/is-web';
 import { isCanvasEmpty } from '@core/helpers/layer/checkContent';
 import useI18n from '@core/helpers/useI18n';
@@ -28,9 +25,8 @@ function PathPreviewButton({ isDeviceConnected }: Props): ReactNode {
   const lang = useI18n().topbar;
   const isMobile = useIsMobile();
   const { mode, togglePathPreview } = useCanvasStore(useShallow((state) => pick(state, ['mode', 'togglePathPreview'])));
-  const workarea = useWorkarea();
 
-  if (isMobile || !checkWebGL() || (!isDev() && modelsWithModules.has(workarea))) {
+  if (isMobile || !checkWebGL()) {
     return null;
   }
 

--- a/packages/core/src/web/app/components/beambox/TopBar/__snapshots__/PathPreviewButton.spec.tsx.snap
+++ b/packages/core/src/web/app/components/beambox/TopBar/__snapshots__/PathPreviewButton.spec.tsx.snap
@@ -23,5 +23,3 @@ exports[`test PathPreviewButton has WebGL no devices connected in web version 1`
 `;
 
 exports[`test PathPreviewButton no WebGL 1`] = `<div />`;
-
-exports[`test PathPreviewButton workarea is Ador should not render 1`] = `<div />`;

--- a/packages/core/src/web/helpers/addOn/rotary.spec.ts
+++ b/packages/core/src/web/helpers/addOn/rotary.spec.ts
@@ -22,7 +22,17 @@ const mockGetRotaryRatio = jest.fn();
 
 jest.mock('@core/helpers/device/get-rotary-ratio', () => mockGetRotaryRatio);
 
-import { getRotaryInfo } from './rotary';
+const mockGetAutoFeeder = jest.fn();
+
+jest.mock('@core/helpers/addOn', () => ({
+  getAutoFeeder: mockGetAutoFeeder,
+}));
+
+jest.mock('@core/app/constants/workarea-constants', () => ({
+  getWorkarea: () => ({ pxHeight: 3000 }),
+}));
+
+import { getRotaryInfo, getSpinningAxis } from './rotary';
 
 describe('test getAutoFeeder', () => {
   beforeEach(() => {
@@ -119,5 +129,40 @@ describe('test getAutoFeeder', () => {
       y: 15,
       yRatio: 1.23,
     });
+  });
+});
+
+describe('test getSpinningAxis', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetPosition.mockReturnValue(10);
+    mockGetRotaryRatio.mockReturnValue(1.23);
+  });
+
+  it('should return null when neither rotary nor auto feeder is on', () => {
+    mockGetAddOnInfo.mockReturnValue({ autoFeeder: { rotaryRatio: 0.5 } });
+    mockGetState.mockReturnValue({ rotary_mode: false });
+    mockGetAutoFeeder.mockReturnValue(false);
+
+    expect(getSpinningAxis('fbb2')).toBe(null);
+  });
+
+  it('should use the rotary axis and ratio in rotary mode', () => {
+    mockGetAddOnInfo.mockReturnValue({ rotary: {} });
+    mockGetState.mockReturnValue({ rotary_mode: true });
+
+    expect(getSpinningAxis('ado1')).toEqual({ ratio: 1.23, spin: 10 });
+    // job origin (mm) pins the axis to the origin, in px
+    expect(getSpinningAxis('ado1', { jobOriginY: 15 })).toEqual({ ratio: 1.23, spin: 150 });
+  });
+
+  it('should use the feeder edge and scaled ratio for auto feeder', () => {
+    mockGetAddOnInfo.mockReturnValue({ autoFeeder: { minY: 20, rotaryRatio: 0.5 } });
+    mockGetState.mockReturnValue({ 'auto-feeder-scale': 2, rotary_mode: false });
+    mockGetAutoFeeder.mockReturnValue(true);
+
+    expect(getSpinningAxis('fbb2')).toEqual({ ratio: 1, spin: 20 });
+    expect(getSpinningAxis('fbb2', { reverse: true })).toEqual({ ratio: 1, spin: 3000 });
+    expect(getSpinningAxis('fbb2', { jobOriginY: 15, reverse: true })).toEqual({ ratio: 1, spin: 150 });
   });
 });

--- a/packages/core/src/web/helpers/addOn/rotary.ts
+++ b/packages/core/src/web/helpers/addOn/rotary.ts
@@ -2,7 +2,9 @@ import constant from '@core/app/actions/beambox/constant';
 import rotaryAxis from '@core/app/actions/canvas/rotary-axis';
 import { getAddOnInfo } from '@core/app/constants/addOn';
 import type { WorkAreaModel } from '@core/app/constants/workarea-constants';
+import { getWorkarea } from '@core/app/constants/workarea-constants';
 import { useDocumentStore } from '@core/app/stores/documentStore';
+import { getAutoFeeder } from '@core/helpers/addOn';
 import getRotaryRatio from '@core/helpers/device/get-rotary-ratio';
 
 export type RotaryInfo = null | {
@@ -46,4 +48,40 @@ export const getRotaryInfo = (
   }
 
   return info;
+};
+
+export type SpinningAxis = {
+  /** rotary y ratio: fluxclient maps task y to `spin + (y - spin) * ratio` */
+  ratio: number;
+  /** spinning axis y in px (constant.dpmm) */
+  spin: number;
+};
+
+/**
+ * The spinning axis fluxclient maps task y through (rotary or auto feeder): rotary-space
+ * y' = spin + (y - spin) * ratio, written to the A axis on fcode v2 machines and to Y itself
+ * on v1 (after rotary-mode-on). Null when the task spins nothing.
+ * @param jobOriginY job origin y in mm when enabled (the axis then sits at the job origin)
+ * @param reverse reverse-engraving preference (auto feeder spins from the far edge)
+ */
+export const getSpinningAxis = (
+  model: WorkAreaModel,
+  { jobOriginY, reverse = false }: { jobOriginY?: number; reverse?: boolean } = {},
+): null | SpinningAxis => {
+  const addOnInfo = getAddOnInfo(model);
+  const rotaryInfo = getRotaryInfo(model, {
+    forceY: jobOriginY === undefined ? undefined : jobOriginY * constant.dpmm,
+  });
+
+  if (rotaryInfo) return { ratio: rotaryInfo.yRatio, spin: rotaryInfo.y };
+
+  if (!getAutoFeeder(addOnInfo)) return null;
+
+  const { minY = 0, rotaryRatio } = addOnInfo.autoFeeder!;
+  let spin = minY;
+
+  if (jobOriginY !== undefined) spin = jobOriginY * constant.dpmm;
+  else if (reverse) spin = getWorkarea(model).pxHeight;
+
+  return { ratio: rotaryRatio * useDocumentStore.getState()['auto-feeder-scale'], spin };
 };

--- a/packages/core/src/web/helpers/api/svg-laser-parser.ts
+++ b/packages/core/src/web/helpers/api/svg-laser-parser.ts
@@ -20,7 +20,7 @@ import { useDocumentStore } from '@core/app/stores/documentStore';
 import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore';
 import workareaManager, { ExpansionType } from '@core/app/svgedit/workarea';
 import { getAutoFeeder, getPassThrough } from '@core/helpers/addOn';
-import { getRotaryInfo } from '@core/helpers/addOn/rotary';
+import { getRotaryInfo, getSpinningAxis } from '@core/helpers/addOn/rotary';
 import AlertConfig from '@core/helpers/api/alert-config';
 import { getAllOffsets } from '@core/helpers/device/moduleOffsets';
 import deviceMaster from '@core/helpers/device-master';
@@ -108,27 +108,19 @@ export const getExportOpt = async (
   });
   const rotaryMode = Boolean(rotaryInfo);
   const autoFeeder = getAutoFeeder(addOnInfo);
+  const spinningAxis = getSpinningAxis(model, { jobOriginY: config.job_origin?.[1], reverse: config.rev });
+
+  if (spinningAxis) {
+    config.spin = spinningAxis.spin;
+
+    if (spinningAxis.ratio !== 1) config.rotary_y_ratio = spinningAxis.ratio;
+  }
 
   if (rotaryInfo) {
-    config.spin = rotaryInfo.y;
     config.rotary_split = rotaryInfo.ySplit;
     config.rotary_overlap = rotaryInfo.yOverlap;
-
-    const rotaryRatio = rotaryInfo.yRatio;
-
-    if (rotaryRatio !== 1) {
-      config.rotary_y_ratio = rotaryRatio;
-    }
   } else if (autoFeeder) {
-    config.rotary_y_ratio = addOnInfo.autoFeeder!.rotaryRatio;
-    config.rotary_y_ratio *= documentState['auto-feeder-scale'];
     config.rotary_z_motion = false;
-
-    if (config.job_origin) {
-      config.spin = config.job_origin[1] * constant.dpmm;
-    } else {
-      config.spin = config.rev ? workareaObj.pxHeight : (addOnInfo.autoFeeder!.minY ?? 0);
-    }
   }
 
   const updateAccOverride = (value: TAccelerationOverride) => {

--- a/packages/core/src/web/helpers/device/framing.spec.ts
+++ b/packages/core/src/web/helpers/device/framing.spec.ts
@@ -23,6 +23,7 @@ const mockCheckDeviceStatus = jest.fn();
 const mockStartFraming = jest.fn();
 const mockStopFraming = jest.fn();
 const mockGetRotaryInfo = jest.fn();
+const mockGetSpinningAxis = jest.fn();
 const mockGetAddOnInfo = jest.fn();
 const mockSwiftrayOn = jest.fn();
 const mockSwiftrayOff = jest.fn();
@@ -73,6 +74,7 @@ jest.mock('@core/helpers/device-master', () => ({
 
 jest.mock('@core/helpers/addOn/rotary', () => ({
   getRotaryInfo: (...args: any[]) => mockGetRotaryInfo(...args),
+  getSpinningAxis: (...args: any[]) => mockGetSpinningAxis(...args),
 }));
 
 jest.mock('@core/app/constants/addOn', () => ({

--- a/packages/core/src/web/helpers/device/framing.ts
+++ b/packages/core/src/web/helpers/device/framing.ts
@@ -17,9 +17,8 @@ import { useGlobalPreferenceStore } from '@core/app/stores/globalPreferenceStore
 import selectionManager from '@core/app/svgedit/selection';
 import findDefs from '@core/app/svgedit/utils/findDef';
 import workareaManager from '@core/app/svgedit/workarea';
-import { getAutoFeeder } from '@core/helpers/addOn';
 import type { RotaryInfo } from '@core/helpers/addOn/rotary';
-import { getRotaryInfo } from '@core/helpers/addOn/rotary';
+import { getRotaryInfo, getSpinningAxis } from '@core/helpers/addOn/rotary';
 import { swiftrayClient } from '@core/helpers/api/swiftray-client';
 import getUtilWS from '@core/helpers/api/utils-ws';
 import checkDeviceStatus from '@core/helpers/check-device-status';
@@ -726,28 +725,17 @@ class FramingTaskManager extends EventEmitter {
     this.showMessage(sprintf(lang.message.connectingMachine, this.device.name));
     this.resetEnabledInfo();
     this.curPos = { a: 0, x: 0, y: 0 };
-    this.rotaryInfo = getRotaryInfo(this.device.model, { axisInMm: true, forceY: this.jobOrigin?.y });
 
-    const autoFeeder = getAutoFeeder(this.addOnInfo);
+    const spinningAxis = getSpinningAxis(this.device.model, {
+      jobOriginY: this.jobOrigin?.y,
+      reverse: useGlobalPreferenceStore.getState()['reverse-engraving'],
+    });
 
-    if (!this.rotaryInfo && autoFeeder && this.addOnInfo.autoFeeder) {
-      let y: number;
-
-      if (this.jobOrigin) {
-        y = this.jobOrigin.y;
-      } else {
-        const reverseEngraving = useGlobalPreferenceStore.getState()['reverse-engraving'];
-        const workareaObj = getWorkarea(this.device.model);
-
-        y = reverseEngraving ? workareaObj.height : (this.addOnInfo.autoFeeder.minY ?? 0) / dpmm;
-      }
-
-      this.rotaryInfo = {
-        useAAxis: this.isFcodeV2,
-        y,
-        yRatio: this.addOnInfo.autoFeeder.rotaryRatio * useDocumentStore.getState()['auto-feeder-scale'],
-      };
-    }
+    this.rotaryInfo = spinningAxis && {
+      useAAxis: this.isFcodeV2,
+      y: spinningAxis.spin / dpmm,
+      yRatio: spinningAxis.ratio,
+    };
 
     this.shouldCheckDoor = this.isInDangerZone();
   };

--- a/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
@@ -246,6 +246,7 @@ export const tempSplitFullColorLayers = async (): Promise<() => void> => {
   const addedLayers: Element[] = [];
   const removedLayers: Array<{ layer: Element; nextSibling: Node | null; parentNode: Node | null }> = [];
   const currentLayerName = layerManager.getCurrentLayerName();
+  const selectedLayers = [...layerManager.getSelectedLayers()];
 
   for (const layer of layerManager.getAllLayers()) {
     const layerElement = layer.getGroup();
@@ -283,7 +284,9 @@ export const tempSplitFullColorLayers = async (): Promise<() => void> => {
     });
 
     layerManager.identifyLayers();
-    layerManager.setCurrentLayer(currentLayerName!);
+    // the split dropped the original names from the selection; restore both
+    // selection and current layer now that the original groups are back
+    layerManager.setSelectedLayers(selectedLayers, currentLayerName ?? undefined);
   };
 
   return revert;

--- a/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
+++ b/packages/core/src/web/helpers/layer/full-color/splitFullColorLayer.ts
@@ -108,6 +108,13 @@ const splitFullColorLayer = async (
   const batchCmd = new history.BatchCommand('Split Full Color Layer');
   const newLayers: Array<Element | null> = [];
   const promises = [];
+  // cloneLayer appends at the top and records that position; record the move so redo lands here too
+  const placeAboveOriginal = (newLayer: Element) => {
+    const { nextSibling, parentNode } = newLayer;
+
+    layer.parentNode!.insertBefore(newLayer, layer.nextSibling);
+    batchCmd.addSubCommand(new history.MoveElementCommand(newLayer, nextSibling, parentNode!));
+  };
 
   if (is4c) {
     const cloneRes = cloneLayer(layerName, {
@@ -154,7 +161,7 @@ const splitFullColorLayer = async (
         promises.push(promise);
       }
 
-      layer.parentNode!.insertBefore(newLayer, layer.nextSibling);
+      placeAboveOriginal(newLayer);
       newLayers.push(newLayer);
     }
   } else {
@@ -205,7 +212,7 @@ const splitFullColorLayer = async (
         writeDataLayer(newLayer, 'printingStrength', strength);
       }
 
-      layer.parentNode!.insertBefore(newLayer, layer.nextSibling);
+      placeAboveOriginal(newLayer);
       newLayers.push(newLayer);
 
       if (!data) continue;

--- a/packages/core/src/web/helpers/path-preview/draw-commands/GcodePreview.js
+++ b/packages/core/src/web/helpers/path-preview/draw-commands/GcodePreview.js
@@ -32,6 +32,7 @@ export function gcode(drawCommands) {
       uniform float rotaryScale;
       uniform bool isInverting;
       uniform bool showTraversal;
+      uniform bool isPrintPass;
       attribute vec4 position;
       attribute float g;
       attribute float t;
@@ -60,10 +61,30 @@ export function gcode(drawCommands) {
           float k = s / 255.0;
           color = isInverting ? vec4(k, k, k, 1.0) : vec4(1.0 - k, 1.0 - k, 1.0 - k, 1.0);
         }
+        else if(t >= 7.0 && t <= 11.0) {
+          // 4C printer channel run (see PRINTER_CHANNEL_T in parseFcode), drawn only in
+          // the print pass with subtractive blending gl.blendFunc(ZERO, ONE_MINUS_SRC_COLOR):
+          // dst *= 1 - k * absorb, so overlapping inks mix like ink (C+M = blue, C+Y = green).
+          // s is coverage; the exponent boosts halftone tones to perceived density.
+          float k = pow(s / 255.0, 0.5);
+          vec3 absorb;
+          if(t == 7.0) absorb = vec3(1.0, 0.32, 0.06);       // cyan ink absorbs red
+          else if(t == 8.0) absorb = vec3(0.07, 1.0, 0.45);  // magenta absorbs green
+          else if(t == 9.0) absorb = vec3(0.0, 0.15, 1.0);   // yellow absorbs blue
+          else if(t == 10.0) absorb = vec3(1.0, 1.0, 1.0);   // black absorbs all
+          else absorb = vec3(0.10, 0.09, 0.05);              // white ink: faint warm gray hint
+          // alpha carries coverage: the print pass blends alpha additively so the
+          // framebuffer (cleared to white with alpha 0) becomes visible when composited
+          color = vec4(absorb * k, k);
+        }
         else if(isInverting)
           color = vec4(1.0, 1.0, 1.0, 1.0);
         else
           color = vec4(0.0, 0.0, 0.0, 1.0);
+        // print-channel segments render only in the print pass, everything else only
+        // in the normal pass; a zero color is invisible under either blend mode
+        bool isPrintSegment = g != 0.0 && t >= 7.0 && t <= 11.0;
+        if(isPrintSegment != isPrintPass) color = vec4(0.0, 0.0, 0.0, 0.0);
         vg0Time = g0Time;
         vg1Time = g1Time;
       }`,
@@ -103,26 +124,41 @@ export function gcode(drawCommands) {
     data,
     count,
   }) => {
+    const { gl } = drawCommands;
+    const uniforms = {
+      perspective,
+      view,
+      g0Rate,
+      simTime,
+      rotaryScale: rotaryDiameter * (Math.PI / 360),
+      isInverting,
+      showTraversal,
+      showRemaining,
+    };
+    const buffer = {
+      data,
+      stride: drawStride * 4,
+      offset: 0,
+      count,
+    };
+
     drawCommands.execute({
       program,
-      primitive: drawCommands.gl.LINES,
-      uniforms: {
-        perspective,
-        view,
-        g0Rate,
-        simTime,
-        rotaryScale: rotaryDiameter * (Math.PI / 360),
-        isInverting,
-        showTraversal,
-        showRemaining,
-      },
-      buffer: {
-        data,
-        stride: drawStride * 4,
-        offset: 0,
-        count,
-      },
+      primitive: gl.LINES,
+      uniforms: { ...uniforms, isPrintPass: false },
+      buffer,
     });
+    // 4C printer channel runs: subtractive ink blending on rgb (dst *= 1 - src, the
+    // task framebuffer is cleared to white), additive coverage on alpha so the
+    // framebuffer's zero-alpha clear becomes opaque where ink lands
+    gl.blendFuncSeparate(gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE);
+    drawCommands.execute({
+      program,
+      primitive: gl.LINES,
+      uniforms: { ...uniforms, isPrintPass: true },
+      buffer,
+    });
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   };
 } // gcode
 
@@ -248,12 +284,14 @@ export class GcodePreview {
           lastDirection = direction;
         }
 
-        if (g) {
+        // f = NaN marks synthetic zero-time records (printer swath content, see
+        // parseFcode) - not head motion, so they add no distance or time
+        if (g && !Number.isNaN(f)) {
           g1Time += tc;
           g1Dist += dist;
           g1TimeReal += tc;
           g1DistReal += dist;
-        } else if (!Number.isNaN(f)) {
+        } else if (!g && !Number.isNaN(f)) {
           if (f === 7500) {
             g0Time += tc;
             g0Dist += dist;

--- a/packages/core/src/web/helpers/path-preview/draw-commands/GcodePreview.js
+++ b/packages/core/src/web/helpers/path-preview/draw-commands/GcodePreview.js
@@ -117,7 +117,7 @@ export function gcode(drawCommands) {
     view,
     g0Rate,
     simTime,
-    rotaryDiameter,
+    rotaryScale,
     isInverting,
     showTraversal,
     showRemaining,
@@ -130,7 +130,7 @@ export function gcode(drawCommands) {
       view,
       g0Rate,
       simTime,
-      rotaryScale: rotaryDiameter * (Math.PI / 360),
+      rotaryScale,
       isInverting,
       showTraversal,
       showRemaining,
@@ -168,7 +168,24 @@ export class GcodePreview {
     this.timeInterval = [];
   }
 
-  setParsedGcode(parsed, isPromark = false, dpmm = 10, rotaryRatio = 1) {
+  /**
+   * @param rotary fcode rotary/auto-feeder tasks: { axisY, ratio, scaledYFrom }. fluxclient
+   *   writes rotary-space y' = axisY + (y - axisY) * ratio — on the A axis (fcode v2) or on Y
+   *   itself from record index scaledYFrom (v1). The a slot of the draw array then holds the
+   *   offset from the stored y to the design y, so the shader's y + a lands on the canvas
+   *   position while the stored y stays machine y for start-here slicing.
+   */
+  setParsedGcode(parsed, isPromark = false, dpmm = 10, rotaryRatio = 1, rotary = null) {
+    // display offset (a slot) for record i with preview-space y and parsed a (NaN = A unset)
+    const rotaryOffset = (i, y, a) => {
+      if (!rotary) return Number.isNaN(a) ? 0 : a;
+
+      const rotarySpaceY = Number.isNaN(a) ? (i >= rotary.scaledYFrom ? -y : null) : a;
+      if (rotarySpaceY === null) return 0;
+      const designY = rotary.axisY + (rotarySpaceY - rotary.axisY) / rotary.ratio;
+      return -designY - y;
+    };
+
     this.arrayChanged = true;
     this.timeInterval = [];
     this.arrayVersion += 1;
@@ -183,9 +200,7 @@ export class GcodePreview {
       this.g1Dist = 0;
       this.g1Time = 0;
     } else {
-      const array = new Float32Array(
-        ((parsed.length - parsedStride) / parsedStride) * drawStride * 2,
-      );
+      const array = new Float32Array(((parsed.length - parsedStride) / parsedStride) * drawStride * 2);
       this.minX = Number.MAX_VALUE;
       this.maxX = -Number.MAX_VALUE;
       this.minY = Number.MAX_VALUE;
@@ -241,7 +256,7 @@ export class GcodePreview {
         array[i * drawStride * 2 + 1] = x1;
         array[i * drawStride * 2 + 2] = isPromark ? y1 - a1 / rotaryRatio : y1;
         array[i * drawStride * 2 + 3] = z1;
-        array[i * drawStride * 2 + 4] = isPromark ? 0 : a1;
+        array[i * drawStride * 2 + 4] = isPromark ? 0 : rotaryOffset(i, y1, a1);
         array[i * drawStride * 2 + 5] = t;
         array[i * drawStride * 2 + 6] = g0Time;
         array[i * drawStride * 2 + 7] = g1Time;
@@ -276,9 +291,7 @@ export class GcodePreview {
           const direction = Math.atan2(y2 - y1, x2 - x1);
           const lastVel = lastFeedrate * Math.cos(direction - lastDirection);
           const estimateVel =
-            lastVel <= 0
-              ? Math.min(f, (2 * acc * dist) ** 0.5)
-              : Math.min(f, (lastVel ** 2 + 2 * acc * dist) ** 0.5);
+            lastVel <= 0 ? Math.min(f, (2 * acc * dist) ** 0.5) : Math.min(f, (lastVel ** 2 + 2 * acc * dist) ** 0.5);
           tc = Math.abs(estimateVel - lastVel) / acc + dist / estimateVel;
           lastFeedrate = estimateVel;
           lastDirection = direction;
@@ -309,7 +322,7 @@ export class GcodePreview {
         array[i * drawStride * 2 + 10] = x2;
         array[i * drawStride * 2 + 11] = isPromark ? y2 - a2 / rotaryRatio : y2;
         array[i * drawStride * 2 + 12] = z2;
-        array[i * drawStride * 2 + 13] = isPromark ? 0 : a2;
+        array[i * drawStride * 2 + 13] = isPromark ? 0 : rotaryOffset(i + 1, y2, a2);
         array[i * drawStride * 2 + 14] = t;
         array[i * drawStride * 2 + 15] = g0Time;
         array[i * drawStride * 2 + 16] = g1Time;
@@ -335,19 +348,20 @@ export class GcodePreview {
     let index = -1;
     let position = [0, 0];
     let next = [-1, -1];
+    let a = 0;
 
     while (min <= max) {
       guess = Math.floor((max + min) / 2);
 
       if (this.timeInterval[guess] < simTime && this.timeInterval[guess + 1] > simTime) {
         index = guess + 1;
-        const ratio =
-          (simTime - this.timeInterval[guess]) /
-          (this.timeInterval[index] - this.timeInterval[guess]);
+        const ratio = (simTime - this.timeInterval[guess]) / (this.timeInterval[index] - this.timeInterval[guess]);
         const ref = index * drawStride * 2;
         const ref2 = ref + drawStride; // second vertex of the segment
         const x = this.array[ref + 1] + (this.array[ref2 + 1] - this.array[ref + 1]) * ratio;
         const y = this.array[ref + 2] + (this.array[ref2 + 2] - this.array[ref + 2]) * ratio;
+        // a slot: rotary display offset (0 unless the task spins; promark folds a into y upstream)
+        a = this.array[ref + 4] + (this.array[ref2 + 4] - this.array[ref + 4]) * ratio;
         position = [x, -y];
         next = [this.array[ref2 + 1], this.array[ref2 + 2]];
         break;
@@ -359,23 +373,14 @@ export class GcodePreview {
     }
 
     return {
+      a,
       index,
       position,
       next,
     };
   }
 
-  draw(
-    drawCommands,
-    perspective,
-    view,
-    g0Rate,
-    simTime,
-    rotaryDiameter,
-    isInverting,
-    showTraversal,
-    showRemaining,
-  ) {
+  draw(drawCommands, perspective, view, g0Rate, simTime, rotaryScale, isInverting, showTraversal, showRemaining) {
     if (this.drawCommands !== drawCommands) {
       this.drawCommands = drawCommands;
       if (this.buffer) this.buffer.destroy();
@@ -393,7 +398,7 @@ export class GcodePreview {
       view,
       g0Rate,
       simTime,
-      rotaryDiameter,
+      rotaryScale,
       isInverting,
       showTraversal,
       showRemaining,

--- a/packages/core/src/web/helpers/path-preview/draw-commands/GcodePreview.js
+++ b/packages/core/src/web/helpers/path-preview/draw-commands/GcodePreview.js
@@ -19,7 +19,7 @@
 import { controlConfig } from '@core/app/constants/promark-constants';
 
 const parsedStride = 9;
-const drawStride = 8;
+const drawStride = 9;
 const accX = 4000 * 3600; // mm/min^2
 const accY = 2000 * 3600; // mm/min^2
 
@@ -37,6 +37,7 @@ export function gcode(drawCommands) {
       attribute float t;
       attribute float g0Time;
       attribute float g1Time;
+      attribute float s;
       varying vec4 color;
       varying float vg0Time;
       varying float vg1Time;
@@ -54,6 +55,11 @@ export function gcode(drawCommands) {
           color = vec4(0.0, 0.0, 0.0, 1.0);
         else if(t == 5.0)
           color = vec4(0.0, 0.5, 0.7, 1.0);
+        else if(t == 6.0) {
+          // raster pixel run: s is 0-255 power, full power = black (white when inverting)
+          float k = s / 255.0;
+          color = isInverting ? vec4(k, k, k, 1.0) : vec4(1.0 - k, 1.0 - k, 1.0 - k, 1.0);
+        }
         else if(isInverting)
           color = vec4(1.0, 1.0, 1.0, 1.0);
         else
@@ -82,6 +88,7 @@ export function gcode(drawCommands) {
       t: { offset: 20 },
       g0Time: { offset: 24 },
       g1Time: { offset: 28 },
+      s: { offset: 32 },
     },
   });
   return ({
@@ -181,7 +188,8 @@ export class GcodePreview {
         const f = parsed.getItem(i * parsedStride + 14);
         const a2 = parsed.getItem(i * parsedStride + 15);
 
-        // s
+        // segment power: next record's s (raster pixel power, see RASTER_T in parseFcode)
+        const s = parsed.getItem(i * parsedStride + 16);
         const t = parsed.getItem(i * parsedStride + 8);
 
         if (g) {
@@ -201,6 +209,7 @@ export class GcodePreview {
         array[i * drawStride * 2 + 5] = t;
         array[i * drawStride * 2 + 6] = g0Time;
         array[i * drawStride * 2 + 7] = g1Time;
+        array[i * drawStride * 2 + 8] = s;
         const dist = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2 + (isPromark ? 0 : z2 - z1) ** 2);
         let tc = 0;
         if (isPromark) {
@@ -258,14 +267,15 @@ export class GcodePreview {
 
         this.timeInterval.push(g1Time + g0Time);
 
-        array[i * drawStride * 2 + 8] = g;
-        array[i * drawStride * 2 + 9] = x2;
-        array[i * drawStride * 2 + 10] = isPromark ? y2 - a2 / rotaryRatio : y2;
-        array[i * drawStride * 2 + 11] = z2;
-        array[i * drawStride * 2 + 12] = isPromark ? 0 : a2;
-        array[i * drawStride * 2 + 13] = t;
-        array[i * drawStride * 2 + 14] = g0Time;
-        array[i * drawStride * 2 + 15] = g1Time;
+        array[i * drawStride * 2 + 9] = g;
+        array[i * drawStride * 2 + 10] = x2;
+        array[i * drawStride * 2 + 11] = isPromark ? y2 - a2 / rotaryRatio : y2;
+        array[i * drawStride * 2 + 12] = z2;
+        array[i * drawStride * 2 + 13] = isPromark ? 0 : a2;
+        array[i * drawStride * 2 + 14] = t;
+        array[i * drawStride * 2 + 15] = g0Time;
+        array[i * drawStride * 2 + 16] = g1Time;
+        array[i * drawStride * 2 + 17] = s;
       }
 
       this.array = array;
@@ -297,10 +307,11 @@ export class GcodePreview {
           (simTime - this.timeInterval[guess]) /
           (this.timeInterval[index] - this.timeInterval[guess]);
         const ref = index * drawStride * 2;
-        const x = this.array[ref + 1] + (this.array[ref + 9] - this.array[ref + 1]) * ratio;
-        const y = this.array[ref + 2] + (this.array[ref + 10] - this.array[ref + 2]) * ratio;
+        const ref2 = ref + drawStride; // second vertex of the segment
+        const x = this.array[ref + 1] + (this.array[ref2 + 1] - this.array[ref + 1]) * ratio;
+        const y = this.array[ref + 2] + (this.array[ref2 + 2] - this.array[ref + 2]) * ratio;
         position = [x, -y];
-        next = [this.array[ref + 9], this.array[ref + 10]];
+        next = [this.array[ref2 + 1], this.array[ref2 + 2]];
         break;
       } else if (this.timeInterval[guess] < simTime) {
         min = guess + 1;


### PR DESCRIPTION
## 摘要

- 新增 `parseFcode.ts`:直接解析 fcode v1/v2 二進位檔,產出 Path Preview 既有的 stride-9 記錄(含 fast gradient 點陣解碼,PWM 影像以灰階呈現),非 Promark 機種的路徑預覽改為只做一次後端運算(原本需要 gcode + fcode 各算一次);Promark 維持原有 gcode 文字流程(wobble、dotting、變數文字)。
- 新增 `sliceFcode.ts`:「從此處開始」改為直接對快取的 fcode 做位元組切割 — 複製圖層的啟用/功率 prologue、重新發出最新的加速度覆寫與 S 曲線參數(P150 / P154/155/157,P156 關閉則不發)、修補 block/CONT 長度與 crc32,並重建機器顯示用的 FILE time_cost 與 PREV 縮圖 — 全程零後端往返;原 gcode 切割流程保留作為 fallback。
- 開發者模式(`localStorage.dev = 'true'`)下 Shift+點擊「從此處開始」可直接匯出切割後的 .fc 檔,無需連接機器。
- 格式與子系統知識分別記錄於 `fcode` 與 `path-preview` 兩個 agent skills;`tmpParseGcode` 補上 `.d.ts` 型別。

- 新增列印任務預覽:解析 cmd 17 印表機封包(Ador 單色 subs 0-5、Beamo II 4C subs 10-15),將每個 swath 的 2D 內容以零模擬時間記錄繪出 — 4C 依 CMYK 四通道著色並套用固定的通道 x offset 與 0.55035mm 右噴頭補償;Ador 單色從 INFO metadata(submodule.color)取得墨色。渲染採用獨立繪製 pass 的減色法混色(blendFuncSeparate),重疊墨色如實體油墨般混合;合成內容不計入切割距離/時間。
- 「從此處開始」按鈕改為只在 Promark 隱藏(Swiftray 引擎的 fcode 預覽也支援)。
- 效能:共用 walkContentEntries、pixel-major 通道累加、u8 直接索引 — 1.7MB 列印任務解析 1.5s → 0.45s。
- Path Preview 按鈕對所有機種顯示:列印任務預覽完成後,Ador / 4C 印表機機種不再隱藏(原本非 dev 模式下隱藏)。
- 略過 xMIN 腳本區塊:xMIN 是機器端腳本(0003 開工歸位、0001/0002 預噴、0005–0008 上蓋/平台、0004 收尾),非設計內容;`parseFcode` 直接跳過,預覽不再出現這些移動與預噴色塊。「從此處開始」不受影響(切割器以原始位元組複製 pre-task entries)。
- 旋轉軸預覽對齊畫布:fluxclient 會把 y 轉成旋轉空間 `y' = axis + (y - axis) * ratio`(fcode v2 寫在 A 軸、v1 在 rotary-mode-on 後直接寫 Y),先前預覽把絕對 A 值加到停駐的 Y 上,導致旋轉任務內容上下顛倒並偏移軸位置,且 chuck/自動送料的 ratio 未還原。新增 `getSpinningAxis`(rotary/auto feeder 的 spin 與 ratio 唯一來源,匯出端 `svg-laser-parser` 一併改用),`parseFcode` 的 A 在未移動前保持 NaN,`GcodePreview` 在 a slot 存「機器 y → 設計 y」的位移,shader 的 `y + a` 即落在畫布位置,slot 2 仍維持機器 y 供「從此處開始」切割;切割時也會重新發出 rotary/boost 的 pause 指令。

## Summary

- Add `parseFcode.ts`: parses fcode v1/v2 binaries into the previewer's existing stride-9 records (including fast-gradient raster decoding with grayscale PWM runs). Non-Promark machines now preview the fcode itself — one backend conversion instead of the previous gcode + fcode double generation; Promark keeps the gcode-text path (wobble, dotting, variable text).
- Add `sliceFcode.ts`: "start from here" byte-splices the cached fcode at the sim-time cut — copies the layer's arming/power prologue, re-emits the live acceleration override and s-curve params (P150 / P154/155/157; nothing after a P156 off), patches block/CONT lengths and crc32, and rebuilds the FILE time_cost and PREV thumbnail the machine displays — with zero extra backend round-trips. The gcode surgery flow remains as fallback.
- Dev-only: with `localStorage.dev = 'true'`, shift-clicking "Start here" exports the sliced `.fc` for inspection without a machine.
- Format and subsystem knowledge documented in the `fcode` and `path-preview` agent skills; `tmpParseGcode` typed via a `.d.ts`.

- Printing-task preview: parse cmd 17 printer packets (Ador single-color subs 0-5, Beamo II 4C subs 10-15) and draw each swath's 2D content as zero-sim-time records — 4C colored per CMYK channel with the fixed channel x offsets and the 0.55035mm right-nozzle compensation; Ador single-color takes its ink from the layer INFO metadata (submodule.color). Rendering uses a dedicated draw pass with subtractive ink blending (blendFuncSeparate) so overlapping inks mix like physical ink; synthetic content is excluded from cut distance/time.
- "Start here" is now hidden only for Promark (Swiftray-engine fcode previews support it too).
- Perf: shared walkContentEntries, pixel-major channel accumulation, direct-index u8 — a 1.7MB printing task parses in 0.45s (was 1.5s).
- Path Preview button shown for every machine: with printing-task preview done, Ador and 4C printer models are no longer hidden outside dev mode.
- Skip xMIN script blocks: xMIN blocks are machine scripts (0003 pre-task homing, 0001/0002 prespray, 0005–0008 lid/table, 0004 post-task), not design content; `parseFcode` skips them so their travel and prespray swaths stay out of the preview. Start-here is unaffected (the slicer copies pre-task entries as raw bytes).
- Rotary preview matches the canvas: fluxclient writes rotary-space `y' = axis + (y - axis) * ratio` (onto A on fcode v2, onto Y itself after rotary-mode-on on v1). The preview used to add the absolute A onto the parked Y, so rotary content rendered flipped and offset by the axis, and chuck/auto-feeder ratios were never undone. Add `getSpinningAxis` as the single source of a task's spin and ratio (the exporter in `svg-laser-parser` now uses it too), keep A as NaN in `parseFcode` until the task moves it, and store the machine-y → design-y offset in the draw array's a slot so the shader's `y + a` lands on the canvas position while slot 2 keeps machine y for start-here slicing; slicing also re-arms the rotary/boost pause commands.

## Test plan

- [x] `pnpm test parseFcode.spec` (decodePixelRuns unit tests)
- [x] Offline validation against real fbb2 exports: parsed record bounds match fcode metadata; sliced files pass fluxclient-grade structure/CRC checks (Python `zipfile.crc32`) at multiple cut points, incl. multi-layer and mid-raster cuts
- [x] Hardware (Beambox II): preview renders vector + engraving layers; start-from-here mid-raster and mid-vector fires the laser correctly after the prologue fix; monitor shows sliced thumbnail/time while running
- [x] Swiftray fcode: preview + start-from-here verified on Beambox II with both engines via the path-engine preference (swiftray's fcode writer is byte-compatible, confirmed by source audit and hardware run)
- [ ] Promark regression: preview + start-from-here still uses the gcode path
- [x] Printing preview verified on real exports of both families: fbm2 4C and Ador single-color (content, colors, channel offsets, row order per family, nozzle gap); decoded records rasterized offline and compared against the source design
- [x] Refactor verified byte-identical (record count/checksum/channel counts) against the pre-refactor baseline
- [x] `pnpm test rotary.spec` (getSpinningAxis: rotary, job origin, auto feeder, reverse), plus addOn, get-rotary-ratio, parseFcode and PathPreview component specs
- [x] Rotary task preview on a v2 machine (fbb2/ado1) with chuck ratio ≠ 1 sits at the canvas y; start-from-here on a rotary task resumes at the right spot
- [x] Auto-feeder task preview (fbb2) matches the canvas
- [x] `pnpm test PathPreviewButton.spec` (Ador hidden case removed, snapshot pruned); `pnpm test parseFcode.spec`
- [ ] Ador / fbm2: Path Preview button visible in a normal build; printing task preview shows no prespray swaths or homing travel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183WMC4ke6PnbTf3Hxf68Xw



