### PR TITLE
Block browser back navigation on the editor page

### DIFF
--- a/packages/core/src/web/app/pages/Beambox.tsx
+++ b/packages/core/src/web/app/pages/Beambox.tsx
@@ -49,11 +49,14 @@ const Beambox = (): React.JSX.Element => {
       communicator.on(MenuEvents.NewAppMenu, BeamboxGlobalInteraction.attach);
     }
 
-    // Trap browser/mouse "back": duplicate the current entry so a pop lands on the same route, then re-arm
+    // Electron only: trap mouse/trackpad "back" (no address bar to recover from) by duplicating the
+    // current entry so a pop lands on the same route, then re-arm. Web keeps native browser history.
     const armBackTrap = () => window.history.pushState(null, '', window.location.href);
 
-    armBackTrap();
-    window.addEventListener('popstate', armBackTrap);
+    if (!isWeb()) {
+      armBackTrap();
+      window.addEventListener('popstate', armBackTrap);
+    }
 
     return () => {
       BeamboxGlobalInteraction.detach();

--- a/packages/core/src/web/app/pages/Beambox.tsx
+++ b/packages/core/src/web/app/pages/Beambox.tsx
@@ -49,9 +49,16 @@ const Beambox = (): React.JSX.Element => {
       communicator.on(MenuEvents.NewAppMenu, BeamboxGlobalInteraction.attach);
     }
 
+    // Trap browser/mouse "back": duplicate the current entry so a pop lands on the same route, then re-arm
+    const armBackTrap = () => window.history.pushState(null, '', window.location.href);
+
+    armBackTrap();
+    window.addEventListener('popstate', armBackTrap);
+
     return () => {
       BeamboxGlobalInteraction.detach();
       communicator.off(MenuEvents.NewAppMenu, BeamboxGlobalInteraction.attach);
+      window.removeEventListener('popstate', armBackTrap);
     };
   }, []);
 


### PR DESCRIPTION
## 摘要

- 部分使用者在編輯器頁面會不小心觸發「上一頁」（滑鼠側鍵、觸控板滑動），導致 hash router 退回 `/` 語言選擇頁，並在沒有經過未儲存變更流程的情況下卸載編輯器。
- **僅限 Electron**：在編輯器掛載時推入一筆重複的 history entry，並在每次 `popstate` 時重新推入，讓「上一頁」落在同一個路由上、編輯器維持掛載。Web 版保留瀏覽器原生的上一頁行為。
- 透過 `window.location.hash = ...` 的正常離開路徑（Welcome 按鈕、機器設定）不受影響。

## Summary

- Some users accidentally trigger "Go to previous page" (mouse side button, trackpad swipe) while in the editor, popping the hash router back to `/` (language selection) and unmounting the editor without the unsaved-changes flow.
- **Electron only**: push a duplicate history entry on editor mount and re-arm it on every `popstate`, so back gestures land on the same route and the editor stays mounted. The web build keeps native browser back behavior.
- Explicit hash assignments (Welcome button, machine setup) are unaffected.

## Test plan

- [x] Electron: open the editor, run `history.back()` in DevTools: hash stays `#/studio/beambox`, canvas untouched
- [x] Electron: mouse side button and trackpad swipe are absorbed
- [x] Electron: Welcome (home) button in the top bar still navigates to the welcome page
- [ ] Web: browser back from `#/studio/beambox` still navigates normally (trap not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oKabxcaFWJFY1GjHgLyxM
